### PR TITLE
feat: Achievement titles system

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -33,6 +33,7 @@ LogManager="*res://scripts/Managers/LogManager.gd"
 ChatManager="*res://scripts/Managers/ChatManager.gd"
 NetworkManager="*res://scripts/Networking/network_manager.gd"
 SaveManager="*res://scripts/Managers/save_manager.gd"
+AchievementManager="*res://scripts/Managers/achievement_manager.gd"
 
 [display]
 

--- a/scripts/Enemy/enemy_base.gd
+++ b/scripts/Enemy/enemy_base.gd
@@ -247,6 +247,12 @@ func _deferred_death_processing(_killer: Node) -> void:
 				print("PID: %s did %s%% damage to %s gaining %s exp" % [str(player_id), share * 100, name, str(exp_amount)])
 				player_node.gain_experience(exp_amount)
 				
+	# Record kills for achievement tracking
+	for player_id in players_to_reward:
+		var player_node = PlayerManager.get_player_node(player_id)
+		if player_node and player_node is MultiplayerPlayerV2:
+			AchievementManager.record_kill(player_node.username, monster_name)
+
 	# Spawn drops for all eligible players
 	if not eligible_player_ids_for_drops.is_empty():
 		_spawn_drops(eligible_player_ids_for_drops)

--- a/scripts/Managers/ChatManager.gd
+++ b/scripts/Managers/ChatManager.gd
@@ -11,6 +11,13 @@ func register_local_player(player_node: MultiplayerPlayerV2):
 	local_player_node = player_node
 
 func send_chat_message(text: String):
+	if text.begins_with("/"):
+		var parts: PackedStringArray = text.strip_edges().split(" ", false)
+		var command: String = parts[0].to_lower()
+		if command == "/title":
+			_request_title.rpc_id(1, text.strip_edges())
+			return
+
 	if local_player_node:
 		broadcast_message.rpc(local_player_node.username, text)
 	else:
@@ -23,3 +30,69 @@ func add_system_message(text: String, color: Color = Color.WHITE):
 func broadcast_message(sender_name: String, text: String):
 	var message = "%s: %s" % [sender_name, text]
 	message_received.emit(message, Color.WHITE)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# TITLE COMMAND
+# ═══════════════════════════════════════════════════════════════════════════
+
+@rpc("any_peer", "call_remote", "reliable")
+func _request_title(raw_text: String) -> void:
+	if not multiplayer.is_server():
+		return
+
+	var sender_id: int = multiplayer.get_remote_sender_id()
+	if sender_id == 0:
+		sender_id = 1
+
+	var sender_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(sender_id)
+	if not is_instance_valid(sender_node):
+		return
+
+	var parts: PackedStringArray = raw_text.split(" ", false)
+
+	# /title list — show unlocked achievements
+	if parts.size() >= 2 and parts[1].to_lower() == "list":
+		var unlocked: Array = AchievementManager.get_unlocked_achievements(sender_node.username)
+		if unlocked.is_empty():
+			_send_system_message.rpc_id(sender_id, "You have no unlocked titles yet.", Color.GRAY)
+			return
+		var lines: String = "Unlocked titles:"
+		for aid in unlocked:
+			if AchievementManager.ACHIEVEMENTS.has(aid):
+				lines += "\n  %s — %s" % [aid, AchievementManager.ACHIEVEMENTS[aid].title]
+		_send_system_message.rpc_id(sender_id, lines, Color.GOLD)
+		return
+
+	# /title clear — remove active title
+	if parts.size() >= 2 and parts[1].to_lower() == "clear":
+		AchievementManager.set_active_title(sender_node.username, "")
+		# Sync to all peers on same map
+		var map_id: String = MapManager.get_player_map(sender_id)
+		if not map_id.is_empty():
+			for pid in MapManager.get_players_on_map(map_id):
+				sender_node._sync_title.rpc_id(pid, "")
+		_send_system_message.rpc_id(sender_id, "Title cleared.", Color.GRAY)
+		return
+
+	# /title <achievement_id> — set active title
+	if parts.size() >= 2:
+		var title_id: String = parts[1]
+		if AchievementManager.set_active_title(sender_node.username, title_id):
+			var map_id: String = MapManager.get_player_map(sender_id)
+			if not map_id.is_empty():
+				for pid in MapManager.get_players_on_map(map_id):
+					sender_node._sync_title.rpc_id(pid, title_id)
+			var title_name: String = AchievementManager.ACHIEVEMENTS[title_id].title
+			_send_system_message.rpc_id(sender_id, "Title set to: %s" % title_name, Color.GOLD)
+		else:
+			_send_system_message.rpc_id(sender_id, "Title not found or not unlocked. Use /title list to see your titles.", Color.RED)
+		return
+
+	# /title — show usage
+	_send_system_message.rpc_id(sender_id, "Usage: /title list | /title <id> | /title clear", Color.GRAY)
+
+
+@rpc("authority", "call_local", "reliable")
+func _send_system_message(text: String, color: Color) -> void:
+	message_received.emit(text, color)

