### PR TITLE
Reuse persistent HTTPRequest in NetworkManager

### DIFF
--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -13,60 +13,57 @@ var account_username: String = ""
 var api_url = ""  # Will be loaded from UserConfig
 var is_dev_mode: bool = false
 var use_local_save: bool = false
+var _http: HTTPRequest
 
 func _ready():
 	# Load API URL from config (supports environment variable override)
 	api_url = UserConfig.get_backend_api_url()
 	print("NetworkManager: Using API URL: %s" % api_url)
+	# Persistent HTTPRequest node reused across all API calls
+	_http = HTTPRequest.new()
+	_http.name = "HTTPRequest"
+	_http.timeout = 10.0
+	add_child(_http)
 
 func register(username, password):
-	var http = HTTPRequest.new()
-	add_child(http)
-	http.request_completed.connect(_on_register_completed.bind(http))
-	
+	_reconnect_http(_on_register_completed)
+
 	var body = JSON.stringify({"username": username, "password": password})
 	var headers = ["Content-Type: application/json"]
-	var error = http.request(api_url + "/account/register", headers, HTTPClient.METHOD_POST, body)
-	
+	var error = _http.request(api_url + "/account/register", headers, HTTPClient.METHOD_POST, body)
+
 	if error != OK:
 		registration_failed.emit("Connection error")
-		http.queue_free()
 
-func _on_register_completed(result, response_code, headers, body, http):
+func _on_register_completed(result, response_code, headers, body):
 	var response_text = body.get_string_from_utf8()
 	print("Register Response Code: ", response_code)
 	print("Register Response Body: ", response_text)
-	
+
 	var json = JSON.new()
 	var error = json.parse(response_text)
-	
+
 	if error != OK:
 		print("JSON Parse Error: ", error)
 		registration_failed.emit("Failed to parse server response")
-		http.queue_free()
 		return
-	
+
 	var response = json.get_data()
-	
+
 	if response_code == 201:
 		registration_success.emit(response.get("account_id"))
 	else:
 		registration_failed.emit(response.get("error", "Unknown error"))
-	
-	http.queue_free()
 
 func login(username, password):
-	var http = HTTPRequest.new()
-	add_child(http)
-	http.request_completed.connect(_on_login_completed.bind(http))
-	
+	_reconnect_http(_on_login_completed)
+
 	var body = JSON.stringify({"username": username, "password": password})
 	var headers = ["Content-Type: application/json"]
-	var error = http.request(api_url + "/account/login", headers, HTTPClient.METHOD_POST, body)
-	
+	var error = _http.request(api_url + "/account/login", headers, HTTPClient.METHOD_POST, body)
+
 	if error != OK:
 		login_failed.emit("Connection error")
-		http.queue_free()
 
 func dev_login():
 	is_dev_mode = true
@@ -74,30 +71,27 @@ func dev_login():
 	account_username = "DevUser"
 	login_success.emit(account_id, account_username)
 
-func _on_login_completed(result, response_code, headers, body, http):
+func _on_login_completed(result, response_code, headers, body):
 	var response_text = body.get_string_from_utf8()
 	print("Login Response Code: ", response_code)
 	print("Login Response Body: ", response_text)
-	
+
 	var json = JSON.new()
 	var error = json.parse(response_text)
-	
+
 	if error != OK:
 		print("JSON Parse Error: ", error)
 		login_failed.emit("Failed to parse server response")
-		http.queue_free()
 		return
-	
+
 	var response = json.get_data()
-	
+
 	if response_code == 200:
 		account_id = response.get("account_id")
 		account_username = response.get("username")
 		login_success.emit(account_id, account_username)
 	else:
 		login_failed.emit(response.get("error", "Unknown error"))
-	
-	http.queue_free()
 
 func get_characters():
 	if is_dev_mode:
@@ -139,58 +133,55 @@ func get_characters():
 	if account_id == -1:
 		return
 		
-	var http = HTTPRequest.new()
-	add_child(http)
-	http.request_completed.connect(_on_get_characters_completed.bind(http))
-	
+	_reconnect_http(_on_get_characters_completed)
+
 	var body = JSON.stringify({"account_id": account_id})
 	var headers = ["Content-Type: application/json"]
-	var error = http.request(api_url + "/account/characters", headers, HTTPClient.METHOD_POST, body)
-	
-	if error != OK:
-		http.queue_free()
+	var error = _http.request(api_url + "/account/characters", headers, HTTPClient.METHOD_POST, body)
 
-func _on_get_characters_completed(result, response_code, headers, body, http):
+	if error != OK:
+		pass
+
+func _on_get_characters_completed(result, response_code, headers, body):
 	if response_code == 200:
 		var response = JSON.parse_string(body.get_string_from_utf8())
-		
+
 		if response != null:
 			characters_received.emit(response.get("characters", []))
-	
-	http.queue_free()
 
 func create_character(char_name, class_id):
 	if account_id == -1:
 		return
 		
-	var http = HTTPRequest.new()
-	add_child(http)
-	http.request_completed.connect(_on_create_character_completed.bind(http))
-	
+	_reconnect_http(_on_create_character_completed)
+
 	var body = JSON.stringify({
 		"account_id": account_id,
 		"name": char_name,
 		"class_id": class_id
 	})
 	var headers = ["Content-Type: application/json"]
-	var error = http.request(api_url + "/character/create", headers, HTTPClient.METHOD_POST, body)
-	
+	var error = _http.request(api_url + "/character/create", headers, HTTPClient.METHOD_POST, body)
+
 	if error != OK:
 		character_creation_failed.emit("Connection error")
-		http.queue_free()
 
-func _on_create_character_completed(result, response_code, headers, body, http):
+func _on_create_character_completed(result, response_code, headers, body):
 	var response_text = body.get_string_from_utf8()
 	var response = JSON.parse_string(response_text)
-	
+
 	if response == null:
 		character_creation_failed.emit("Failed to parse server response")
-		http.queue_free()
 		return
-	
+
 	if response_code == 201:
 		character_created.emit(response.get("name"))
 	else:
 		character_creation_failed.emit(response.get("error", "Unknown error"))
-	
-	http.queue_free()
+
+
+func _reconnect_http(callback: Callable) -> void:
+	# Disconnect any previous callback before connecting the new one
+	for connection in _http.request_completed.get_connections():
+		_http.request_completed.disconnect(connection.callable)
+	_http.request_completed.connect(callback)


### PR DESCRIPTION
## Summary
- Replaced 4 separate `HTTPRequest.new()` + `queue_free()` patterns with a single persistent `_http` node created in `_ready()`
- Added `_reconnect_http()` helper to swap signal callbacks between operations
- Removes `http` parameter from all callback signatures (no longer binding the node)

## Test plan
- [ ] Login with valid credentials and verify success
- [ ] Register a new account and verify success
- [ ] View character list after login
- [ ] Create a new character and verify it appears in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)