### PR TITLE
feat: Server-wide announcements

### DIFF
--- a/scripts/Managers/ChatManager.gd
+++ b/scripts/Managers/ChatManager.gd
@@ -4,6 +4,9 @@ signal message_received(message, color)
 
 var local_player_node: MultiplayerPlayerV2 = null
 
+# Level milestones that trigger server-wide announcements
+const LEVEL_MILESTONES: Array[int] = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+
 func _ready():
 	pass
 
@@ -23,3 +26,32 @@ func add_system_message(text: String, color: Color = Color.WHITE):
 func broadcast_message(sender_name: String, text: String):
 	var message = "%s: %s" % [sender_name, text]
 	message_received.emit(message, Color.WHITE)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SERVER-WIDE ANNOUNCEMENTS
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Broadcast a server-wide announcement to ALL connected players.
+## Called only on the server.
+func server_announce(text: String, color: Color = Color.GOLD) -> void:
+	if not multiplayer.is_server():
+		return
+	_receive_announcement.rpc(text, color)
+
+@rpc("authority", "call_local", "reliable")
+func _receive_announcement(text: String, color: Color) -> void:
+	message_received.emit(text, color)
+
+## Called by player controller when a level milestone is reached.
+func announce_level_up(username: String, new_level: int) -> void:
+	if not multiplayer.is_server():
+		return
+	if new_level in LEVEL_MILESTONES:
+		server_announce("[ANNOUNCE] %s has reached level %d!" % [username, new_level])
+
+## Called when a rare item drops.
+func announce_rare_drop(username: String, item_name: String, rarity_name: String) -> void:
+	if not multiplayer.is_server():
+		return
+	server_announce("[ANNOUNCE] %s obtained a %s %s!" % [username, rarity_name, item_name])

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -242,6 +242,7 @@ func _setup_signals() -> void:
 		level_component.leveled_up.connect(func(_l): _data_changed("all")) # Level up might affect everything (points, stats)
 		if multiplayer.is_server():
 			level_component.leveled_up.connect(_handle_sprite_change_on_server.unbind(1))
+			level_component.leveled_up.connect(func(new_level): ChatManager.announce_level_up(username, new_level))
 	
 	if health_component:
 		health_component.health_changed.connect(func(_c, _m): _data_changed("stats"))

--- a/scripts/Resources/ItemSystem/DroppedItem.gd
+++ b/scripts/Resources/ItemSystem/DroppedItem.gd
@@ -195,6 +195,11 @@ func _pickup_item(picking_player: MultiplayerPlayerV2 = null) -> void:
 
 	# RPC to client to show log message
 		show_pickup_log_rpc.rpc_id(player_to_give_item.player_id, item_data.name, stack_amount)
+
+		# Announce rare+ drops server-wide
+		if item_data.rarity >= Constants.ItemRarity.RARE and item_data.name != "Coin":
+			var rarity_name: String = Constants.ItemRarity.find_key(item_data.rarity)
+			ChatManager.announce_rare_drop(player_to_give_item.username, item_data.name, rarity_name.capitalize())
 	
 	# Stop syncing immediately to prevent "Node not found" errors on client
 	var synchronizer = get_node_or_null("MultiplayerSynchronizer")


### PR DESCRIPTION
## Summary
- Adds `server_announce()` and `_receive_announcement` RPC to ChatManager for broadcasting to all peers
- Adds `announce_level_up()` — triggers at milestone levels (10, 20, 30... 100)
- Adds `announce_rare_drop()` — triggers when players pick up Rare+ items
- Hooks level-up announcements via `leveled_up` signal in player controller
- Hooks rare drop announcements in `DroppedItem._pickup_item()`
- Announcements display in gold `[ANNOUNCE]` prefix

Closes #3

## Test plan
- [ ] Level up to 10 and verify server-wide announcement appears for all players
- [ ] Pick up a Rare or higher rarity item and verify announcement for all players
- [ ] Verify Common/Uncommon drops do NOT trigger announcements
- [ ] Verify announcements appear even for players on different maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)