### PR TITLE
fix: PlayerSynchronizer replication_interval 50ms→0 (jitter test 3/4)

### DIFF
--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -487,7 +487,7 @@ inventory_window = NodePath("CanvasLayer/MoveableWindows/InventoryWindow")
 quest_window = NodePath("CanvasLayer/MoveableWindows/QuestWindow")
 
 [node name="PlayerSynchronizer" type="MultiplayerSynchronizer" parent="."]
-replication_interval = 0.05
+replication_interval = 0.0
 replication_config = SubResource("SceneReplicationConfig_2d20i")
 visibility_update_mode = 1
 


### PR DESCRIPTION
Part of #70 — test independently before merging others.

## What changed
`replication_interval = 0.05` → `replication_interval = 0.0` on `PlayerSynchronizer` in `scenes/Player/player.tscn`.

## Why
At 50ms (20 Hz) the server was broadcasting player positions 3 physics frames apart. Clients had to interpolate or snap across those gaps, showing as stepped/jittery movement on remote players. Setting to `0.0` syncs position on every physics tick (60 Hz).

## Trade-off
Higher network traffic — instead of 20 position packets/sec per player you get up to 60. With a small player count this is negligible; worth monitoring at larger scale.

## Test
- Best observed as a second client watching another player move — jitter on *remote* players should reduce significantly
- Local player jitter is addressed by PRs #89 and #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)