### PR TITLE
fix: Camera2D process_callback IDLE→PHYSICS (jitter test 1/4)

### DIFF
--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -1188,7 +1188,7 @@ shape = SubResource("CircleShape2D_h0wtf")
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(0, -16)
 zoom = Vector2(4, 4)
-process_callback = 0
+process_callback = 1
 limit_enabled = false
 limit_bottom = 120
 position_smoothing_enabled = true


### PR DESCRIPTION
Part of #70 — test independently before merging others.

## What changed
`process_callback = 0` (IDLE) → `process_callback = 1` (PHYSICS) on the player's Camera2D in `scenes/Player/player.tscn`.

## Why
The camera was updating in `_process()` (render framerate) while all player movement runs in `_physics_process()` (60 Hz physics tick). Every rendered frame the camera was chasing a position that was already one physics step old. Switching to PHYSICS mode keeps both in lockstep.

## Test
- Move and jump around locally — watch for reduction in camera/player wobble
- Compare with `fix/jitter-camera-smoothing` (PR 2) on top of this if this alone isn't enough

🤖 Generated with [Claude Code](https://claude.com/claude-code)