### PR TITLE
Batch stats window UI updates with dirty flag

### DIFF
--- a/scripts/UI/stats_window.gd
+++ b/scripts/UI/stats_window.gd
@@ -28,6 +28,7 @@ var player: MultiplayerPlayerV2
 
 var is_dragging = false
 var drag_offset = Vector2()
+var _ui_dirty: bool = false
 
 func _ready() -> void:
 	# Add to ui_window group for drop detection
@@ -37,12 +38,12 @@ func _ready() -> void:
 		player = owner as MultiplayerPlayerV2
 		
 	if multiplayer.get_unique_id() == player.player_id:
-		player.stats_component.stats_changed.connect(update_stats_window)
-		player.level_component.leveled_up.connect(update_stats_window.unbind(1))
-		player.level_component.experience_changed.connect(update_stats_window.unbind(2))
-		player.health_component.health_changed.connect(update_stats_window.unbind(2))
-		player.class_component.class_changed.connect(update_stats_window.unbind(1))
-		
+		player.stats_component.stats_changed.connect(_mark_ui_dirty)
+		player.level_component.leveled_up.connect(_mark_ui_dirty.unbind(1))
+		player.level_component.experience_changed.connect(_mark_ui_dirty.unbind(2))
+		player.health_component.health_changed.connect(_mark_ui_dirty.unbind(2))
+		player.class_component.class_changed.connect(_mark_ui_dirty.unbind(1))
+
 		update_stats_window()
 
 func _process(_delta: float) -> void:
@@ -75,6 +76,20 @@ func _gui_input(event: InputEvent) -> void:
 		else:
 			is_dragging = false
 			
+
+func _mark_ui_dirty() -> void:
+	if _ui_dirty:
+		return
+	_ui_dirty = true
+	call_deferred("_flush_ui_update")
+
+
+func _flush_ui_update() -> void:
+	if not _ui_dirty:
+		return
+	_ui_dirty = false
+	update_stats_window()
+
 
 func update_stats_window():
 	name_string_label.text = player.username


### PR DESCRIPTION
## Summary
- Stats window was rebuilding all 18 labels on every `stats_changed`, `health_changed`, `leveled_up`, `experience_changed`, and `class_changed` signal
- Now uses a dirty flag + `call_deferred` pattern to coalesce multiple signal-driven updates into a single deferred rebuild
- Same pattern as the stats component batching from PR #55

## Test plan
- [ ] Open stats window and verify all stats display correctly
- [ ] Equip/unequip items and verify stats update
- [ ] Level up and verify level, experience, and stats all update
- [ ] Take damage and verify health updates in stats window

🤖 Generated with [Claude Code](https://claude.com/claude-code)