### PR TITLE
Add fame/reputation system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -30,6 +30,7 @@ PartyManager="*res://scripts/Managers/party_manager.gd"
 InputManager="*res://scripts/Managers/InputManager.gd"
 LogManager="*res://scripts/Managers/LogManager.gd"
 ChatManager="*res://scripts/Managers/ChatManager.gd"
+FameManager="*res://scripts/Managers/fame_manager.gd"
 
 [display]
 

--- a/scenes/UI/stats_window.tscn
+++ b/scenes/UI/stats_window.tscn
@@ -378,6 +378,44 @@ theme_override_styles/normal = SubResource("StyleBoxFlat_fqhit")
 text = "100/100"
 horizontal_alignment = 2
 
+[node name="FameContainer" type="HBoxContainer" parent="StatsPanel/ScrollContainer/MarginContainer/VBoxContainer"]
+layout_mode = 2
+alignment = 1
+
+[node name="FameLabel" type="Label" parent="StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/FameContainer"]
+clip_children = 2
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 1)
+theme_override_constants/shadow_outline_size = 4
+theme_override_styles/normal = SubResource("StyleBoxFlat_cgmen")
+text = "Fame"
+uppercase = true
+
+[node name="GradientMask" type="Panel" parent="StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/FameContainer/FameLabel"]
+clip_contents = true
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = -2.0
+offset_top = -4.0
+offset_right = 2.0
+offset_bottom = 5.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxTexture_kp55c")
+
+[node name="FameAmountLabel" type="Label" parent="StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/FameContainer"]
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_constants/outline_size = 0
+theme_override_fonts/font = ExtResource("4_hyo3f")
+theme_override_styles/normal = SubResource("StyleBoxFlat_fqhit")
+text = "0"
+horizontal_alignment = 2
+
 [node name="HSeparator" type="HSeparator" parent="StatsPanel/ScrollContainer/MarginContainer/VBoxContainer"]
 layout_mode = 2
 theme_override_constants/separation = 10

--- a/scripts/Managers/ChatManager.gd
+++ b/scripts/Managers/ChatManager.gd
@@ -11,6 +11,11 @@ func register_local_player(player_node: MultiplayerPlayerV2):
 	local_player_node = player_node
 
 func send_chat_message(text: String):
+	# Handle slash commands locally before broadcasting
+	if text.begins_with("/"):
+		_handle_command(text)
+		return
+
 	if local_player_node:
 		broadcast_message.rpc(local_player_node.username, text)
 	else:
@@ -23,3 +28,30 @@ func add_system_message(text: String, color: Color = Color.WHITE):
 func broadcast_message(sender_name: String, text: String):
 	var message = "%s: %s" % [sender_name, text]
 	message_received.emit(message, Color.WHITE)
+
+
+func _handle_command(text: String) -> void:
+	var parts: PackedStringArray = text.strip_edges().split(" ", false)
+	if parts.is_empty():
+		return
+
+	var command: String = parts[0].to_lower()
+
+	match command:
+		"/fame", "/defame":
+			if parts.size() < 2:
+				add_system_message("Usage: %s <player_name>" % command, Color.YELLOW)
+				return
+			var target_name: String = parts[1]
+			var is_defame: bool = command == "/defame"
+			_request_fame.rpc_id(1, target_name, is_defame)
+		_:
+			add_system_message("Unknown command: %s" % command, Color.YELLOW)
+
+
+@rpc("any_peer", "call_remote", "reliable")
+func _request_fame(target_username: String, is_defame: bool) -> void:
+	if not multiplayer.is_server():
+		return
+	var sender_id: int = multiplayer.get_remote_sender_id()
+	FameManager.handle_fame_command(sender_id, target_username, is_defame)

