### PR TITLE
fix: enable physics interpolation (jitter test 4/4)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -183,6 +183,10 @@ OpenQuestWindow={
 2d_physics/layer_3="Platforms"
 2d_physics/layer_4="Enemy"
 
+[physics]
+
+common/physics_interpolation=true
+
 [rendering]
 
 textures/canvas_textures/default_texture_filter=0


### PR DESCRIPTION
Part of #70 — test independently before merging others.

## What changed
Added `common/physics_interpolation=true` under `[physics]` in `project.godot`.

## Why
Godot renders at the monitor refresh rate but physics ticks at a fixed 60 Hz. Without interpolation, every physics body (players, platforms) visually snaps to its new physics position each tick — visible as stutter whenever the render rate doesn't divide evenly into the physics rate (e.g. 144 Hz monitor, 165 Hz, etc.). Enabling this makes Godot sub-step all `CharacterBody2D` and `RigidBody2D` positions between ticks so motion looks smooth at any framerate.

## Caution
This is a broad project-wide setting. If any nodes do not opt into interpolation correctly (e.g. nodes manually moved in `_process`), they may appear to lag by one physics frame. Test all moving objects (players, enemies, platforms, projectiles).

## Test
- Play on a high-refresh-rate monitor — movement should feel smoother
- Check that enemies and projectiles don't appear delayed
- Compare with and without on a 60 Hz display (less noticeable difference there)

🤖 Generated with [Claude Code](https://claude.com/claude-code)