--- a/scripts/Managers/achievement_manager.gd
+++ b/scripts/Managers/achievement_manager.gd
@@ -1,0 +1,164 @@
+extends Node
+## AchievementManager — Tracks milestones and awards titles.
+##
+## Server-authoritative. Stores progress in player save data.
+## Players can set an active title displayed under their name.
+
+signal achievement_unlocked(username: String, achievement_id: String)
+
+# Achievement definitions: { id: { title, description, stat, threshold } }
+const ACHIEVEMENTS: Dictionary = {
+	"slime_slayer": {
+		"title": "Slime Slayer",
+		"description": "Defeat 100 slimes",
+		"stat": "kills_slime",
+		"threshold": 100,
+	},
+	"slime_master": {
+		"title": "Slime Master",
+		"description": "Defeat 1000 slimes",
+		"stat": "kills_slime",
+		"threshold": 1000,
+	},
+	"boar_hunter": {
+		"title": "Boar Hunter",
+		"description": "Defeat 100 boars",
+		"stat": "kills_boar",
+		"threshold": 100,
+	},
+	"veteran": {
+		"title": "Veteran",
+		"description": "Reach level 30",
+		"stat": "level",
+		"threshold": 30,
+	},
+	"elite": {
+		"title": "Elite",
+		"description": "Reach level 50",
+		"stat": "level",
+		"threshold": 50,
+	},
+	"first_blood": {
+		"title": "First Blood",
+		"description": "Defeat your first enemy",
+		"stat": "kills_total",
+		"threshold": 1,
+	},
+	"centurion": {
+		"title": "Centurion",
+		"description": "Defeat 100 enemies",
+		"stat": "kills_total",
+		"threshold": 100,
+	},
+	"millionaire": {
+		"title": "Millionaire",
+		"description": "Accumulate 1,000,000 coins",
+		"stat": "monies_earned",
+		"threshold": 1000000,
+	},
+}
+
+# Per-player data: username -> { stats: {stat_key: value}, unlocked: [achievement_ids], active_title: String }
+var _player_data: Dictionary = {}
+
+
+func record_kill(username: String, enemy_name: String) -> void:
+	if not multiplayer.is_server():
+		return
+	var stats: Dictionary = _get_stats(username)
+	var kill_key: String = "kills_" + enemy_name.to_lower().replace(" ", "_")
+	stats[kill_key] = stats.get(kill_key, 0) + 1
+	stats["kills_total"] = stats.get("kills_total", 0) + 1
+	_check_achievements(username)
+
+
+func record_stat(username: String, stat_key: String, value: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var stats: Dictionary = _get_stats(username)
+	stats[stat_key] = value
+	_check_achievements(username)
+
+
+func get_active_title(username: String) -> String:
+	if not _player_data.has(username):
+		return ""
+	return _player_data[username].get("active_title", "")
+
+
+func get_unlocked_achievements(username: String) -> Array:
+	if not _player_data.has(username):
+		return []
+	return _player_data[username].get("unlocked", [])
+
+
+func set_active_title(username: String, achievement_id: String) -> bool:
+	if not multiplayer.is_server():
+		return false
+	if not _player_data.has(username):
+		return false
+	if achievement_id.is_empty():
+		_player_data[username]["active_title"] = ""
+		return true
+	var unlocked: Array = _player_data[username].get("unlocked", [])
+	if achievement_id not in unlocked:
+		return false
+	_player_data[username]["active_title"] = achievement_id
+	return true
+
+
+func get_save_data(username: String) -> Dictionary:
+	if not _player_data.has(username):
+		return {}
+	return _player_data[username].duplicate(true)
+
+
+func load_save_data(username: String, data: Dictionary) -> void:
+	_player_data[username] = {
+		"stats": data.get("stats", {}),
+		"unlocked": data.get("unlocked", []),
+		"active_title": data.get("active_title", ""),
+	}
+
+
+func _get_stats(username: String) -> Dictionary:
+	if not _player_data.has(username):
+		_player_data[username] = {"stats": {}, "unlocked": [], "active_title": ""}
+	return _player_data[username]["stats"]
+
+
+func _check_achievements(username: String) -> void:
+	if not _player_data.has(username):
+		return
+	var stats: Dictionary = _player_data[username]["stats"]
+	var unlocked: Array = _player_data[username]["unlocked"]
+
+	for achievement_id in ACHIEVEMENTS:
+		if achievement_id in unlocked:
+			continue
+		var achievement: Dictionary = ACHIEVEMENTS[achievement_id]
+		var current_value: int = stats.get(achievement.stat, 0)
+		if current_value >= achievement.threshold:
+			unlocked.append(achievement_id)
+			achievement_unlocked.emit(username, achievement_id)
+			_notify_achievement(username, achievement_id)
+
+
+func _notify_achievement(username: String, achievement_id: String) -> void:
+	var achievement: Dictionary = ACHIEVEMENTS[achievement_id]
+	var title: String = achievement.get("title", "")
+
+	# Find the player and notify via chat
+	for map_id in MapManager.active_maps.keys():
+		var map_instance = MapManager.active_maps[map_id].scene_instance
+		if not is_instance_valid(map_instance):
+			continue
+		var players_node = map_instance.get_node_or_null("Players")
+		if not players_node:
+			continue
+		for child in players_node.get_children():
+			if child is MultiplayerPlayerV2 and child.username == username:
+				ChatManager.add_system_message.rpc_id(child.player_id,
+					"Achievement Unlocked: %s — %s" % [title, achievement.description],
+					Color.GOLD)
+				return

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -242,6 +242,7 @@ func _setup_signals() -> void:
 		level_component.leveled_up.connect(func(_l): _data_changed("all")) # Level up might affect everything (points, stats)
 		if multiplayer.is_server():
 			level_component.leveled_up.connect(_handle_sprite_change_on_server.unbind(1))
+			level_component.leveled_up.connect(func(new_level): AchievementManager.record_stat(username, "level", new_level))
 	
 	if health_component:
 		health_component.health_changed.connect(func(_c, _m): _data_changed("stats"))
@@ -425,7 +426,10 @@ func get_save_data(update_type: String = "all") -> Dictionary:
 	if update_type == "all" or update_type == "buffs":
 		if is_instance_valid(buff_component):
 			data['buffs'] = buff_component.save_buffs()
-		
+
+	if update_type == "all" or update_type == "stats":
+		data['achievements'] = AchievementManager.get_save_data(username)
+
 	return data
 
 
@@ -498,7 +502,16 @@ func _load_data(data: Dictionary) -> void:
 		var buff_data = data.get("buffs", {})
 		if not buff_data.is_empty():
 			buff_component.load_buffs(buff_data)
-		
+
+	# Load achievement data
+	var achievement_data = data.get("achievements", {})
+	if not achievement_data.is_empty():
+		AchievementManager.load_save_data(username, achievement_data)
+	# Update level stat for level-based achievements
+	AchievementManager.record_stat(username, "level", level_component.level if is_instance_valid(level_component) else 1)
+	# Update title display
+	_update_title_display()
+
 	_is_loading_data = false
 
 
@@ -664,8 +677,26 @@ func request_all_sprite_states() -> void:
 @rpc("any_peer", "call_local", "reliable")
 func set_username(uname: String) -> void:
 	username = uname
-	if is_instance_valid(player_name_label):
+	_update_title_display()
+
+
+func _update_title_display() -> void:
+	if not is_instance_valid(player_name_label):
+		return
+	var title_id: String = AchievementManager.get_active_title(username)
+	if title_id.is_empty() or not AchievementManager.ACHIEVEMENTS.has(title_id):
 		player_name_label.text = username
+	else:
+		var title_name: String = AchievementManager.ACHIEVEMENTS[title_id].title
+		player_name_label.text = "%s\n[color=gold]<%s>[/color]" % [username, title_name]
+
+
+@rpc("authority", "call_local", "reliable")
+func _sync_title(title_id: String) -> void:
+	# Server sets the title and syncs display to all peers
+	if multiplayer.is_server():
+		AchievementManager.set_active_title(username, title_id)
+	_update_title_display()
 		
 		
 @rpc("any_peer", "call_local", "reliable")


### PR DESCRIPTION
## Summary
- Adds `AchievementManager` autoload with 8 built-in achievements (kill counts, levels, coins)
- Tracks enemy kills per monster type in `enemy_base.gd` death processing
- Tracks level milestones via `leveled_up` signal
- Persists achievement stats, unlocked list, and active title in player save data
- Displays active title under player name via BBCode `[color=gold]<Title>[/color]`
- Chat commands: `/title list`, `/title <id>`, `/title clear`
- Server-authoritative — all validation and tracking happens server-side

Closes #26

## Test plan
- [ ] Kill enemies and verify kill counts accumulate (check via save file)
- [ ] Reach achievement thresholds and verify "Achievement Unlocked" message appears
- [ ] Use `/title list` to see unlocked titles
- [ ] Use `/title <id>` to set a title, verify it appears under player name
- [ ] Use `/title clear` to remove title
- [ ] Verify title persists across disconnect/reconnect
- [ ] Verify other players on same map can see your title

🤖 Generated with [Claude Code](https://claude.com/claude-code)