### PR TITLE
feat: Jump quest map scaffolding

### DIFF
--- a/scenes/Levels/jumpquest.tscn
+++ b/scenes/Levels/jumpquest.tscn
@@ -1,0 +1,60 @@
+[gd_scene load_steps=7 format=4]
+
+[ext_resource type="Script" uid="uid://dfj1ny2sygjrj" path="res://scripts/Gameplay/map_base.gd" id="1_mapbase"]
+[ext_resource type="Script" uid="uid://b1ruh77vt7mdu" path="res://scripts/damage_numbers.gd" id="2_dmgnum"]
+[ext_resource type="PackedScene" uid="uid://bx2n3vrfxk75m" path="res://scenes/Gameplay/killzone.tscn" id="3_killzone"]
+[ext_resource type="Script" path="res://scripts/Gameplay/jump_quest_goal.gd" id="4_goal"]
+[ext_resource type="PackedScene" uid="uid://brfb5t5im33fl" path="res://scenes/Gameplay/portal.tscn" id="5_portal"]
+[ext_resource type="Script" uid="uid://igk1rxt26f2i" path="res://scripts/UI/global_drop_handler.gd" id="6_drop"]
+
+[node name="JumpQuest" type="Node2D"]
+script = ExtResource("1_mapbase")
+
+[node name="DmgNumberSpawner" type="MultiplayerSpawner" parent="."]
+spawn_path = NodePath("..")
+script = ExtResource("2_dmgnum")
+
+[node name="ProjectileSpawner" type="MultiplayerSpawner" parent="."]
+_spawnable_scenes = PackedStringArray("uid://d0ig4oiimrnei")
+spawn_path = NodePath("../Projectiles")
+
+[node name="ExitPortal" parent="." instance=ExtResource("5_portal")]
+position = Vector2(16, 176)
+target_map_id = "game"
+target_spawn_point_name = ""
+
+[node name="PlayerSpawn" type="Marker2D" parent="."]
+position = Vector2(32, 192)
+
+[node name="Killzone" parent="." instance=ExtResource("3_killzone")]
+position = Vector2(0, 400)
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Killzone"]
+position = Vector2(512, 0)
+
+[node name="JumpQuestGoal" type="Area2D" parent="."]
+position = Vector2(960, -320)
+script = ExtResource("4_goal")
+reward_coins = 5000
+return_map_id = "game"
+
+[node name="GoalCollision" type="CollisionShape2D" parent="JumpQuestGoal"]
+
+[node name="GoalLabel" type="Label" parent="JumpQuestGoal"]
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 0.0
+text = "GOAL!"
+horizontal_alignment = 1
+
+[node name="Players" type="Node2D" parent="."]
+
+[node name="Projectiles" type="Node2D" parent="."]
+
+[node name="ItemDrops" type="Node2D" parent="."]
+
+[node name="GlobalDropHandler" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 0
+script = ExtResource("6_drop")

--- a/scripts/Gameplay/jump_quest_goal.gd
+++ b/scripts/Gameplay/jump_quest_goal.gd
@@ -1,0 +1,46 @@
+extends Area2D
+class_name JumpQuestGoal
+
+## Placed at the end of a jump quest map. Awards a reward when a player reaches it.
+## Each player can only claim the reward once per server session.
+
+@export var reward_title: String = "Platformer"
+@export var reward_coins: int = 5000
+@export var return_map_id: String = "game"
+@export var return_spawn_point: String = ""
+
+var _claimed_players: Dictionary = {}  # player_id -> true
+
+func _ready():
+	if not multiplayer.is_server():
+		return
+	body_entered.connect(_on_body_entered)
+
+func _on_body_entered(body: Node2D):
+	if not multiplayer.is_server():
+		return
+	if not body is MultiplayerPlayerV2:
+		return
+
+	var player: MultiplayerPlayerV2 = body as MultiplayerPlayerV2
+	if _claimed_players.has(player.player_id):
+		return
+
+	_claimed_players[player.player_id] = true
+
+	# Award coins
+	if reward_coins > 0 and is_instance_valid(player.player_inventory):
+		player.player_inventory.monies_amount += reward_coins
+		player.player_inventory.set_monies_rpc.rpc(player.player_inventory.monies_amount)
+
+	# Notify the player
+	ChatManager.add_system_message.rpc_id(player.player_id,
+		"Jump Quest Complete! You earned %d coins!" % reward_coins, Color.GOLD)
+
+	print("JumpQuestGoal: Player '%s' completed the jump quest." % player.username)
+
+	# Teleport back after a short delay
+	get_tree().create_timer(2.0).timeout.connect(func():
+		if is_instance_valid(player):
+			MapManager.request_map_change(player.player_id, return_map_id, return_spawn_point)
+	)

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -11,6 +11,7 @@ const MAP_SCENES = {
 	"game": "res://scenes/Levels/game.tscn",
 	"game2": "res://scenes/Levels/game2.tscn",
 	"game3": "res://scenes/Levels/game3.tscn",
+	"jumpquest": "res://scenes/Levels/jumpquest.tscn",
 }
 
 const DEFAULT_MAP = "game"


### PR DESCRIPTION
## Summary
- Adds `JumpQuestGoal` area component that awards coins on completion and teleports player back
- Adds `jumpquest.tscn` scaffold map with required nodes (Players, Killzone, DmgNumberSpawner, etc.)
- Registers `jumpquest` map in `MapManager.MAP_SCENES`
- Goal rewards: 5000 coins per completion (once per session per player)
- Includes exit portal back to town
- **Note:** Tile/platform layout needs to be designed in the Godot editor

Closes #19

## Test plan
- [ ] Open `jumpquest.tscn` in editor and add platforms/tiles for the challenge
- [ ] Place a portal on an existing map pointing to `jumpquest`
- [ ] Enter the jump quest and navigate to the JumpQuestGoal area
- [ ] Verify coin reward and completion message
- [ ] Verify auto-teleport back to town after 2 seconds
- [ ] Try reaching the goal again — verify reward is only given once per session

🤖 Generated with [Claude Code](https://claude.com/claude-code)