### PR TITLE
Disable _process when no cooldowns or buffs are active

### DIFF
--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -120,6 +120,7 @@ func _ready() -> void:
 				_learn_ability_local(ability_data.ability_id, 0, false)
 
 	print("AbilityComponent ready. Loaded abilities: ", _ability_levels)
+	set_process(false) # No cooldowns active at start
 
 
 func _process(delta: float) -> void:
@@ -132,6 +133,10 @@ func _process(delta: float) -> void:
 
 	for ability_id in finished_cooldowns:
 		_cooldowns.erase(ability_id)
+
+	# Disable processing when no cooldowns are active
+	if _cooldowns.is_empty():
+		set_process(false)
 #endregion
 
 
@@ -330,7 +335,8 @@ func _consume_ability_resources(ability_id: String, level_stats: AbilityLevelDat
 	# Start cooldown
 	var modified_cooldown = level_stats.cooldown_time * get_ability_cooldown_modifier(ability_id)
 	_cooldowns[ability_id] = modified_cooldown
-	
+	set_process(true)
+
 	return modified_cooldown
 
 #endregion
@@ -655,7 +661,8 @@ func ability_used_client(ability_id: String, cooldown_time: float) -> void:
 	
 	# Set cooldown locally for all instances (server and clients)
 	_cooldowns[ability_id] = cooldown_time
-	
+	set_process(true)
+
 	# Emit signals for UI and other systems
 	ability_used.emit(ability_id)
 	cooldown_started.emit(ability_id, cooldown_time)

--- a/scripts/Components/buff.gd
+++ b/scripts/Components/buff.gd
@@ -52,6 +52,8 @@ func _ready() -> void:
 	if _health_component and multiplayer.is_server():
 		_health_component.damaged.connect(_on_damaged)
 
+	set_process(false) # No buffs active at start
+
 
 func _process(delta: float) -> void:
 	if not multiplayer.is_server():
@@ -78,6 +80,15 @@ func _process(delta: float) -> void:
 	# Remove expired buffs
 	for buff_id in expired_buffs:
 		remove_buff(buff_id)
+
+	# Disable processing when no timed buffs remain
+	var has_timed_buffs = false
+	for buff_id in _active_buffs:
+		if _active_buffs[buff_id].buff_data.duration > 0:
+			has_timed_buffs = true
+			break
+	if not has_timed_buffs:
+		set_process(false)
 #endregion
 
 #region #################### Public API ####################
@@ -144,6 +155,8 @@ func _apply_buff_local(buff_id: String, source: Node = null, custom_duration: fl
 	var active_buff := ActiveBuff.new(buff_data, source)
 	active_buff.remaining_duration = duration
 	_active_buffs[buff_id] = active_buff
+	if duration > 0:
+		set_process(true)
 	
 	# Call custom logic on_apply if available
 	if active_buff.custom_logic_instance and active_buff.custom_logic_instance.has_method("on_apply"):
@@ -298,7 +311,9 @@ func sync_buff_applied(buff_id: String, duration: float) -> void:
 	var active_buff := ActiveBuff.new(buff_data, null)
 	active_buff.remaining_duration = duration
 	_active_buffs[buff_id] = active_buff
-	
+	if duration > 0:
+		set_process(true)
+
 	buff_applied.emit(buff_id, duration)
 
 
@@ -360,7 +375,9 @@ func sync_buff_with_stacks(buff_id: String, stacks: int, duration: float) -> voi
 	active_buff.stacks = stacks
 	active_buff.remaining_duration = duration
 	_active_buffs[buff_id] = active_buff
-	
+	if duration > 0:
+		set_process(true)
+
 	buff_applied.emit(buff_id, duration)
 #endregion
 
@@ -407,6 +424,8 @@ func load_buffs(data: Dictionary) -> void:
 			active_buff.stacks = stacks
 			active_buff.remaining_duration = duration
 			_active_buffs[buff_id] = active_buff
+			if duration > 0:
+				set_process(true)
 
 			# Skip on_apply during load — we are restoring persisted state,
 			# not freshly applying a buff. on_apply callbacks may trigger


### PR DESCRIPTION
## Summary
- AbilityComponent now disables `_process` on startup and re-enables only when cooldowns start, auto-disables when all cooldowns expire
- BuffComponent now disables `_process` on startup and re-enables when timed buffs are applied, auto-disables when no timed buffs remain
- Eliminates per-frame function call overhead for idle components

## Test plan
- [ ] Use abilities and verify cooldowns still tick down correctly
- [ ] Verify cooldown UI updates properly on both server and clients
- [ ] Apply timed buffs and verify they expire correctly
- [ ] Apply permanent buffs and verify _process stays disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)