### PR TITLE
Fix Rogue/Mage/Archer abilities: Dark Sight, Teleport, Disorder, Shadow Partner, Archer basic attack

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -96,6 +96,12 @@ Slide={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
 ]
 }
+"Move Up"={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":119,"location":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 Attack={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194326,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)

--- a/resources/Abilities/Rogue/A_Disorder.tres
+++ b/resources/Abilities/Rogue/A_Disorder.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://disorder001x"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=21 format=3 uid="uid://disorder001x"]
 
 [ext_resource type="Texture2D" uid="uid://r5s1f68lrr7w" path="res://assets/sprites/Abilities/HP_Boost.png" id="1_diso1"]
 [ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="1_diso2"]
@@ -8,6 +8,8 @@
 [ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="6_diso1"]
 [ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="7_diso1"]
 [ext_resource type="Resource" uid="uid://dxf1ejii6pw" path="res://resources/Abilities/Rogue/A_Double_Stab.tres" id="9_diso1"]
+[ext_resource type="Script" path="res://scripts/Abilities/AL_Disorder.gd" id="10_diso1"]
+[ext_resource type="Resource" uid="uid://bdisorder0001" path="res://resources/Buffs/B_Disorder.tres" id="11_diso1"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_diso1"]
 size = Vector2(30, 20)
@@ -19,6 +21,7 @@ hit_box_shape_data = SubResource("RectangleShape2D_diso1")
 hit_box_position_data = Vector2(15, -10)
 animation_name = "attack_1"
 sfx_path = "res://assets/sounds/tap.wav"
+logic_script = ExtResource("10_diso1")
 
 [sub_resource type="Resource" id="Resource_diso2"]
 script = ExtResource("5_diso1")
@@ -50,6 +53,12 @@ script = ExtResource("5_diso1")
 base_value = 1.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
+[sub_resource type="Resource" id="Resource_diso9"]
+script = ExtResource("5_diso1")
+base_value = 10.0
+per_level = 1.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
 [sub_resource type="Resource" id="Resource_diso8"]
 script = ExtResource("6_diso1")
 mana_cost_formula = SubResource("Resource_diso5")
@@ -72,5 +81,7 @@ prerequisite_abilities = Dictionary[ExtResource("2_diso2"), int]({
 ExtResource("9_diso1"): 5
 })
 active_behavior = SubResource("Resource_diso1")
+applies_target_debuff = ExtResource("11_diso1")
+debuff_duration_formula = SubResource("Resource_diso9")
 scaling_data = SubResource("Resource_diso8")
 metadata/_custom_type_script = "uid://b8y62rc8nb40j"

--- a/resources/Abilities/Rogue/A_Shadow_Partner.tres
+++ b/resources/Abilities/Rogue/A_Shadow_Partner.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=13 format=3 uid="uid://shdwpart001x"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=16 format=3 uid="uid://shdwpart001x"]
 
 [ext_resource type="Texture2D" uid="uid://r5s1f68lrr7w" path="res://assets/sprites/Abilities/HP_Boost.png" id="1_shpn1"]
 [ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_shpn2"]
@@ -8,10 +8,13 @@
 [ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_shpn1"]
 [ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="8_t6c7f"]
 [ext_resource type="Resource" uid="uid://drksghtabl01" path="res://resources/Abilities/Rogue/A_Dark_Sight.tres" id="9_shpn1"]
+[ext_resource type="Script" path="res://scripts/Abilities/AL_ShadowPartner.gd" id="10_shpn1"]
+[ext_resource type="Resource" uid="uid://bshdwprt0001" path="res://resources/Buffs/B_Shadow_Partner.tres" id="11_shpn1"]
 
 [sub_resource type="Resource" id="Resource_shpn1"]
 resource_local_to_scene = true
 script = ExtResource("1_shpn2")
+logic_script = ExtResource("10_shpn1")
 
 [sub_resource type="Resource" id="Resource_shpn2"]
 script = ExtResource("7_shpn1")
@@ -21,6 +24,12 @@ metadata/_custom_type_script = "uid://dnsex6fyou07d"
 [sub_resource type="Resource" id="Resource_shpn3"]
 script = ExtResource("7_shpn1")
 base_value = 30.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_shpn5"]
+script = ExtResource("7_shpn1")
+base_value = 30.0
+per_level = 5.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_shpn4"]
@@ -33,7 +42,7 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 script = ExtResource("2_shpn2")
 ability_id = "19104979711132011-10180-19141116-8591-12491086711491468"
 ability_name = "Shadow Partner"
-description = "Summons a shadow copy that mimics your attacks for 30 seconds. (Coming Soon)"
+description = "Summons a shadow copy that mimics your attacks at $[damage_percent] damage for $[buff_duration]."
 ability_icon = ExtResource("1_shpn1")
 max_level = 5
 required_class = Array[int]([3])
@@ -41,5 +50,7 @@ prerequisite_abilities = Dictionary[ExtResource("2_shpn2"), int]({
 ExtResource("9_shpn1"): 3
 })
 active_behavior = SubResource("Resource_shpn1")
+applies_buff = ExtResource("11_shpn1")
+buff_duration_formula = SubResource("Resource_shpn5")
 scaling_data = SubResource("Resource_shpn4")
 metadata/_custom_type_script = "uid://b8y62rc8nb40j"

--- a/resources/Buffs/B_Disorder.tres
+++ b/resources/Buffs/B_Disorder.tres
@@ -1,0 +1,36 @@
+[gd_resource type="Resource" script_class="BuffData" load_steps=5 format=3 uid="uid://bdisorder0001"]
+
+[ext_resource type="Texture2D" uid="uid://r5s1f68lrr7w" path="res://assets/sprites/Abilities/HP_Boost.png" id="1_dis01"]
+[ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_dis02"]
+[ext_resource type="Script" uid="uid://cptesvvlfbytw" path="res://scripts/Resources/StatSystem/StatData.gd" id="2_dis01"]
+
+[sub_resource type="Resource" id="Resource_dis_def"]
+script = ExtResource("2_dis01")
+stat_type = 8
+base_value = 0
+flat_bonus_value = -15
+percent_bonus_value = -20.0
+metadata/_custom_type_script = "uid://cptesvvlfbytw"
+
+[sub_resource type="Resource" id="Resource_dis_atk"]
+script = ExtResource("2_dis01")
+stat_type = 12
+base_value = 0
+flat_bonus_value = -10
+percent_bonus_value = -15.0
+metadata/_custom_type_script = "uid://cptesvvlfbytw"
+
+[resource]
+resource_local_to_scene = true
+script = ExtResource("1_dis02")
+buff_id = "8105115111411410011-10180-20141116-8591-12491086711491469"
+buff_name = "Disorder"
+description = "Weakens the target, reducing their defense and attack power."
+buff_icon = ExtResource("1_dis01")
+duration = 10.0
+is_debuff = true
+stat_modifiers = {
+8: SubResource("Resource_dis_def"),
+12: SubResource("Resource_dis_atk")
+}
+metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/resources/Buffs/B_Shadow_Partner.tres
+++ b/resources/Buffs/B_Shadow_Partner.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="BuffData" load_steps=4 format=3 uid="uid://bshdwprt0001"]
+
+[ext_resource type="Texture2D" uid="uid://r5s1f68lrr7w" path="res://assets/sprites/Abilities/HP_Boost.png" id="1_shp01"]
+[ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_shp02"]
+[ext_resource type="Script" path="res://scripts/Buffs/BL_ShadowPartner.gd" id="2_shp01"]
+
+[resource]
+resource_local_to_scene = true
+script = ExtResource("1_shp02")
+buff_id = "19104979711132011-10180-21141116-8591-12491086711491470"
+buff_name = "Shadow Partner"
+description = "A shadow copy follows you and mimics your attacks."
+buff_icon = ExtResource("1_shp01")
+duration = 30.0
+logic_script = ExtResource("2_shp01")
+metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -77,9 +77,12 @@ properties/0/replication_mode = 2
 properties/1/path = NodePath("InputSynchronizer:input_down")
 properties/1/spawn = true
 properties/1/replication_mode = 2
-properties/2/path = NodePath("InputSynchronizer:sync_facing_direction")
+properties/2/path = NodePath("InputSynchronizer:input_up")
 properties/2/spawn = true
 properties/2/replication_mode = 2
+properties/3/path = NodePath("InputSynchronizer:sync_facing_direction")
+properties/3/spawn = true
+properties/3/replication_mode = 2
 
 [sub_resource type="SceneReplicationConfig" id="SceneReplicationConfig_x5q00"]
 properties/0/path = NodePath("Health:max_health")

--- a/scripts/Abilities/AL_Disorder.gd
+++ b/scripts/Abilities/AL_Disorder.gd
@@ -1,0 +1,9 @@
+extends Node
+
+## Ability logic for Rogue's Disorder.
+## The hitbox deals damage via the standard combat system.
+## The debuff is applied automatically by combat.gd via applies_target_debuff.
+## This script exists for any additional on-cast effects.
+
+func execute(owner_node: Node, _ability: AbilityData, level_stats: AbilityLevelData):
+	print("%s used Disorder (Level %d)" % [owner_node.name, level_stats.level])

--- a/scripts/Abilities/AL_ShadowPartner.gd
+++ b/scripts/Abilities/AL_ShadowPartner.gd
@@ -1,0 +1,23 @@
+extends Node
+
+## Ability logic for Rogue's Shadow Partner.
+## Applies a timed buff that spawns a shadow copy behind the player.
+## The shadow mimics the player's attacks at reduced damage.
+
+func execute(owner_node: Node, ability: AbilityData, level_stats: AbilityLevelData):
+	var buff_component: BuffComponent = owner_node.get_node_or_null("Components/Buff")
+	if not buff_component:
+		return
+
+	var duration: float = ability.buff_duration_formula.calculate(level_stats.level)
+	var damage_percent: float = 30.0 + level_stats.level * 5.0
+
+	buff_component.apply_buff("Shadow Partner", owner_node, duration)
+
+	var active_buff = buff_component._active_buffs.get("Shadow Partner")
+	if active_buff and active_buff.custom_logic_instance:
+		active_buff.custom_logic_instance.source_ability_level = level_stats.level
+		active_buff.custom_logic_instance.damage_percent = damage_percent
+
+	print("%s summoned Shadow Partner (Level %d) — %.0f%% damage for %.0fs" % [
+		owner_node.name, level_stats.level, damage_percent, duration])

--- a/scripts/Abilities/AL_Teleport.gd
+++ b/scripts/Abilities/AL_Teleport.gd
@@ -1,17 +1,125 @@
 extends Node
 
 ## Ability logic for Mage's Teleport.
-## Blinks the player forward in their facing direction. Server-authoritative —
-## the PlayerSynchronizer propagates the new position to all clients.
+## Blinks the player in the direction they're holding. Server-authoritative.
+## Supports horizontal (facing direction), up (W), and down (S) teleport.
+## Validates destination against collision to prevent teleporting into walls,
+## and snaps to nearby ledges when teleporting vertically.
+
+const TELEPORT_RANGE: float = 100.0
+const EDGE_SNAP_DISTANCE: float = 24.0
+const GROUND_CHECK_DISTANCE: float = 200.0
 
 func execute(owner_node: Node, _ability: AbilityData, level_stats: AbilityLevelData):
+	var space_state := owner_node.get_world_2d().direct_space_state
+	var collision_mask: int = owner_node.collision_mask
+	var origin: Vector2 = owner_node.global_position
 
+	var input_up: bool = owner_node.get("input_up") == true
+	var input_down: bool = owner_node.get("input_down") == true
 
-	# Range: 200px base + 10px per level
-	var teleport_range: float = 100.0
-	var direction: int = 1 if owner_node.facing_direction >= 0 else -1
+	var destination: Vector2
+	if input_up:
+		destination = _try_vertical_teleport(origin, -1, space_state, collision_mask, owner_node)
+	elif input_down:
+		destination = _try_vertical_teleport(origin, 1, space_state, collision_mask, owner_node)
+	else:
+		destination = _try_horizontal_teleport(origin, owner_node.facing_direction, space_state, collision_mask, owner_node)
 
-	owner_node.global_position += Vector2(direction * teleport_range, 0.0)
+	if destination == origin:
+		print("%s teleport blocked — no valid destination (Level %d)" % [owner_node.name, level_stats.level])
+		return
+
+	owner_node.global_position = destination
 	owner_node.velocity = Vector2.ZERO
+	print("%s teleported to %s (Level %d)" % [owner_node.name, destination, level_stats.level])
 
-	print("%s teleported %.0fpx (Level %d)" % [owner_node.name, teleport_range, level_stats.level])
+
+func _try_horizontal_teleport(origin: Vector2, dir: int, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> Vector2:
+	var target := origin + Vector2(dir * TELEPORT_RANGE, 0.0)
+
+	if _is_position_blocked(target, space, mask, owner):
+		var clear := _find_furthest_clear_horizontal(origin, dir, space, mask, owner)
+		if clear == origin:
+			return origin
+		target = clear
+
+	# Snap down to ground if there is ground below
+	var grounded := _find_ground_below(target, space, mask, owner)
+	if grounded != Vector2.INF:
+		target.y = grounded.y
+	else:
+		return origin
+
+	# Try snapping up to a nearby ledge edge
+	target = _try_edge_snap(target, space, mask, owner)
+
+	if _is_position_blocked(target, space, mask, owner):
+		return origin
+
+	return target
+
+
+func _try_vertical_teleport(origin: Vector2, y_dir: int, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> Vector2:
+	var target := origin + Vector2(0.0, y_dir * TELEPORT_RANGE)
+
+	# For downward teleport, find ground below the target
+	if y_dir > 0:
+		var grounded := _find_ground_below(target, space, mask, owner)
+		if grounded == Vector2.INF:
+			return origin
+		target.y = grounded.y
+	else:
+		# For upward teleport, find ground below target to land on
+		var grounded := _find_ground_below(target, space, mask, owner)
+		if grounded == Vector2.INF:
+			return origin
+		target.y = grounded.y
+
+	if _is_position_blocked(target, space, mask, owner):
+		return origin
+
+	return target
+
+
+func _is_position_blocked(pos: Vector2, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> bool:
+	var shape := owner.get_node("StandingCollisionShape").shape as Shape2D
+	var offset: Vector2 = owner.get_node("StandingCollisionShape").position
+	var params := PhysicsShapeQueryParameters2D.new()
+	params.shape = shape
+	params.transform = Transform2D(0, pos + offset)
+	params.collision_mask = mask
+	params.exclude = [owner.get_rid()]
+	var results := space.intersect_shape(params, 1)
+	return not results.is_empty()
+
+
+func _find_ground_below(pos: Vector2, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> Vector2:
+	var ray_params := PhysicsRayQueryParameters2D.create(pos, pos + Vector2(0, GROUND_CHECK_DISTANCE), mask, [owner.get_rid()])
+	var result := space.intersect_ray(ray_params)
+	if result.is_empty():
+		return Vector2.INF
+	return result.position
+
+
+func _find_furthest_clear_horizontal(origin: Vector2, dir: int, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> Vector2:
+	var step := 16.0
+	var best := origin
+	var dist := step
+	while dist <= TELEPORT_RANGE:
+		var test_pos := origin + Vector2(dir * dist, 0.0)
+		if _is_position_blocked(test_pos, space, mask, owner):
+			break
+		best = test_pos
+		dist += step
+	return best
+
+
+func _try_edge_snap(pos: Vector2, space: PhysicsDirectSpaceState2D, mask: int, owner: Node) -> Vector2:
+	if _is_position_blocked(pos, space, mask, owner):
+		# Try snapping upward in small increments
+		for i in range(1, int(EDGE_SNAP_DISTANCE / 4.0) + 1):
+			var snapped := pos + Vector2(0, -4.0 * i)
+			if not _is_position_blocked(snapped, space, mask, owner):
+				return snapped
+	return pos

--- a/scripts/Buffs/BL_DarkSight.gd
+++ b/scripts/Buffs/BL_DarkSight.gd
@@ -1,18 +1,28 @@
 extends Node
 
 ## Buff logic for Rogue's Dark Sight.
-## Sets an is_invisible meta flag on the player so enemy AI can check it.
+## Sets an is_invisible meta flag on the player so enemy AI skips them,
+## and makes the sprite semi-transparent as a visual indicator.
 
 var source_ability_level: int = 1
 
 func on_apply(owner_node: Node, _active_buff) -> void:
 	owner_node.set_meta("is_invisible", true)
+	_set_sprite_alpha(owner_node, 0.3)
 	print("Dark Sight (Level %d) activated — %s is now invisible!" % [
 		source_ability_level, owner_node.name])
 
 func on_remove(owner_node: Node, _active_buff) -> void:
 	owner_node.set_meta("is_invisible", false)
+	_set_sprite_alpha(owner_node, 1.0)
 	print("Dark Sight expired on %s" % owner_node.name)
 
 func on_tick(_owner_node: Node, _active_buff, _delta: float) -> void:
 	pass
+
+func _set_sprite_alpha(owner_node: Node, alpha: float) -> void:
+	var sprite := owner_node.get_node_or_null("AnimatedSprite2D") as AnimatedSprite2D
+	if sprite:
+		sprite.modulate.a = alpha
+	if owner_node.has_method("sync_dark_sight_visual"):
+		owner_node.sync_dark_sight_visual.rpc(alpha)

--- a/scripts/Buffs/BL_ShadowPartner.gd
+++ b/scripts/Buffs/BL_ShadowPartner.gd
@@ -1,0 +1,90 @@
+extends Node
+
+## Buff logic for Rogue's Shadow Partner.
+## Spawns a dark copy of the player that follows behind them and mirrors attacks.
+
+var source_ability_level: int = 1
+var damage_percent: float = 50.0
+var _shadow: Node2D = null
+var _owner_ref: Node = null
+var _combat_component: CombatComponent = null
+var _shadow_offset := Vector2(-20, 0)
+
+func on_apply(owner_node: Node, _active_buff) -> void:
+	_owner_ref = owner_node
+	_combat_component = owner_node.get_node_or_null("Components/Combat")
+
+	_shadow = Node2D.new()
+	_shadow.name = "ShadowPartner"
+
+	var owner_sprite: AnimatedSprite2D = owner_node.get_node_or_null("AnimatedSprite2D")
+	if owner_sprite and owner_sprite.sprite_frames:
+		var shadow_sprite := AnimatedSprite2D.new()
+		shadow_sprite.name = "ShadowSprite"
+		shadow_sprite.sprite_frames = owner_sprite.sprite_frames
+		shadow_sprite.modulate = Color(0.15, 0.05, 0.25, 0.6)
+		shadow_sprite.offset = owner_sprite.offset
+		shadow_sprite.scale = owner_sprite.scale
+		shadow_sprite.z_index = -1
+		_shadow.add_child(shadow_sprite)
+
+	owner_node.add_child(_shadow)
+	_shadow.position = _shadow_offset
+
+	if _combat_component:
+		var hitbox_area: Area2D = _combat_component.attack_hitbox.get_parent()
+		if not hitbox_area.area_entered.is_connected(_on_owner_hit):
+			hitbox_area.area_entered.connect(_on_owner_hit)
+
+	if owner_node.has_method("sync_shadow_partner"):
+		owner_node.sync_shadow_partner.rpc(true)
+
+	print("Shadow Partner spawned for %s (Level %d, %.0f%% damage)" % [
+		owner_node.name, source_ability_level, damage_percent])
+
+
+func on_remove(owner_node: Node, _active_buff) -> void:
+	if _combat_component:
+		var hitbox_area: Area2D = _combat_component.attack_hitbox.get_parent()
+		if hitbox_area.area_entered.is_connected(_on_owner_hit):
+			hitbox_area.area_entered.disconnect(_on_owner_hit)
+
+	if is_instance_valid(_shadow):
+		_shadow.queue_free()
+		_shadow = null
+
+	if owner_node.has_method("sync_shadow_partner"):
+		owner_node.sync_shadow_partner.rpc(false)
+
+	print("Shadow Partner expired on %s" % owner_node.name)
+
+
+func on_tick(owner_node: Node, _active_buff, _delta: float) -> void:
+	if not is_instance_valid(_shadow):
+		return
+
+	var dir: int = owner_node.facing_direction
+	_shadow.position = Vector2(-20 * dir, 0)
+
+	var shadow_sprite = _shadow.get_node_or_null("ShadowSprite")
+	var owner_sprite: AnimatedSprite2D = owner_node.get_node_or_null("AnimatedSprite2D")
+	if shadow_sprite and owner_sprite:
+		shadow_sprite.flip_h = owner_sprite.flip_h
+		if owner_sprite.is_playing():
+			shadow_sprite.play(owner_sprite.animation)
+
+
+func _on_owner_hit(area: Area2D) -> void:
+	if not is_instance_valid(_owner_ref) or not _owner_ref.multiplayer.is_server():
+		return
+	if not area.owner is EnemyBase:
+		return
+	var enemy: EnemyBase = area.owner
+	var health_comp = enemy.get("health_component")
+	if not health_comp or health_comp.is_dead:
+		return
+
+	var shadow_damage := roundi(_combat_component.calculate_attack_damage() * (damage_percent / 100.0))
+	shadow_damage = maxi(1, shadow_damage)
+	health_comp.take_damage(shadow_damage, _combat_component, true, false, false)
+	print("Shadow Partner hit %s for %d damage" % [enemy.name, shadow_damage])

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -327,6 +327,13 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 			}
 			_ability_component.try_trigger_procs(event_type, target_enemy, context)
 
+	# Apply target debuff if the ability defines one
+	if ability and ability.applies_target_debuff and target_enemy is EnemyBase:
+		var debuff_duration := 10.0
+		if ability.debuff_duration_formula:
+			debuff_duration = ability.debuff_duration_formula.calculate(level_stats.level)
+		_apply_enemy_debuff(target_enemy, ability.applies_target_debuff, debuff_duration)
+
 	# After the loop, display all collected hits as a single combo
 	if not damage_values.is_empty():
 		var spawn_pos = health_comp.damage_number_origin.global_position
@@ -392,3 +399,45 @@ func _calculate_base_damage() -> int:
 	
 	# This is the core shared formula
 	return roundi(weapon_multiplier * stat_contribution * weapon_attack / 100.0)
+
+
+func _apply_enemy_debuff(enemy: EnemyBase, debuff: BuffData, duration: float) -> void:
+	if not enemy.stats_component:
+		return
+
+	var debuff_key := "debuff_%s" % debuff.buff_name
+	if enemy.has_meta(debuff_key):
+		return
+
+	var saved_values: Dictionary = {}
+	for stat_type in debuff.stat_modifiers:
+		var modifier: StatData = debuff.stat_modifiers[stat_type]
+		if enemy.stats_component.stats.has(stat_type):
+			var enemy_stat: StatData = enemy.stats_component.stats[stat_type]
+			saved_values[stat_type] = {
+				"flat": enemy_stat.flat_bonus_value,
+				"percent": enemy_stat.percent_bonus_value
+			}
+			enemy_stat.flat_bonus_value += modifier.flat_bonus_value
+			enemy_stat.percent_bonus_value += modifier.percent_bonus_value
+
+	enemy.set_meta(debuff_key, true)
+
+	if enemy.animated_sprite and is_instance_valid(enemy.animated_sprite):
+		enemy.animated_sprite.modulate = Color(0.6, 0.5, 0.8, 1.0)
+
+	get_tree().create_timer(duration).timeout.connect(
+		func():
+			if not is_instance_valid(enemy) or not is_instance_valid(enemy.stats_component):
+				return
+			for stat_type in saved_values:
+				if enemy.stats_component.stats.has(stat_type):
+					var enemy_stat: StatData = enemy.stats_component.stats[stat_type]
+					enemy_stat.flat_bonus_value = saved_values[stat_type]["flat"]
+					enemy_stat.percent_bonus_value = saved_values[stat_type]["percent"]
+			enemy.remove_meta(debuff_key)
+			if enemy.animated_sprite and is_instance_valid(enemy.animated_sprite):
+				enemy.animated_sprite.modulate = Color.WHITE
+			print("Debuff '%s' expired on %s" % [debuff.buff_name, enemy.name])
+	)
+	print("Applied debuff '%s' to %s for %.1fs" % [debuff.buff_name, enemy.name, duration])

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -86,6 +86,47 @@ func perform_attack(_attack_name: String, _duration: float) -> void:
 	get_tree().create_timer(0.1).timeout.connect(end_attack)
 
 
+const BASIC_ARROW_SCENE = preload("uid://d0ig4oiimrnei")
+const BASIC_ARROW_SPEED: float = 250.0
+
+func perform_ranged_attack(_attack_name: String, _duration: float) -> void:
+	if not multiplayer.is_server():
+		return
+
+	if current_attack_data != "" or current_ability_data != null:
+		return
+
+	_current_attack_mode = AttackMode.BASIC
+	current_attack_data = _attack_name
+
+	if not _ability_component:
+		return
+
+	var direction := Vector2(owner_node.facing_direction, 0).normalized()
+	var projectile := BASIC_ARROW_SCENE.instantiate()
+	projectile.initialize(owner_node, null, null, null, BASIC_ARROW_SPEED, direction)
+	projectile.set_meta("basic_attack_caster", owner_node)
+
+	var current_map = owner_node.get_parent().get_parent()
+	var container: Node = null
+	if current_map and current_map.is_in_group("map_base"):
+		container = current_map.get_node_or_null("Projectiles")
+		if not container:
+			container = Node.new()
+			container.name = "Projectiles"
+			current_map.add_child(container)
+	if not container:
+		return
+
+	container.add_child(projectile, true)
+	if is_instance_valid(owner_node.projectile_spawn_location):
+		projectile.global_position = owner_node.projectile_spawn_location.global_position
+	else:
+		projectile.global_position = owner_node.global_position
+
+	get_tree().create_timer(0.1).timeout.connect(func(): current_attack_data = "")
+
+
 func process_ability_hit(ability: AbilityData, level_stats: AbilityLevelData) -> void:
 	"""Called by the attack state when an ability attack is triggered"""
 	if not multiplayer.is_server():
@@ -240,9 +281,10 @@ func process_projectile_hit(target_enemy: Node, ability: AbilityData, level_stat
 	"""Public function for projectiles to call when they hit a target."""
 	if not multiplayer.is_server():
 		return
-	
+
 	print("CombatComponent: Processing projectile hit on %s" % target_enemy.name)
-	_execute_hit(target_enemy, ability, level_stats, "") # Projectiles are always abilities, so basic attack is empty
+	var attack_name := "basic_arrow" if ability == null else ""
+	_execute_hit(target_enemy, ability, level_stats, attack_name)
 
 
 func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: AbilityLevelData, attack_name: String) -> void:

--- a/scripts/Enemy/enemy_base.gd
+++ b/scripts/Enemy/enemy_base.gd
@@ -463,11 +463,14 @@ func damage_on_overlap(body: Node):
 		push_warning("Enemy %s is missing a StatsComponent! Cannot calculate damage." % name)
 		return
 
+	if body.has_meta("is_invisible") and body.get_meta("is_invisible"):
+		return
+
 	if body.has_node("Components/Health"):
 		var health: HealthComponent = body.get_node("Components/Health")
 		var player_stats: StatsComponent = body.get_node("Components/Stats")
 		var player_level_comp: LevelingComponent = body.get_node("Components/Leveling")
-		
+
 		if health.is_dead or health.is_invulnerable:
 			return
 

--- a/scripts/Player/StateMachine/attack.gd
+++ b/scripts/Player/StateMachine/attack.gd
@@ -58,19 +58,28 @@ func _play_animation(anim_name: String) -> void:
 				animations.play(anim_name, attack_speed_percent)
 
 func _start_basic_attack():
-	"""Executes a basic melee attack"""
-	_play_animation(_current_attack_name)
-	
-	var duration: float = _get_animation_duration(_current_attack_name)
-	print("Basic Attack: %s, Duration: %f" % [_current_attack_name, duration])
-	
+	"""Executes a basic melee attack, or a projectile for Archer"""
+	var is_archer := false
+	if player.class_component:
+		var cls: int = player.class_component.current_class
+		is_archer = cls == Constants.ClassType.ARCHER or cls == Constants.ClassType.RANGER
+
+	var anim_name: String = "attack_2" if is_archer else _current_attack_name
+	_play_animation(anim_name)
+
+	var duration: float = _get_animation_duration(anim_name)
+	print("Basic Attack: %s, Duration: %f" % [anim_name, duration])
+
 	var buffer: float = 0.02
 	attack_state_timer.start(max(duration - buffer, 0.01))
-	
+
 	# Server handles the combat component
 	if multiplayer.is_server():
 		if player.combat_component:
-			player.combat_component.perform_attack(_current_attack_name, duration)
+			if is_archer:
+				player.combat_component.perform_ranged_attack(anim_name, duration)
+			else:
+				player.combat_component.perform_attack(_current_attack_name, duration)
 
 func _start_ability_attack():
 	"""Executes an ability attack"""

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -43,6 +43,7 @@ var _current_party_id: int = -1
 var direction: int = 0 # The current input direction from the synchronizer
 var facing_direction: int = 1 # The last non-zero direction, for facing
 var input_down: bool = false # The current down input from the synchronizer
+var input_up: bool = false # The current up input from the synchronizer
 
 var do_attack: bool = false
 var do_jump: bool = false
@@ -348,16 +349,19 @@ func _update_input_from_synchronizer() -> void:
 	if is_instance_valid(health_component) and health_component.is_dead:
 		direction = 0
 		input_down = false
+		input_up = false
 		return
 
 	var input_sync: Node = get_node_or_null("%InputSynchronizer")
 	if is_instance_valid(input_sync):
 		direction = input_sync.input_direction
 		input_down = input_sync.input_down
+		input_up = input_sync.input_up
 	else:
 		# Fallback if the synchronizer is not found.
 		direction = 0
 		input_down = false
+		input_up = false
 
 
 func is_pressing_pickup() -> bool:
@@ -701,6 +705,12 @@ func set_username(uname: String) -> void:
 	username = uname
 	if is_instance_valid(player_name_label):
 		player_name_label.text = username
+
+
+@rpc("authority", "call_local", "reliable")
+func sync_dark_sight_visual(alpha: float) -> void:
+	if is_instance_valid(animated_sprite):
+		animated_sprite.modulate.a = alpha
 
 
 func _on_leveled_up_effect(_new_level: int) -> void:

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -713,6 +713,29 @@ func sync_dark_sight_visual(alpha: float) -> void:
 		animated_sprite.modulate.a = alpha
 
 
+@rpc("authority", "call_local", "reliable")
+func sync_shadow_partner(active: bool) -> void:
+	if active:
+		if not get_node_or_null("ShadowPartnerClient"):
+			var shadow := Node2D.new()
+			shadow.name = "ShadowPartnerClient"
+			var shadow_sprite := AnimatedSprite2D.new()
+			shadow_sprite.name = "ShadowSprite"
+			if is_instance_valid(animated_sprite) and animated_sprite.sprite_frames:
+				shadow_sprite.sprite_frames = animated_sprite.sprite_frames
+				shadow_sprite.offset = animated_sprite.offset
+				shadow_sprite.scale = animated_sprite.scale
+			shadow_sprite.modulate = Color(0.15, 0.05, 0.25, 0.6)
+			shadow_sprite.z_index = -1
+			shadow.add_child(shadow_sprite)
+			add_child(shadow)
+			shadow.position = Vector2(-20 * facing_direction, 0)
+	else:
+		var shadow := get_node_or_null("ShadowPartnerClient")
+		if shadow:
+			shadow.queue_free()
+
+
 func _on_leveled_up_effect(_new_level: int) -> void:
 	if _is_loading_data or _is_being_cleaned_up:
 		return

--- a/scripts/Player/multiplayer_input.gd
+++ b/scripts/Player/multiplayer_input.gd
@@ -10,6 +10,7 @@ extends MultiplayerSynchronizer
 
 var input_direction
 var input_down: bool
+var input_up: bool
 var portal_interact: bool
 var is_left_pressed := false
 var is_right_pressed := false
@@ -29,6 +30,7 @@ func _ready():
 
 	input_direction = Input.get_axis("Move Left", "Move Right")
 	input_down = Input.is_action_pressed("Move Down")
+	input_up = Input.is_action_pressed("Move Up")
 	portal_interact = Input.is_action_just_pressed("Portal Interact")
 
 func _physics_process(_delta: float) -> void:
@@ -56,8 +58,9 @@ func _physics_process(_delta: float) -> void:
 	if input_direction != 0:
 		sync_facing_direction = input_direction
 
-	# Get down input
+	# Get vertical input
 	input_down = Input.is_action_pressed("Move Down")
+	input_up = Input.is_action_pressed("Move Up")
 
 func _process(_delta: float) -> void:
 	if InputManager.is_locked():
@@ -134,6 +137,7 @@ func cleanup_before_removal():
 	# Reset input states
 	input_direction = 0
 	input_down = false
+	input_up = false
 	is_left_pressed = false
 	is_right_pressed = false
 	sync_facing_direction = 1

--- a/scripts/Resources/AbilitySystem/AbilityData.gd
+++ b/scripts/Resources/AbilitySystem/AbilityData.gd
@@ -24,6 +24,11 @@ extends Resource
 @export var applies_buff: BuffData = null
 @export var buff_duration_formula: AbilityScalingFormula = null
 
+@export_group("Target Debuff")
+## Debuff applied to each enemy hit by this ability
+@export var applies_target_debuff: BuffData = null
+@export var debuff_duration_formula: AbilityScalingFormula = null
+
 ## NEW: Use either scaling data OR manual level data
 @export_group("Scaling Configuration")
 @export var use_scaling_formulas: bool = true


### PR DESCRIPTION
## Summary

### Dark Sight (#84)
- Enemies now respect the `is_invisible` meta flag and skip invisible players in `damage_on_overlap`
- Sprite becomes semi-transparent (30% alpha) during buff, synced to all clients via RPC

### Teleport (#81)
- Collision-aware teleport using shape queries — prevents teleporting into walls
- Edge snapping (up to 24px) for landing on nearby ledges
- Directional: hold W to teleport up, S to teleport down (only if ground exists at destination)
- Added "Move Up" input action (W / Up arrow) synced via InputSynchronizer replication

### Disorder (#85)
- Added `applies_target_debuff` field to AbilityData for abilities that debuff enemies on hit
- CombatComponent applies debuffs to enemies after ability hit: DEF (-15 flat, -20%) and ATK (-10 flat, -15%)
- Debuffed enemies get a purple tint visual indicator that clears on expiry
- Duration: 10s base + 1s per level

### Shadow Partner (#86)
- Buff-based summon: spawns a dark semi-transparent copy of the player sprite behind them
- Shadow mirrors player animations and facing direction each tick
- On player attack hit, shadow deals additional damage (30% + 5% per level of base ATK)
- Duration: 30s base + 5s per level, 120s cooldown
- Visual synced to all clients via `sync_shadow_partner` RPC

### Archer basic attack (#94)
- Attack state checks player class — Archer/Ranger route to `perform_ranged_attack()`
- Spawns a basic arrow projectile using existing `projectile_base.tscn` and `Projectiles` MultiplayerSpawner
- Uses `attack_2` (bow draw) animation instead of `attack_1` (punch)
- Projectile hit processes as basic attack damage via `process_projectile_hit()`

Closes #81, closes #84, closes #85, closes #86, closes #94

## Test plan
- [ ] **Dark Sight**: Activate as Rogue — sprite transparent, enemies skip contact damage; expires → opacity restored
- [ ] **Teleport**: Use near wall — blocked; near ledge — snaps up; hold W → teleport up; hold S → teleport down; into void → blocked
- [ ] **Disorder**: Hit enemy — turns purple, takes more damage for 10s+; debuff expires → color + stats restored
- [ ] **Shadow Partner**: Activate — dark copy appears; attack enemy → shadow deals extra damage; buff expires → shadow disappears
- [ ] **Archer basic attack**: Basic attack as Archer → shoots arrow projectile with bow animation, no punch; arrow hits enemies for correct damage
- [ ] Verify all abilities sync correctly in multiplayer (other clients see visuals/projectiles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)