--- a/scripts/Managers/fame_manager.gd
+++ b/scripts/Managers/fame_manager.gd
@@ -1,0 +1,113 @@
+extends Node
+## FameManager — Server-authoritative fame/reputation system.
+##
+## Players can give +1 or -1 fame to another player once per day (per target).
+## Fame is persisted as part of the player's save data.
+##
+## Usage (via chat commands):
+##   /fame <player>    — Give +1 fame
+##   /defame <player>  — Give -1 fame
+
+signal fame_changed(username: String, new_fame: int)
+
+## Tracks daily fame cooldowns: "giver:target" -> unix timestamp of last fame action
+var _fame_cooldowns: Dictionary = {}
+
+const FAME_COOLDOWN_SECONDS: int = 86400  # 24 hours
+const FAME_PROXIMITY_RANGE: float = 100.0  # Must be within range to give fame
+
+
+## Give fame to a target player. Called on the server.
+## Returns an error message string, or empty string on success.
+func give_fame(giver_node: MultiplayerPlayerV2, target_username: String, amount: int) -> String:
+	if not multiplayer.is_server():
+		return "Only the server can process fame."
+
+	if amount != 1 and amount != -1:
+		return "Invalid fame amount."
+
+	var giver_username: String = giver_node.username
+	if giver_username == target_username:
+		return "You cannot give fame to yourself."
+
+	# Find target player node
+	var target_node: MultiplayerPlayerV2 = _find_player_by_username(target_username)
+	if not is_instance_valid(target_node):
+		return "Player '%s' not found." % target_username
+
+	# Check proximity
+	var distance: float = giver_node.global_position.distance_to(target_node.global_position)
+	if distance > FAME_PROXIMITY_RANGE:
+		return "You need to be closer to %s." % target_username
+
+	# Check daily cooldown
+	var cooldown_key: String = "%s:%s" % [giver_username, target_username]
+	if _fame_cooldowns.has(cooldown_key):
+		var last_time: float = _fame_cooldowns[cooldown_key]
+		var now: float = Time.get_unix_time_from_system()
+		if now - last_time < FAME_COOLDOWN_SECONDS:
+			var remaining: int = int(FAME_COOLDOWN_SECONDS - (now - last_time))
+			var hours: int = remaining / 3600
+			var minutes: int = (remaining % 3600) / 60
+			return "You can give fame to %s again in %dh %dm." % [target_username, hours, minutes]
+
+	# Apply fame
+	target_node.fame += amount
+	_fame_cooldowns[cooldown_key] = Time.get_unix_time_from_system()
+
+	# Sync to target client
+	_sync_fame_to_client.rpc_id(target_node.player_id, target_node.fame)
+
+	# Emit signal for any listeners
+	fame_changed.emit(target_username, target_node.fame)
+
+	# Notify both players via chat
+	var action_word: String = "raised" if amount > 0 else "lowered"
+	var giver_msg: String = "You %s %s's fame to %d." % [action_word, target_username, target_node.fame]
+	var target_msg: String = "%s %s your fame to %d." % [giver_username, action_word, target_node.fame]
+
+	_send_system_message.rpc_id(giver_node.player_id, giver_msg)
+	_send_system_message.rpc_id(target_node.player_id, target_msg)
+
+	# Also show on server console
+	print("FameManager: %s %s %s's fame to %d" % [giver_username, action_word, target_username, target_node.fame])
+
+	return ""
+
+
+## Handle a /fame or /defame chat command from a client.
+func handle_fame_command(sender_peer_id: int, target_username: String, is_defame: bool) -> void:
+	if not multiplayer.is_server():
+		return
+
+	var giver_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(sender_peer_id)
+	if not is_instance_valid(giver_node):
+		return
+
+	var amount: int = -1 if is_defame else 1
+	var error: String = give_fame(giver_node, target_username, amount)
+
+	if not error.is_empty():
+		_send_system_message.rpc_id(sender_peer_id, error)
+
+
+func _find_player_by_username(target_username: String) -> MultiplayerPlayerV2:
+	for node in get_tree().get_nodes_in_group("Players"):
+		if is_instance_valid(node) and node is MultiplayerPlayerV2:
+			if node.username == target_username:
+				return node
+	return null
+
+
+@rpc("authority", "call_local", "reliable")
+func _sync_fame_to_client(new_fame: int) -> void:
+	# Client receives their updated fame — find local player and update
+	var local_id: int = multiplayer.get_unique_id()
+	var player_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(local_id)
+	if is_instance_valid(player_node):
+		player_node.fame = new_fame
+
+
+@rpc("authority", "call_local", "reliable")
+func _send_system_message(text: String) -> void:
+	ChatManager.add_system_message(text, Color.GOLD)

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -41,6 +41,7 @@ const SERVER_ID: int = 1
 
 
 var username: String = ""
