### PR TITLE
feat: Megaphone Chat consumable

### DIFF
--- a/resources/Items/Consumables/Megaphone.tres
+++ b/resources/Items/Consumables/Megaphone.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="ConsumableData" load_steps=3 format=3]
+
+[ext_resource type="Script" uid="uid://ubv3mjjv4lvi" path="res://scripts/Resources/ItemSystem/ConsumableData.gd" id="1_script"]
+[ext_resource type="Script" path="res://scripts/Resources/ItemSystem/Effects/Effect_MegaphoneChat.gd" id="2_effect"]
+
+[resource]
+script = ExtResource("1_script")
+effect_script = ExtResource("2_effect")
+effect_properties = {}
+item_id = "megaphone-chat-001"
+name = "Megaphone"
+description = "Use to broadcast your next chat message server-wide!"
+item_type = 2
+item_level = -1
+custom_item_value = 500
+can_stack = true
+max_stack_amount = 99
+current_stack_amount = 1

--- a/scripts/Managers/ChatManager.gd
+++ b/scripts/Managers/ChatManager.gd
@@ -4,6 +4,9 @@ signal message_received(message, color)
 
 var local_player_node: MultiplayerPlayerV2 = null
 
+# Megaphone: maps peer_id -> username for players with active megaphone
+var _megaphone_active: Dictionary = {}
+
 func _ready():
 	pass
 
@@ -19,7 +22,37 @@ func send_chat_message(text: String):
 func add_system_message(text: String, color: Color = Color.WHITE):
 	message_received.emit(text, color)
 
+## Called by Effect_MegaphoneChat on the server to flag the next message as megaphone.
+func enable_megaphone(peer_id: int, username: String) -> void:
+	if not multiplayer.is_server():
+		return
+	_megaphone_active[peer_id] = username
+	# Notify the client that megaphone is ready
+	_notify_megaphone_ready.rpc_id(peer_id)
+	print("ChatManager: Megaphone enabled for '%s' (peer %d)." % [username, peer_id])
+
+@rpc("authority", "call_local", "reliable")
+func _notify_megaphone_ready() -> void:
+	add_system_message("[MEGAPHONE] Your next message will be broadcast server-wide!", Color.YELLOW)
+
 @rpc("any_peer", "call_local", "reliable")
 func broadcast_message(sender_name: String, text: String):
+	if multiplayer.is_server():
+		var sender_id: int = multiplayer.get_remote_sender_id()
+		if sender_id == 0:
+			sender_id = 1  # Server itself
+
+		# Check if this sender has megaphone active
+		if _megaphone_active.has(sender_id):
+			_megaphone_active.erase(sender_id)
+			# Broadcast megaphone message to ALL connected peers
+			_receive_megaphone_message.rpc("[MEGAPHONE] %s: %s" % [sender_name, text])
+			return
+
+	# Normal local display
 	var message = "%s: %s" % [sender_name, text]
 	message_received.emit(message, Color.WHITE)
+
+@rpc("authority", "call_local", "reliable")
+func _receive_megaphone_message(text: String) -> void:
+	message_received.emit(text, Color.YELLOW)

--- a/scripts/Resources/ItemSystem/Effects/Effect_MegaphoneChat.gd
+++ b/scripts/Resources/ItemSystem/Effects/Effect_MegaphoneChat.gd
@@ -1,0 +1,11 @@
+class_name Effect_MegaphoneChat
+extends BaseItemEffect
+
+func execute():
+	if not is_instance_valid(user):
+		print("Megaphone Effect: Invalid user.")
+		return
+
+	# Enable megaphone mode on ChatManager for this player's next message
+	ChatManager.enable_megaphone(user.player_id, user.username)
+	print("Megaphone activated for player '%s'." % user.username)


### PR DESCRIPTION
## Summary
- Adds `Effect_MegaphoneChat.gd` effect script that flags the player's next chat message as a megaphone broadcast
- Extends `ChatManager` with megaphone support: `enable_megaphone()`, server-side intercept in `broadcast_message`, and `_receive_megaphone_message` RPC to all peers
- Adds `Megaphone.tres` consumable resource (500 gold value, stackable)
- Megaphone messages display in yellow with `[MEGAPHONE]` prefix server-wide

Closes #24

## Test plan
- [ ] Give player a Megaphone item and use it from inventory
- [ ] Verify system message "[MEGAPHONE] Your next message will be broadcast server-wide!" appears
- [ ] Send a chat message and verify all connected players see it in yellow with [MEGAPHONE] prefix
- [ ] Verify the megaphone is consumed (only one message broadcasted per use)
- [ ] Verify normal chat still works after megaphone message is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)