### PR TITLE
feat: Town Scroll consumable

### DIFF
--- a/resources/Items/Consumables/Town_Scroll.tres
+++ b/resources/Items/Consumables/Town_Scroll.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="ConsumableData" load_steps=3 format=3]
+
+[ext_resource type="Script" uid="uid://ubv3mjjv4lvi" path="res://scripts/Resources/ItemSystem/ConsumableData.gd" id="1_script"]
+[ext_resource type="Script" path="res://scripts/Resources/ItemSystem/Effects/Effect_TownScroll.gd" id="2_effect"]
+
+[resource]
+script = ExtResource("1_script")
+effect_script = ExtResource("2_effect")
+effect_properties = {
+"target_map": "game"
+}
+item_id = "town-scroll-001"
+name = "Town Scroll"
+description = "A magical scroll that teleports you back to town."
+item_type = 2
+item_level = -1
+custom_item_value = 200
+can_stack = true
+max_stack_amount = 99
+current_stack_amount = 1

--- a/scripts/Resources/ItemSystem/Effects/Effect_TownScroll.gd
+++ b/scripts/Resources/ItemSystem/Effects/Effect_TownScroll.gd
@@ -1,0 +1,20 @@
+class_name Effect_TownScroll
+extends BaseItemEffect
+
+func execute():
+	if not is_instance_valid(user):
+		print("Town Scroll Effect: Invalid user.")
+		return
+
+	var target_map: String = source_item.effect_properties.get("target_map", MapManager.DEFAULT_MAP)
+
+	if not multiplayer.is_server():
+		return
+
+	var current_map: String = MapManager.get_player_map(user.player_id)
+	if current_map == target_map:
+		print("Town Scroll: Player '%s' is already on map '%s'." % [user.username, target_map])
+		return
+
+	print("Town Scroll: Teleporting '%s' to '%s'." % [user.username, target_map])
+	MapManager.request_map_change(user.player_id, target_map)


### PR DESCRIPTION
## Summary
- Adds `Effect_TownScroll.gd` effect script that teleports the player to the town map via `MapManager.request_map_change()`
- Adds `Town_Scroll.tres` consumable resource (200 gold value, stackable, targets "game" map by default)
- Supports configurable `target_map` via `effect_properties` for future map variants
- Skips teleport if player is already on the target map

Closes #20

## Test plan
- [ ] Give player a Town Scroll while on game2 or game3
- [ ] Use the Town Scroll from inventory and verify teleport to game (town)
- [ ] Verify the scroll is consumed from inventory
- [ ] Use a Town Scroll while already on game — verify no teleport and item is still consumed
- [ ] Test as both host and remote client

🤖 Generated with [Claude Code](https://claude.com/claude-code)