+var fame: int = 0
 var _current_party_id: int = -1
 
 var direction: int = 0  # The current input direction from the synchronizer
@@ -329,7 +330,8 @@ func _get_save_data() -> Dictionary:
 	   'current_health': health_component.current_health if is_instance_valid(health_component) else 100,
 	   'level': level_component.level if is_instance_valid(level_component) else 1,
 	   'experience': level_component.experience if is_instance_valid(level_component) else 0,
-	   'party_id': _current_party_id # Save party_id from local variable
+	   'party_id': _current_party_id, # Save party_id from local variable
+	   'fame': fame
 	}
 	
 	if is_instance_valid(player_inventory):
@@ -400,7 +402,9 @@ func _load_data(data: Dictionary) -> void:
 		var buff_data = data.get("buffs", {})
 		if not buff_data.is_empty():
 			buff_component.load_buffs(buff_data)
-		
+
+	fame = data.get("fame", 0)
+
 	_is_loading_data = false
 
 

--- a/scripts/UI/stats_window.gd
+++ b/scripts/UI/stats_window.gd
@@ -12,6 +12,8 @@ extends Control
 @onready var health_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/HealthContainer/HealthAmountLabel
 @onready var mana_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/ManaContainer/ManaAmountLabel
 
+@onready var fame_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/FameContainer/FameAmountLabel
+
 @onready var str_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/STRContainer/STRAmountLabel
 @onready var dex_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/DEXContainer/DEXAmountLabel
 @onready var int_amount_label: Label = $StatsPanel/ScrollContainer/MarginContainer/VBoxContainer/INTContainer/INTAmountLabel
@@ -83,7 +85,8 @@ func update_stats_window():
 	experience_string_label.text = str(int(player.level_component.experience)) + "/" + str(int(player.level_component.get_exp_to_next_level()))
 	health_amount_label.text = str(player.health_component.current_health) + "/" + str(player.health_component.max_health)
 	mana_amount_label.text = str(player.mana_component.current_mana) + "/" + str(player.mana_component.max_mana)
-	
+	fame_amount_label.text = str(player.fame)
+
 	str_amount_label.text = "%d (%d+%d)" % [player.stats_component.stats.get(Constants.StatType.STRENGTH).total_value, player.stats_component.stats.get(Constants.StatType.STRENGTH).base_value, player.stats_component.stats.get(Constants.StatType.STRENGTH).combined_bonus_value]	
 	dex_amount_label.text = "%d (%d+%d)" % [player.stats_component.stats.get(Constants.StatType.DEXTERITY).total_value, player.stats_component.stats.get(Constants.StatType.DEXTERITY).base_value, player.stats_component.stats.get(Constants.StatType.DEXTERITY).combined_bonus_value]	
 	int_amount_label.text = "%d (%d+%d)" % [player.stats_component.stats.get(Constants.StatType.INTELLIGENCE).total_value, player.stats_component.stats.get(Constants.StatType.INTELLIGENCE).base_value, player.stats_component.stats.get(Constants.StatType.INTELLIGENCE).combined_bonus_value]	


### PR DESCRIPTION
## Summary
- **FameManager** autoload singleton handles server-authoritative fame with daily cooldown per giver-target pair and proximity check (100px)
- `/fame <player>` gives +1, `/defame <player>` gives -1 fame via chat commands
- Fame displayed in stats window (between Mana and stat attributes)
- Fame value persisted in player save data
- ChatManager extended with slash command routing framework

Closes #4

## Test plan
- [ ] Start server + client, use `/fame <other_player>` while standing nearby
- [ ] Verify fame appears in stats window and updates after receiving fame
- [ ] Verify daily cooldown prevents giving fame to same player twice
- [ ] Verify `/fame self` returns error
- [ ] Verify out-of-range players can't exchange fame
- [ ] Verify fame persists across disconnect/reconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)