### PR TITLE
feat: Per-map BGM support

### DIFF
--- a/scenes/Levels/game.tscn
+++ b/scenes/Levels/game.tscn
@@ -550,6 +550,7 @@ _data = {
 
 [node name="Game" type="Node2D"]
 script = ExtResource("1_e24jv")
+bgm_path = "res://assets/music/gameplay.mp3"
 
 [node name="DmgNumberSpawner" type="MultiplayerSpawner" parent="."]
 spawn_path = NodePath("..")

--- a/scenes/Levels/game2.tscn
+++ b/scenes/Levels/game2.tscn
@@ -515,6 +515,7 @@ sources/2 = SubResource("TileSetAtlasSource_fnxnp")
 
 [node name="Game2" type="Node2D"]
 script = ExtResource("1_hd3yw")
+bgm_path = "res://assets/music/time_for_adventure.mp3"
 
 [node name="DmgNumberSpawner" type="MultiplayerSpawner" parent="."]
 unique_name_in_owner = true

--- a/scenes/Levels/game3.tscn
+++ b/scenes/Levels/game3.tscn
@@ -504,6 +504,7 @@ sources/2 = SubResource("TileSetAtlasSource_72b6d")
 
 [node name="Game3" type="Node2D"]
 script = ExtResource("1_gfksk")
+bgm_path = "res://assets/music/gameplay.mp3"
 
 [node name="DmgNumberSpawner" type="MultiplayerSpawner" parent="."]
 spawn_path = NodePath("..")

--- a/scripts/Gameplay/map_base.gd
+++ b/scripts/Gameplay/map_base.gd
@@ -4,6 +4,10 @@ class_name MapBase
 # This script should be attached to the root node of every map scene.
 # Maps now use manual spawning for both the map itself and players.
 
+## Path to the background music track for this map (e.g. "res://assets/music/gameplay.mp3").
+## Leave empty to keep playing whatever is currently playing.
+@export_file("*.mp3", "*.ogg", "*.wav") var bgm_path: String = ""
+
 func _ready():
 	# Add to group so MapManager can identify maps
 	add_to_group("map_base")

--- a/scripts/Managers/audio_manager.gd
+++ b/scripts/Managers/audio_manager.gd
@@ -1,15 +1,26 @@
 extends Node
 
 var _music_player: AudioStreamPlayer = AudioStreamPlayer.new()
+var _current_song_path: String = ""
 
 func _ready():
 	add_child(_music_player)
 	_music_player.bus = "Music"
 
 func play_song(path: String):
+	if path.is_empty():
+		return
+	# Skip if already playing this track
+	if path == _current_song_path and _music_player.playing:
+		return
+	_current_song_path = path
 	var song: AudioStream = ResourceLoader.load(path)
 	_music_player.stream = song
 	_music_player.play()
+
+func stop_song():
+	_music_player.stop()
+	_current_song_path = ""
 
 # Plays an SFX locally.
 func play_sfx(sfx_path: String, global_position: Vector2 = Vector2.ZERO, volume_db: float = 0.0):

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -77,6 +77,9 @@ func request_map_change(player_id: int, target_map_id: String, target_spawn_poin
 	if player_id == 1:
 		current_map_instance = map_instance
 		current_map_id = target_map_id
+		# Play per-map BGM for the host player
+		if map_instance is MapBase and not map_instance.bgm_path.is_empty():
+			AudioManager.play_song(map_instance.bgm_path)
 		_finalize_player_spawn(player_id, target_map_id, target_spawn_point_name)
 		return
 
@@ -421,9 +424,13 @@ func client_set_current_map(map_id: String, spawn_point_name: String = ""):
 	current_map_instance = map_instance
 	current_map_id = map_id
 	_warned_missing_paths.clear()
-	
+
+	# Play per-map BGM if the map defines one
+	if map_instance is MapBase and not map_instance.bgm_path.is_empty():
+		AudioManager.play_song(map_instance.bgm_path)
+
 	#print("Client %d: Loaded map '%s' at path %s" % [multiplayer.get_unique_id(), map_id, map_instance.get_path()])
-	
+
 	# ACK to server
 	rpc_id(1, "client_map_loaded", map_id, spawn_point_name)
 

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -75,7 +75,6 @@ func _ready() -> void:
 	if multiplayer.get_unique_id() == player_id:
 		ChatManager.register_local_player(self)
 		# Request the sprite states of all other players from the server.
-		AudioManager.play_song("res://assets/music/gameplay.mp3")
 		stats_window.update_stats_window()
 		request_all_sprite_states.rpc_id(SERVER_ID)
 


### PR DESCRIPTION
## Summary
- Adds `bgm_path` export to `MapBase` so each map scene can specify its own background music track
- Updates `AudioManager.play_song()` to skip replaying the same track and adds `stop_song()`
- Triggers BGM in `MapManager` on map load for both host (peer 1) and remote clients
- Removes hardcoded `gameplay.mp3` from player controller `_ready()`
- Assigns tracks: game → `gameplay.mp3`, game2 → `time_for_adventure.mp3`, game3 → `gameplay.mp3`

Closes #23

## Test plan
- [ ] Load into game (map 1) and verify `gameplay.mp3` plays
- [ ] Travel through portal to game2 and verify music changes to `time_for_adventure.mp3`
- [ ] Travel to game3 and verify `gameplay.mp3` plays again
- [ ] Re-enter game from game3 — music should not restart since it's the same track
- [ ] Test as both host and joining client

🤖 Generated with [Claude Code](https://claude.com/claude-code)