### PR TITLE
fix: disable Camera2D position smoothing (jitter test 2/4)

### DIFF
--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -1191,7 +1191,7 @@ zoom = Vector2(4, 4)
 process_callback = 0
 limit_enabled = false
 limit_bottom = 120
-position_smoothing_enabled = true
+position_smoothing_enabled = false
 
 [node name="RespawnTimer" type="Timer" parent="."]
 wait_time = 2.0


### PR DESCRIPTION
Part of #70 — test independently before merging others.

## What changed
`position_smoothing_enabled = true` → `false` on the player's Camera2D in `scenes/Player/player.tscn`.

## Why
The default smoothing speed (4.0) introduces intentional camera lag. On top of the process-mode mismatch (PR #89), this compounds the visual delay. Disabling it removes the smoothing-induced lag and locks the camera directly to the player's physics position, making any remaining jitter attributable purely to physics stepping rather than smoothing fighting it.

## Test
- Move and jump — camera should feel more immediate/locked
- May feel less polished than with smoothing; consider combining with PR #89 (process_callback fix) which is the more likely root cause

🤖 Generated with [Claude Code](https://claude.com/claude-code)