### PR TITLE
fix: Jump sound and initial audio volume

### DIFF
--- a/scripts/Managers/user_config.gd
+++ b/scripts/Managers/user_config.gd
@@ -232,10 +232,10 @@ func _load_sound_settings_from_config(config: ConfigFile):
 		master_volume_db = config.get_value(SOUND_CONFIG_SECTION, "master_volume_db", master_volume_db)
 		music_volume_db = config.get_value(SOUND_CONFIG_SECTION, "music_volume_db", music_volume_db)
 		sfx_volume_db = config.get_value(SOUND_CONFIG_SECTION, "sfx_volume_db", sfx_volume_db)
-		
-		# Apply loaded settings to AudioServer
-		_apply_sound_settings()
 		print("Sound settings loaded.")
+
+	# Always apply — ensures defaults take effect even when section is missing
+	_apply_sound_settings()
 
 
 func _save_sound_settings_to_config(config: ConfigFile, file_existed_before_save: bool):

--- a/scripts/Player/StateMachine/jump.gd
+++ b/scripts/Player/StateMachine/jump.gd
@@ -14,6 +14,8 @@ func enter() -> void:
 		player = parent
 	player.do_jump = false
 
+	AudioManager.play_sfx_rpc.rpc("res://assets/sounds/jump.wav", parent.global_position)
+
 	# A regular jump should immediately stop any active coyote timer
 	# to prevent weird interactions.
 	player.coyote_timer.stop()


### PR DESCRIPTION
Closes #69
Closes #67

## Summary
- **Jump sound**: `jump.gd` now calls `AudioManager.play_sfx_rpc.rpc()` in `enter()`, broadcasting `jump.wav` positionally to all clients when a player jumps. The file was already in `assets/sounds/` but never wired up.
- **Initial volume**: `_load_sound_settings_from_config` was only calling `_apply_sound_settings()` when the `SoundSettings` config section existed. If the section was missing (e.g. older config files or fresh install edge case), AudioServer volumes were never set and defaults never applied. Now `_apply_sound_settings()` always runs at the end regardless.

## Test plan
- [ ] Jump in-game — should hear `jump.wav` on every jump
- [ ] Delete `user://user_config.cfg`, launch game — music/SFX volumes should be at the configured defaults (-8 dB), not at Godot project defaults
- [ ] Adjust volume in settings, restart game — saved volumes should persist correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)