### PR TITLE
feat: Hidden secret portals

### DIFF
--- a/scenes/Gameplay/secret_portal.tscn
+++ b/scenes/Gameplay/secret_portal.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=5 format=3 uid="uid://secret_portal_001"]
+
+[ext_resource type="Script" path="res://scripts/Gameplay/secret_portal.gd" id="1_secret_gd"]
+[ext_resource type="Texture2D" uid="uid://1oyrvvlfb431" path="res://assets/sprites/Portal.editor.pg.webp" id="2_ecvi2"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_shape"]
+size = Vector2(16, 29)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_ecvi2"]
+bg_color = Color(1, 1, 1, 0.7882353)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0, 0, 0, 1)
+corner_radius_top_left = 3
+corner_radius_top_right = 3
+corner_radius_bottom_right = 3
+corner_radius_bottom_left = 3
+
+[node name="SecretPortal" type="Area2D"]
+collision_layer = 0
+collision_mask = 2
+script = ExtResource("1_secret_gd")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1.5)
+shape = SubResource("RectangleShape2D_shape")
+
+[node name="Sprite2D" type="Sprite2D" parent="."]
+visible = false
+scale = Vector2(0.185, 0.185)
+texture = ExtResource("2_ecvi2")
+
+[node name="InteractionLabel" type="Label" parent="."]
+visible = false
+offset_left = -6.0
+offset_top = -29.0
+offset_right = 2333.0
+offset_bottom = 2056.0
+scale = Vector2(0.005, 0.005)
+theme_override_colors/font_color = Color(0, 0, 0, 1)
+theme_override_font_sizes/font_size = 1516
+theme_override_styles/normal = SubResource("StyleBoxFlat_ecvi2")
+text = "↑"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[connection signal="body_entered" from="." to="." method="_on_body_entered"]
+[connection signal="body_exited" from="." to="." method="_on_body_exited"]

--- a/scripts/Gameplay/secret_portal.gd
+++ b/scripts/Gameplay/secret_portal.gd
@@ -1,0 +1,40 @@
+extends Portal
+class_name SecretPortal
+
+## A hidden portal that becomes visible only when a player touches it.
+## Place in hard-to-reach spots for discoverable secret areas.
+
+@export var reveal_message: String = "You found a secret passage!"
+
+func _ready():
+	super._ready()
+	# Start invisible — the sprite and label are hidden
+	if has_node("Sprite2D"):
+		$Sprite2D.visible = false
+	interaction_label.visible = false
+
+func _on_body_entered(body: Node2D):
+	if body is MultiplayerPlayerV2 and body.player_id != 0:
+		# Reveal the portal visually for this player
+		if has_node("Sprite2D"):
+			$Sprite2D.visible = true
+		interaction_label.visible = true
+
+		if body.has_method("set_current_portal"):
+			body.set_current_portal(self)
+
+		# Show discovery message
+		if multiplayer.is_server() and not reveal_message.is_empty():
+			ChatManager.add_system_message.rpc_id(body.player_id, reveal_message, Color.CYAN)
+
+		print("Player %d discovered secret portal to '%s'" % [body.player_id, target_map_id])
+
+func _on_body_exited(body: Node2D):
+	if body is MultiplayerPlayerV2 and body.player_id != 0:
+		# Hide again when player leaves
+		if has_node("Sprite2D"):
+			$Sprite2D.visible = false
+		interaction_label.visible = false
+
+		if body.has_method("clear_current_portal"):
+			body.clear_current_portal()


### PR DESCRIPTION
## Summary
- Adds `SecretPortal` class extending `Portal` — starts invisible, reveals on player contact
- Shows a customizable discovery message via ChatManager (cyan system message)
- Includes `secret_portal.tscn` scene ready to place in existing maps
- Portal hides again when player exits the area

Closes #18

## Test plan
- [ ] Place a SecretPortal in a map scene via the editor
- [ ] Set `target_map_id` and `target_spawn_point_name` on the portal
- [ ] Walk into the portal area — verify it becomes visible and shows discovery message
- [ ] Press interact to use the portal — verify map transition works
- [ ] Walk away from portal — verify it hides again

🤖 Generated with [Claude Code](https://claude.com/claude-code)