### PR TITLE
Add class-specific party buffs

### DIFF
--- a/resources/Abilities/Archer/A_Sharp_Eyes.tres
+++ b/resources/Abilities/Archer/A_Sharp_Eyes.tres
@@ -1,0 +1,71 @@
+[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://shrpeyes001x"]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
+[ext_resource type="Script" path="res://scripts/Abilities/AL_SharpEyes.gd" id="2_logic"]
+[ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
+[ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
+[ext_resource type="Resource" path="res://resources/Buffs/B_Sharp_Eyes.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
+[ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
+
+[sub_resource type="Resource" id="Resource_behav"]
+resource_local_to_scene = true
+script = ExtResource("1_behav")
+logic_script = ExtResource("2_logic")
+
+[sub_resource type="Resource" id="Resource_buff_dur"]
+script = ExtResource("7_formula")
+base_value = 30.0
+per_level = 30.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_mana"]
+script = ExtResource("7_formula")
+base_value = 10.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_critchance_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 3.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_critdmg_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 2.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_sbf_critchance"]
+script = ExtResource("5_sbf")
+stat_type = 10
+percent_bonus_formula = SubResource("Resource_critchance_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_sbf_critdmg"]
+script = ExtResource("5_sbf")
+stat_type = 11
+percent_bonus_formula = SubResource("Resource_critdmg_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_scaling"]
+resource_local_to_scene = true
+script = ExtResource("4_scale")
+mana_cost_formula = SubResource("Resource_mana")
+stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_critchance"), SubResource("Resource_sbf_critdmg")])
+
+[resource]
+script = ExtResource("3_abil")
+ability_id = "sharp-eyes-ability-001"
+ability_name = "Sharp Eyes"
+description = "Grants a temporary buff that increases critical hit chance by $[stat_bonus]% and critical damage for all party members for $[buff_duration]."
+ability_icon = ExtResource("1_icon")
+max_level = 30
+required_class = Array[int]([1])
+required_weapon_types = Array[int]([0])
+active_behavior = SubResource("Resource_behav")
+applies_buff = ExtResource("4_buff")
+buff_duration_formula = SubResource("Resource_buff_dur")
+scaling_data = SubResource("Resource_scaling")

--- a/resources/Abilities/Archer/A_Sharp_Eyes.tres
+++ b/resources/Abilities/Archer/A_Sharp_Eyes.tres
@@ -1,12 +1,12 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://shrpeyes001x"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=23 format=3 uid="uid://shrpeyes001x"]
 
-[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
 [ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
-[ext_resource type="Script" path="res://scripts/Abilities/AL_SharpEyes.gd" id="2_logic"]
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://tcmlhlo7jekp" path="res://scripts/Abilities/AL_SharpEyes.gd" id="2_logic"]
 [ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
 [ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
-[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Resource" path="res://resources/Buffs/B_Sharp_Eyes.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
 [ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
 
@@ -21,9 +21,30 @@ base_value = 30.0
 per_level = 30.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
+[sub_resource type="Resource" id="Resource_chef7"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_irth1"]
+resource_local_to_scene = true
+script = ExtResource("7_formula")
+base_value = 1.0
+
+[sub_resource type="Resource" id="Resource_gegqc"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
 [sub_resource type="Resource" id="Resource_mana"]
 script = ExtResource("7_formula")
 base_value = 10.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_g7nd7"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_0oxvw"]
+script = ExtResource("7_formula")
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_critchance_pct"]
@@ -32,33 +53,38 @@ scaling_type = 3
 custom_formula = "ceil(level / 3.0)"
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
+[sub_resource type="Resource" id="Resource_sbf_critchance"]
+script = ExtResource("5_sbf")
+stat_type = 10
+flat_bonus_formula = SubResource("Resource_critchance_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
 [sub_resource type="Resource" id="Resource_critdmg_pct"]
 script = ExtResource("7_formula")
 scaling_type = 3
 custom_formula = "ceil(level / 2.0)"
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
-[sub_resource type="Resource" id="Resource_sbf_critchance"]
-script = ExtResource("5_sbf")
-stat_type = 10
-percent_bonus_formula = SubResource("Resource_critchance_pct")
-metadata/_custom_type_script = "uid://bx4thfjsjclbw"
-
 [sub_resource type="Resource" id="Resource_sbf_critdmg"]
 script = ExtResource("5_sbf")
 stat_type = 11
-percent_bonus_formula = SubResource("Resource_critdmg_pct")
+flat_bonus_formula = SubResource("Resource_critdmg_pct")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 
 [sub_resource type="Resource" id="Resource_scaling"]
 resource_local_to_scene = true
 script = ExtResource("4_scale")
 mana_cost_formula = SubResource("Resource_mana")
+cooldown_formula = SubResource("Resource_irth1")
+damage_percent_formula = SubResource("Resource_gegqc")
+max_targets_formula = SubResource("Resource_0oxvw")
+max_hits_formula = SubResource("Resource_g7nd7")
+cast_time_formula = SubResource("Resource_chef7")
 stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_critchance"), SubResource("Resource_sbf_critdmg")])
 
 [resource]
 script = ExtResource("3_abil")
-ability_id = "sharp-eyes-ability-001"
+ability_id = "5147156014-1790-791510-01334-1212151111193121132"
 ability_name = "Sharp Eyes"
 description = "Grants a temporary buff that increases critical hit chance by $[stat_bonus]% and critical damage for all party members for $[buff_duration]."
 ability_icon = ExtResource("1_icon")

--- a/resources/Abilities/Mage/A_Meditation.tres
+++ b/resources/Abilities/Mage/A_Meditation.tres
@@ -1,12 +1,12 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://meditate001x"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=23 format=3 uid="uid://meditate001x"]
 
-[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
 [ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
-[ext_resource type="Script" path="res://scripts/Abilities/AL_Meditation.gd" id="2_logic"]
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://cgorujwyt5d3" path="res://scripts/Abilities/AL_Meditation.gd" id="2_logic"]
 [ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
 [ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
-[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Resource" path="res://resources/Buffs/B_Meditation.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
 [ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
 
@@ -21,9 +21,30 @@ base_value = 30.0
 per_level = 30.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
+[sub_resource type="Resource" id="Resource_h4exd"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_5vmv4"]
+script = ExtResource("7_formula")
+base_value = 1.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_ga1wd"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
 [sub_resource type="Resource" id="Resource_mana"]
 script = ExtResource("7_formula")
 base_value = 15.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_1p3ft"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_exrxk"]
+script = ExtResource("7_formula")
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_mpregen_flat"]
@@ -32,17 +53,17 @@ base_value = 1.0
 per_level = 1.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
-[sub_resource type="Resource" id="Resource_matk_pct"]
-script = ExtResource("7_formula")
-scaling_type = 3
-custom_formula = "ceil(level / 2.0)"
-metadata/_custom_type_script = "uid://dnsex6fyou07d"
-
 [sub_resource type="Resource" id="Resource_sbf_mpregen"]
 script = ExtResource("5_sbf")
 stat_type = 7
 flat_bonus_formula = SubResource("Resource_mpregen_flat")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_matk_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 2.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_sbf_matk"]
 script = ExtResource("5_sbf")
@@ -54,17 +75,22 @@ metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 resource_local_to_scene = true
 script = ExtResource("4_scale")
 mana_cost_formula = SubResource("Resource_mana")
+cooldown_formula = SubResource("Resource_5vmv4")
+damage_percent_formula = SubResource("Resource_ga1wd")
+max_targets_formula = SubResource("Resource_exrxk")
+max_hits_formula = SubResource("Resource_1p3ft")
+cast_time_formula = SubResource("Resource_h4exd")
 stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_mpregen"), SubResource("Resource_sbf_matk")])
 
 [resource]
 script = ExtResource("3_abil")
-ability_id = "meditation-ability-001"
+ability_id = "9751111025-69115-100811-142130-111111471072141439"
 ability_name = "Meditation"
 description = "Grants a temporary buff that increases MP regeneration and magic attack by $[stat_bonus]% for all party members for $[buff_duration]."
 ability_icon = ExtResource("1_icon")
 max_level = 30
 required_class = Array[int]([2])
-required_weapon_types = Array[int]([0])
+required_weapon_types = Array[int]([2])
 active_behavior = SubResource("Resource_behav")
 applies_buff = ExtResource("4_buff")
 buff_duration_formula = SubResource("Resource_buff_dur")

--- a/resources/Abilities/Mage/A_Meditation.tres
+++ b/resources/Abilities/Mage/A_Meditation.tres
@@ -1,0 +1,71 @@
+[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://meditate001x"]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
+[ext_resource type="Script" path="res://scripts/Abilities/AL_Meditation.gd" id="2_logic"]
+[ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
+[ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
+[ext_resource type="Resource" path="res://resources/Buffs/B_Meditation.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
+[ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
+
+[sub_resource type="Resource" id="Resource_behav"]
+resource_local_to_scene = true
+script = ExtResource("1_behav")
+logic_script = ExtResource("2_logic")
+
+[sub_resource type="Resource" id="Resource_buff_dur"]
+script = ExtResource("7_formula")
+base_value = 30.0
+per_level = 30.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_mana"]
+script = ExtResource("7_formula")
+base_value = 15.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_mpregen_flat"]
+script = ExtResource("7_formula")
+base_value = 1.0
+per_level = 1.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_matk_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 2.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_sbf_mpregen"]
+script = ExtResource("5_sbf")
+stat_type = 7
+flat_bonus_formula = SubResource("Resource_mpregen_flat")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_sbf_matk"]
+script = ExtResource("5_sbf")
+stat_type = 13
+percent_bonus_formula = SubResource("Resource_matk_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_scaling"]
+resource_local_to_scene = true
+script = ExtResource("4_scale")
+mana_cost_formula = SubResource("Resource_mana")
+stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_mpregen"), SubResource("Resource_sbf_matk")])
+
+[resource]
+script = ExtResource("3_abil")
+ability_id = "meditation-ability-001"
+ability_name = "Meditation"
+description = "Grants a temporary buff that increases MP regeneration and magic attack by $[stat_bonus]% for all party members for $[buff_duration]."
+ability_icon = ExtResource("1_icon")
+max_level = 30
+required_class = Array[int]([2])
+required_weapon_types = Array[int]([0])
+active_behavior = SubResource("Resource_behav")
+applies_buff = ExtResource("4_buff")
+buff_duration_formula = SubResource("Resource_buff_dur")
+scaling_data = SubResource("Resource_scaling")

--- a/resources/Abilities/Rogue/A_Haste.tres
+++ b/resources/Abilities/Rogue/A_Haste.tres
@@ -1,0 +1,71 @@
+[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://hasteabl001x"]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
+[ext_resource type="Script" path="res://scripts/Abilities/AL_Haste.gd" id="2_logic"]
+[ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
+[ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
+[ext_resource type="Resource" path="res://resources/Buffs/B_Haste.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
+[ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
+
+[sub_resource type="Resource" id="Resource_behav"]
+resource_local_to_scene = true
+script = ExtResource("1_behav")
+logic_script = ExtResource("2_logic")
+
+[sub_resource type="Resource" id="Resource_buff_dur"]
+script = ExtResource("7_formula")
+base_value = 30.0
+per_level = 30.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_mana"]
+script = ExtResource("7_formula")
+base_value = 8.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_dex_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 2.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_luck_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 3.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_sbf_dex"]
+script = ExtResource("5_sbf")
+stat_type = 2
+percent_bonus_formula = SubResource("Resource_dex_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_sbf_luck"]
+script = ExtResource("5_sbf")
+stat_type = 3
+percent_bonus_formula = SubResource("Resource_luck_pct")
+metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_scaling"]
+resource_local_to_scene = true
+script = ExtResource("4_scale")
+mana_cost_formula = SubResource("Resource_mana")
+stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_dex"), SubResource("Resource_sbf_luck")])
+
+[resource]
+script = ExtResource("3_abil")
+ability_id = "haste-ability-001"
+ability_name = "Haste"
+description = "Grants a temporary buff that increases dexterity by $[stat_bonus]% and luck for all party members for $[buff_duration]."
+ability_icon = ExtResource("1_icon")
+max_level = 30
+required_class = Array[int]([3])
+required_weapon_types = Array[int]([0])
+active_behavior = SubResource("Resource_behav")
+applies_buff = ExtResource("4_buff")
+buff_duration_formula = SubResource("Resource_buff_dur")
+scaling_data = SubResource("Resource_scaling")

--- a/resources/Abilities/Rogue/A_Haste.tres
+++ b/resources/Abilities/Rogue/A_Haste.tres
@@ -1,12 +1,12 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=18 format=3 uid="uid://hasteabl001x"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=23 format=3 uid="uid://hasteabl001x"]
 
-[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
 [ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="1_behav"]
-[ext_resource type="Script" path="res://scripts/Abilities/AL_Haste.gd" id="2_logic"]
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://btljx6d0d4ayu" path="res://scripts/Abilities/AL_Haste.gd" id="2_logic"]
 [ext_resource type="Script" uid="uid://iols3c70aq2j" path="res://scripts/Resources/AbilitySystem/AbilityLevelData.gd" id="2_lvl"]
 [ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="3_abil"]
-[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Resource" path="res://resources/Buffs/B_Haste.tres" id="4_buff"]
+[ext_resource type="Script" uid="uid://csg6jvyvm5q1n" path="res://scripts/Resources/AbilitySystem/AbilityScalingData.gd" id="4_scale"]
 [ext_resource type="Script" uid="uid://bx4thfjsjclbw" path="res://scripts/Resources/AbilitySystem/StatBonusFormula.gd" id="5_sbf"]
 [ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="7_formula"]
 
@@ -21,9 +21,30 @@ base_value = 30.0
 per_level = 30.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
+[sub_resource type="Resource" id="Resource_t12uv"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_qpioc"]
+script = ExtResource("7_formula")
+base_value = 1.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_t3peo"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
 [sub_resource type="Resource" id="Resource_mana"]
 script = ExtResource("7_formula")
 base_value = 8.0
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_hhkhc"]
+script = ExtResource("7_formula")
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
+
+[sub_resource type="Resource" id="Resource_poqan"]
+script = ExtResource("7_formula")
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_dex_pct"]
@@ -32,17 +53,17 @@ scaling_type = 3
 custom_formula = "ceil(level / 2.0)"
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
-[sub_resource type="Resource" id="Resource_luck_pct"]
-script = ExtResource("7_formula")
-scaling_type = 3
-custom_formula = "ceil(level / 3.0)"
-metadata/_custom_type_script = "uid://dnsex6fyou07d"
-
 [sub_resource type="Resource" id="Resource_sbf_dex"]
 script = ExtResource("5_sbf")
 stat_type = 2
 percent_bonus_formula = SubResource("Resource_dex_pct")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
+
+[sub_resource type="Resource" id="Resource_luck_pct"]
+script = ExtResource("7_formula")
+scaling_type = 3
+custom_formula = "ceil(level / 3.0)"
+metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_sbf_luck"]
 script = ExtResource("5_sbf")
@@ -54,11 +75,16 @@ metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 resource_local_to_scene = true
 script = ExtResource("4_scale")
 mana_cost_formula = SubResource("Resource_mana")
+cooldown_formula = SubResource("Resource_qpioc")
+damage_percent_formula = SubResource("Resource_t3peo")
+max_targets_formula = SubResource("Resource_poqan")
+max_hits_formula = SubResource("Resource_hhkhc")
+cast_time_formula = SubResource("Resource_t12uv")
 stat_bonus_formulas = Array[ExtResource("5_sbf")]([SubResource("Resource_sbf_dex"), SubResource("Resource_sbf_luck")])
 
 [resource]
 script = ExtResource("3_abil")
-ability_id = "haste-ability-001"
+ability_id = "7115611096-110147-37148-67110-808141342121414115"
 ability_name = "Haste"
 description = "Grants a temporary buff that increases dexterity by $[stat_bonus]% and luck for all party members for $[buff_duration]."
 ability_icon = ExtResource("1_icon")

--- a/resources/Buffs/B_Haste.tres
+++ b/resources/Buffs/B_Haste.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="BuffData" load_steps=4 format=3]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_script"]
+[ext_resource type="Script" path="res://scripts/Buffs/BL_Haste.gd" id="2_logic"]
+
+[resource]
+resource_local_to_scene = true
+script = ExtResource("1_script")
+buff_id = "haste-party-buff-001"
+buff_name = "Haste"
+description = "Increases dexterity and luck of all party members."
+buff_icon = ExtResource("1_icon")
+duration = 30.0
+logic_script = ExtResource("2_logic")
+metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/resources/Buffs/B_Meditation.tres
+++ b/resources/Buffs/B_Meditation.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="BuffData" load_steps=4 format=3]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_script"]
+[ext_resource type="Script" path="res://scripts/Buffs/BL_Meditation.gd" id="2_logic"]
+
+[resource]
+resource_local_to_scene = true
+script = ExtResource("1_script")
+buff_id = "meditation-party-buff-001"
+buff_name = "Meditation"
+description = "Increases MP regeneration and magic attack of all party members."
+buff_icon = ExtResource("1_icon")
+duration = 30.0
+logic_script = ExtResource("2_logic")
+metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/resources/Buffs/B_Sharp_Eyes.tres
+++ b/resources/Buffs/B_Sharp_Eyes.tres
@@ -1,0 +1,16 @@
+[gd_resource type="Resource" script_class="BuffData" load_steps=4 format=3]
+
+[ext_resource type="Texture2D" uid="uid://cflfc6h5gx3n2" path="res://assets/sprites/Abilities/Maple Warrior.png" id="1_icon"]
+[ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_script"]
+[ext_resource type="Script" path="res://scripts/Buffs/BL_SharpEyes.gd" id="2_logic"]
+
+[resource]
+resource_local_to_scene = true
+script = ExtResource("1_script")
+buff_id = "sharp-eyes-party-buff-001"
+buff_name = "Sharp Eyes"
+description = "Increases critical hit chance and critical damage of all party members."
+buff_icon = ExtResource("1_icon")
+duration = 30.0
+logic_script = ExtResource("2_logic")
+metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/resources/Player/Classes/archer.tres
+++ b/resources/Player/Classes/archer.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=11 format=3 uid="uid://cx1em7dag4rai"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://cx1em7dag4rai"]
 
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="1_eu6w6"]
 [ext_resource type="Texture2D" uid="uid://cdrrd25polg8u" path="res://assets/UI/archer_portrait.tres" id="1_v52w3"]
@@ -10,6 +10,7 @@
 [ext_resource type="Resource" uid="uid://rrwrain001x" path="res://resources/Abilities/Archer/A_Arrow_Rain.tres" id="7_avqjs"]
 [ext_resource type="Resource" uid="uid://focusabl001x" path="res://resources/Abilities/Archer/A_Focus.tres" id="8_avqjs"]
 [ext_resource type="Resource" uid="uid://strafearc01x" path="res://resources/Abilities/Archer/A_Strafe.tres" id="9_avqjs"]
+[ext_resource type="Resource" uid="uid://shrpeyes001x" path="res://resources/Abilities/Archer/A_Sharp_Eyes.tres" id="10_avqjs"]
 
 [resource]
 script = ExtResource("1_eu6w6")
@@ -18,7 +19,7 @@ class_type = 1
 sprite_frames = Dictionary[int, SpriteFrames]({
 1: ExtResource("2_aqbok")
 })
-skills = Array[ExtResource("3_3scnm")]([ExtResource("4_avqjs"), ExtResource("5_avqjs"), ExtResource("6_avqjs"), ExtResource("7_avqjs"), ExtResource("8_avqjs"), ExtResource("9_avqjs")])
+skills = Array[ExtResource("3_3scnm")]([ExtResource("4_avqjs"), ExtResource("5_avqjs"), ExtResource("6_avqjs"), ExtResource("7_avqjs"), ExtResource("8_avqjs"), ExtResource("9_avqjs"), ExtResource("10_avqjs")])
 description = "A ranged fighter with exceptional dexterity and precision."
 icon = ExtResource("1_v52w3")
 primary_stat = 2

--- a/resources/Player/Classes/archmage.tres
+++ b/resources/Player/Classes/archmage.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://c5npgqap764va"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=13 format=3 uid="uid://c5npgqap764va"]
 
 [ext_resource type="Texture2D" uid="uid://y524adlth2o4" path="res://assets/UI/mage_portrait.tres" id="1_p2nav"]
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="2_ungre"]
@@ -11,6 +11,7 @@
 [ext_resource type="Resource" uid="uid://telport001xx" path="res://resources/Abilities/Mage/A_Teleport.tres" id="9_ns3st"]
 [ext_resource type="Resource" uid="uid://fei5h0kw8ykp" path="res://resources/Abilities/A_FMA.tres" id="10_p2nav"]
 [ext_resource type="SpriteFrames" uid="uid://b24ebeumvft8j" path="res://resources/Player/SpriteFrames/ArchMage.tres" id="11_7rdlp"]
+[ext_resource type="Resource" uid="uid://meditate001x" path="res://resources/Abilities/Mage/A_Meditation.tres" id="12_medit"]
 
 [resource]
 script = ExtResource("2_ungre")
@@ -19,7 +20,7 @@ class_type = 7
 sprite_frames = Dictionary[int, SpriteFrames]({
 15: ExtResource("11_7rdlp")
 })
-skills = Array[ExtResource("3_aripf")]([ExtResource("4_lwhha"), ExtResource("5_8h7ua"), ExtResource("6_2m87f"), ExtResource("7_sf8g1"), ExtResource("8_texf7"), ExtResource("9_ns3st"), ExtResource("10_p2nav")])
+skills = Array[ExtResource("3_aripf")]([ExtResource("4_lwhha"), ExtResource("5_8h7ua"), ExtResource("6_2m87f"), ExtResource("7_sf8g1"), ExtResource("8_texf7"), ExtResource("9_ns3st"), ExtResource("10_p2nav"), ExtResource("12_medit")])
 description = "A spellcaster with powerful magic abilities."
 icon = ExtResource("1_p2nav")
 primary_stat = 1

--- a/resources/Player/Classes/assassin.tres
+++ b/resources/Player/Classes/assassin.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://qin8vhhwcseq"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=13 format=3 uid="uid://qin8vhhwcseq"]
 
 [ext_resource type="Texture2D" uid="uid://cpa5fbnwaxoil" path="res://assets/sprites/MinifolksVillagers2/Blue/Outline/MiniGraveDigger.png" id="1_1t47v"]
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="2_3ii6l"]
@@ -10,6 +10,7 @@
 [ext_resource type="Resource" uid="uid://disorder001x" path="res://resources/Abilities/Rogue/A_Disorder.tres" id="8_bsvx6"]
 [ext_resource type="Resource" uid="uid://shdwpart001x" path="res://resources/Abilities/Rogue/A_Shadow_Partner.tres" id="9_rb1q2"]
 [ext_resource type="SpriteFrames" uid="uid://61bhtp5n4qmo" path="res://resources/Player/SpriteFrames/Rogue.tres" id="10_1lxec"]
+[ext_resource type="Resource" uid="uid://hasteabl001x" path="res://resources/Abilities/Rogue/A_Haste.tres" id="11_haste"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_3ii6l"]
 atlas = ExtResource("1_1t47v")
@@ -22,7 +23,7 @@ class_type = 8
 sprite_frames = Dictionary[int, SpriteFrames]({
 1: ExtResource("10_1lxec")
 })
-skills = Array[ExtResource("3_n0jsu")]([ExtResource("4_ov5jb"), ExtResource("5_84jlb"), ExtResource("6_jbg73"), ExtResource("7_8c5jw"), ExtResource("8_bsvx6"), ExtResource("9_rb1q2")])
+skills = Array[ExtResource("3_n0jsu")]([ExtResource("4_ov5jb"), ExtResource("5_84jlb"), ExtResource("6_jbg73"), ExtResource("7_8c5jw"), ExtResource("8_bsvx6"), ExtResource("9_rb1q2"), ExtResource("11_haste")])
 icon = SubResource("AtlasTexture_3ii6l")
 primary_stat = 3
 secondary_stat = 2

--- a/resources/Player/Classes/mage.tres
+++ b/resources/Player/Classes/mage.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://cvxw64kd5bfn7"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=13 format=3 uid="uid://cvxw64kd5bfn7"]
 
 [ext_resource type="Texture2D" uid="uid://xooxqubnslej" path="res://assets/sprites/MinifolksHumans/Outline/MiniMage.png" id="1_lnmub"]
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="1_uo3r6"]
@@ -10,6 +10,7 @@
 [ext_resource type="Resource" uid="uid://icestrik001x" path="res://resources/Abilities/Mage/A_Ice_Strike.tres" id="8_h2y4b"]
 [ext_resource type="Resource" uid="uid://mshldabl001x" path="res://resources/Abilities/Mage/A_Mana_Shield.tres" id="9_h2y4b"]
 [ext_resource type="Resource" uid="uid://telport001xx" path="res://resources/Abilities/Mage/A_Teleport.tres" id="10_h2y4b"]
+[ext_resource type="Resource" uid="uid://meditate001x" path="res://resources/Abilities/Mage/A_Meditation.tres" id="11_h2y4b"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_pq730"]
 atlas = ExtResource("1_lnmub")
@@ -22,7 +23,7 @@ class_type = 2
 sprite_frames = Dictionary[int, SpriteFrames]({
 1: ExtResource("3_uwn8l")
 })
-skills = Array[ExtResource("3_csbtv")]([ExtResource("5_h2y4b"), ExtResource("6_h2y4b"), ExtResource("7_h2y4b"), ExtResource("8_h2y4b"), ExtResource("9_h2y4b"), ExtResource("10_h2y4b")])
+skills = Array[ExtResource("3_csbtv")]([ExtResource("5_h2y4b"), ExtResource("6_h2y4b"), ExtResource("7_h2y4b"), ExtResource("8_h2y4b"), ExtResource("9_h2y4b"), ExtResource("10_h2y4b"), ExtResource("11_h2y4b")])
 description = "A spellcaster with powerful magic abilities."
 icon = SubResource("AtlasTexture_pq730")
 primary_stat = 1

--- a/resources/Player/Classes/ranger.tres
+++ b/resources/Player/Classes/ranger.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://dmkd1505putdo"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=13 format=3 uid="uid://dmkd1505putdo"]
 
 [ext_resource type="Texture2D" uid="uid://cig1ahxxfil30" path="res://assets/sprites/MinifolksHumans/Outline/MiniCrossBowMan.png" id="1_msg8v"]
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="2_0er32"]
@@ -9,6 +9,7 @@
 [ext_resource type="Resource" uid="uid://rrwrain001x" path="res://resources/Abilities/Archer/A_Arrow_Rain.tres" id="7_0rdxn"]
 [ext_resource type="Resource" uid="uid://focusabl001x" path="res://resources/Abilities/Archer/A_Focus.tres" id="8_g5get"]
 [ext_resource type="Resource" uid="uid://strafearc01x" path="res://resources/Abilities/Archer/A_Strafe.tres" id="9_y0b2h"]
+[ext_resource type="Resource" uid="uid://shrpeyes001x" path="res://resources/Abilities/Archer/A_Sharp_Eyes.tres" id="10_seyes"]
 [ext_resource type="SpriteFrames" uid="uid://pqxtacaxyo41" path="res://resources/Player/SpriteFrames/Crossbow.tres" id="11_4p4o7"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_0er32"]
@@ -22,7 +23,7 @@ class_type = 6
 sprite_frames = Dictionary[int, SpriteFrames]({
 15: ExtResource("11_4p4o7")
 })
-skills = Array[ExtResource("3_j76vt")]([ExtResource("4_hvlbx"), ExtResource("5_wtaon"), ExtResource("6_ygfep"), ExtResource("7_0rdxn"), ExtResource("8_g5get"), ExtResource("9_y0b2h")])
+skills = Array[ExtResource("3_j76vt")]([ExtResource("4_hvlbx"), ExtResource("5_wtaon"), ExtResource("6_ygfep"), ExtResource("7_0rdxn"), ExtResource("8_g5get"), ExtResource("9_y0b2h"), ExtResource("10_seyes")])
 description = "A ranged fighter with exceptional dexterity and precision."
 icon = SubResource("AtlasTexture_0er32")
 primary_stat = 2

--- a/resources/Player/Classes/rogue.tres
+++ b/resources/Player/Classes/rogue.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ClassData" load_steps=11 format=3 uid="uid://cd72f2m3bg0sh"]
+[gd_resource type="Resource" script_class="ClassData" load_steps=12 format=3 uid="uid://cd72f2m3bg0sh"]
 
 [ext_resource type="Texture2D" uid="uid://cgx33w5mdt6ar" path="res://assets/UI/rogue_portrait.tres" id="1_5hc5c"]
 [ext_resource type="Script" uid="uid://buwbui1bka8vl" path="res://scripts/Resources/ClassSystem/ClassData.gd" id="2_ynuw2"]
@@ -10,6 +10,7 @@
 [ext_resource type="Resource" uid="uid://drksghtabl01" path="res://resources/Abilities/Rogue/A_Dark_Sight.tres" id="7_so2ya"]
 [ext_resource type="Resource" uid="uid://disorder001x" path="res://resources/Abilities/Rogue/A_Disorder.tres" id="8_so2ya"]
 [ext_resource type="Resource" uid="uid://shdwpart001x" path="res://resources/Abilities/Rogue/A_Shadow_Partner.tres" id="9_so2ya"]
+[ext_resource type="Resource" uid="uid://hasteabl001x" path="res://resources/Abilities/Rogue/A_Haste.tres" id="10_so2ya"]
 
 [resource]
 script = ExtResource("2_ynuw2")
@@ -18,7 +19,7 @@ class_type = 3
 sprite_frames = Dictionary[int, SpriteFrames]({
 1: ExtResource("4_ynuw2")
 })
-skills = Array[ExtResource("3_76b0u")]([ExtResource("4_so2ya"), ExtResource("5_so2ya"), ExtResource("6_so2ya"), ExtResource("7_so2ya"), ExtResource("8_so2ya"), ExtResource("9_so2ya")])
+skills = Array[ExtResource("3_76b0u")]([ExtResource("4_so2ya"), ExtResource("5_so2ya"), ExtResource("6_so2ya"), ExtResource("7_so2ya"), ExtResource("8_so2ya"), ExtResource("9_so2ya"), ExtResource("10_so2ya")])
 icon = ExtResource("1_5hc5c")
 primary_stat = 3
 secondary_stat = 2

--- a/scripts/Abilities/AL_Haste.gd
+++ b/scripts/Abilities/AL_Haste.gd
@@ -11,10 +11,11 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
+	var caster_players_node := _owner_node.get_parent()
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
-		if not member_node:
+		if not member_node or member_node.get_parent() != caster_players_node:
 			continue
 
 		var buff_component: BuffComponent = member_node.get_node_or_null("Components/Buff")
@@ -33,6 +34,7 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		active_buff.buff_data = active_buff.buff_data.duplicate()
 		active_buff.buff_data.stat_modifiers.clear()
 
+		var modifier_data := {}
 		for bonus in _ability.scaling_data.stat_bonus_formulas:
 			var stat_data = StatData.new(bonus.stat_type, 0)
 			if bonus.flat_bonus_formula:
@@ -40,8 +42,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 			if bonus.percent_bonus_formula:
 				stat_data.percent_bonus_value = bonus.percent_bonus_formula.calculate(_level_stats.level)
 			active_buff.buff_data.stat_modifiers[bonus.stat_type] = stat_data
+			modifier_data[bonus.stat_type] = {
+				"flat": stat_data.flat_bonus_value,
+				"percent": stat_data.percent_bonus_value
+			}
 
 		buff_component._force_stat_recalc()
+		buff_component.sync_buff_stat_modifiers.rpc("Haste", modifier_data)
 
 	print("%s activated Haste (Level %d) - Duration: %ds [%d members]" %
 		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_Haste.gd
+++ b/scripts/Abilities/AL_Haste.gd
@@ -11,7 +11,6 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
-	var stats_percent = ceil(_level_stats.level / 2.0)
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
@@ -22,14 +21,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		if not buff_component:
 			continue
 
-		buff_component.apply_buff("Maple Warrior", _owner_node, duration)
+		buff_component.apply_buff("Haste", _owner_node, duration)
 
-		var active_buff = buff_component._active_buffs.get("Maple Warrior")
+		var active_buff = buff_component._active_buffs.get("Haste")
 		if not active_buff:
 			continue
 
 		if active_buff.custom_logic_instance:
-			active_buff.custom_logic_instance.stats_percent = stats_percent
 			active_buff.custom_logic_instance.source_ability_level = _level_stats.level
 
 		active_buff.buff_data = active_buff.buff_data.duplicate()
@@ -45,5 +43,5 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 
 		buff_component._force_stat_recalc()
 
-	print("%s activated Maple Warrior (Level %d) - Duration: %ds, Stats: +%.0f%% [%d members]" %
-		[_owner_node.name, _level_stats.level, duration, stats_percent, party_members.size()])
+	print("%s activated Haste (Level %d) - Duration: %ds [%d members]" %
+		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_Haste.gd.uid
+++ b/scripts/Abilities/AL_Haste.gd.uid
@@ -1,0 +1,1 @@
+uid://btljx6d0d4ayu

--- a/scripts/Abilities/AL_Maple_Warrior.gd
+++ b/scripts/Abilities/AL_Maple_Warrior.gd
@@ -13,9 +13,11 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
 	var stats_percent = ceil(_level_stats.level / 2.0)
 
+	var caster_players_node := _owner_node.get_parent()
+
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
-		if not member_node:
+		if not member_node or member_node.get_parent() != caster_players_node:
 			continue
 
 		var buff_component: BuffComponent = member_node.get_node_or_null("Components/Buff")
@@ -35,6 +37,7 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		active_buff.buff_data = active_buff.buff_data.duplicate()
 		active_buff.buff_data.stat_modifiers.clear()
 
+		var modifier_data := {}
 		for bonus in _ability.scaling_data.stat_bonus_formulas:
 			var stat_data = StatData.new(bonus.stat_type, 0)
 			if bonus.flat_bonus_formula:
@@ -42,8 +45,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 			if bonus.percent_bonus_formula:
 				stat_data.percent_bonus_value = bonus.percent_bonus_formula.calculate(_level_stats.level)
 			active_buff.buff_data.stat_modifiers[bonus.stat_type] = stat_data
+			modifier_data[bonus.stat_type] = {
+				"flat": stat_data.flat_bonus_value,
+				"percent": stat_data.percent_bonus_value
+			}
 
 		buff_component._force_stat_recalc()
+		buff_component.sync_buff_stat_modifiers.rpc("Maple Warrior", modifier_data)
 
 	print("%s activated Maple Warrior (Level %d) - Duration: %ds, Stats: +%.0f%% [%d members]" %
 		[_owner_node.name, _level_stats.level, duration, stats_percent, party_members.size()])

--- a/scripts/Abilities/AL_Meditation.gd
+++ b/scripts/Abilities/AL_Meditation.gd
@@ -11,7 +11,6 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
-	var stats_percent = ceil(_level_stats.level / 2.0)
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
@@ -22,14 +21,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		if not buff_component:
 			continue
 
-		buff_component.apply_buff("Maple Warrior", _owner_node, duration)
+		buff_component.apply_buff("Meditation", _owner_node, duration)
 
-		var active_buff = buff_component._active_buffs.get("Maple Warrior")
+		var active_buff = buff_component._active_buffs.get("Meditation")
 		if not active_buff:
 			continue
 
 		if active_buff.custom_logic_instance:
-			active_buff.custom_logic_instance.stats_percent = stats_percent
 			active_buff.custom_logic_instance.source_ability_level = _level_stats.level
 
 		active_buff.buff_data = active_buff.buff_data.duplicate()
@@ -45,5 +43,5 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 
 		buff_component._force_stat_recalc()
 
-	print("%s activated Maple Warrior (Level %d) - Duration: %ds, Stats: +%.0f%% [%d members]" %
-		[_owner_node.name, _level_stats.level, duration, stats_percent, party_members.size()])
+	print("%s activated Meditation (Level %d) - Duration: %ds [%d members]" %
+		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_Meditation.gd
+++ b/scripts/Abilities/AL_Meditation.gd
@@ -11,10 +11,11 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
+	var caster_players_node := _owner_node.get_parent()
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
-		if not member_node:
+		if not member_node or member_node.get_parent() != caster_players_node:
 			continue
 
 		var buff_component: BuffComponent = member_node.get_node_or_null("Components/Buff")
@@ -33,6 +34,7 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		active_buff.buff_data = active_buff.buff_data.duplicate()
 		active_buff.buff_data.stat_modifiers.clear()
 
+		var modifier_data := {}
 		for bonus in _ability.scaling_data.stat_bonus_formulas:
 			var stat_data = StatData.new(bonus.stat_type, 0)
 			if bonus.flat_bonus_formula:
@@ -40,8 +42,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 			if bonus.percent_bonus_formula:
 				stat_data.percent_bonus_value = bonus.percent_bonus_formula.calculate(_level_stats.level)
 			active_buff.buff_data.stat_modifiers[bonus.stat_type] = stat_data
+			modifier_data[bonus.stat_type] = {
+				"flat": stat_data.flat_bonus_value,
+				"percent": stat_data.percent_bonus_value
+			}
 
 		buff_component._force_stat_recalc()
+		buff_component.sync_buff_stat_modifiers.rpc("Meditation", modifier_data)
 
 	print("%s activated Meditation (Level %d) - Duration: %ds [%d members]" %
 		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_Meditation.gd.uid
+++ b/scripts/Abilities/AL_Meditation.gd.uid
@@ -1,0 +1,1 @@
+uid://cgorujwyt5d3

--- a/scripts/Abilities/AL_SharpEyes.gd
+++ b/scripts/Abilities/AL_SharpEyes.gd
@@ -11,7 +11,6 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
-	var stats_percent = ceil(_level_stats.level / 2.0)
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
@@ -22,14 +21,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		if not buff_component:
 			continue
 
-		buff_component.apply_buff("Maple Warrior", _owner_node, duration)
+		buff_component.apply_buff("Sharp Eyes", _owner_node, duration)
 
-		var active_buff = buff_component._active_buffs.get("Maple Warrior")
+		var active_buff = buff_component._active_buffs.get("Sharp Eyes")
 		if not active_buff:
 			continue
 
 		if active_buff.custom_logic_instance:
-			active_buff.custom_logic_instance.stats_percent = stats_percent
 			active_buff.custom_logic_instance.source_ability_level = _level_stats.level
 
 		active_buff.buff_data = active_buff.buff_data.duplicate()
@@ -45,5 +43,5 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 
 		buff_component._force_stat_recalc()
 
-	print("%s activated Maple Warrior (Level %d) - Duration: %ds, Stats: +%.0f%% [%d members]" %
-		[_owner_node.name, _level_stats.level, duration, stats_percent, party_members.size()])
+	print("%s activated Sharp Eyes (Level %d) - Duration: %ds [%d members]" %
+		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_SharpEyes.gd
+++ b/scripts/Abilities/AL_SharpEyes.gd
@@ -11,10 +11,11 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		party_members = [owner_id]
 
 	var duration = _ability.buff_duration_formula.calculate(_level_stats.level)
+	var caster_players_node := _owner_node.get_parent()
 
 	for member_id in party_members:
 		var member_node = PlayerManager.get_player_node(member_id)
-		if not member_node:
+		if not member_node or member_node.get_parent() != caster_players_node:
 			continue
 
 		var buff_component: BuffComponent = member_node.get_node_or_null("Components/Buff")
@@ -33,6 +34,7 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 		active_buff.buff_data = active_buff.buff_data.duplicate()
 		active_buff.buff_data.stat_modifiers.clear()
 
+		var modifier_data := {}
 		for bonus in _ability.scaling_data.stat_bonus_formulas:
 			var stat_data = StatData.new(bonus.stat_type, 0)
 			if bonus.flat_bonus_formula:
@@ -40,8 +42,13 @@ func execute(_owner_node: Node, _ability: AbilityData, _level_stats: AbilityLeve
 			if bonus.percent_bonus_formula:
 				stat_data.percent_bonus_value = bonus.percent_bonus_formula.calculate(_level_stats.level)
 			active_buff.buff_data.stat_modifiers[bonus.stat_type] = stat_data
+			modifier_data[bonus.stat_type] = {
+				"flat": stat_data.flat_bonus_value,
+				"percent": stat_data.percent_bonus_value
+			}
 
 		buff_component._force_stat_recalc()
+		buff_component.sync_buff_stat_modifiers.rpc("Sharp Eyes", modifier_data)
 
 	print("%s activated Sharp Eyes (Level %d) - Duration: %ds [%d members]" %
 		[_owner_node.name, _level_stats.level, duration, party_members.size()])

--- a/scripts/Abilities/AL_SharpEyes.gd.uid
+++ b/scripts/Abilities/AL_SharpEyes.gd.uid
@@ -1,0 +1,1 @@
+uid://tcmlhlo7jekp

--- a/scripts/Buffs/BL_Haste.gd
+++ b/scripts/Buffs/BL_Haste.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var source_ability_level: int = 1
+
+func on_apply(_owner_node: Node, _active_buff) -> void:
+	print("Haste (Level %d) activated on %s!" % [source_ability_level, _owner_node.name])
+
+func on_remove(_owner_node: Node, _active_buff) -> void:
+	print("Haste expired on %s" % _owner_node.name)
+
+func on_tick(_owner_node: Node, _active_buff, _delta: float) -> void:
+	pass

--- a/scripts/Buffs/BL_Haste.gd.uid
+++ b/scripts/Buffs/BL_Haste.gd.uid
@@ -1,0 +1,1 @@
+uid://dj8xfaoxksopd

--- a/scripts/Buffs/BL_Meditation.gd
+++ b/scripts/Buffs/BL_Meditation.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var source_ability_level: int = 1
+
+func on_apply(_owner_node: Node, _active_buff) -> void:
+	print("Meditation (Level %d) activated on %s!" % [source_ability_level, _owner_node.name])
+
+func on_remove(_owner_node: Node, _active_buff) -> void:
+	print("Meditation expired on %s" % _owner_node.name)
+
+func on_tick(_owner_node: Node, _active_buff, _delta: float) -> void:
+	pass

--- a/scripts/Buffs/BL_Meditation.gd.uid
+++ b/scripts/Buffs/BL_Meditation.gd.uid
@@ -1,0 +1,1 @@
+uid://dpdrf8nthv53k

--- a/scripts/Buffs/BL_SharpEyes.gd
+++ b/scripts/Buffs/BL_SharpEyes.gd
@@ -1,0 +1,12 @@
+extends Node
+
+var source_ability_level: int = 1
+
+func on_apply(_owner_node: Node, _active_buff) -> void:
+	print("Sharp Eyes (Level %d) activated on %s!" % [source_ability_level, _owner_node.name])
+
+func on_remove(_owner_node: Node, _active_buff) -> void:
+	print("Sharp Eyes expired on %s" % _owner_node.name)
+
+func on_tick(_owner_node: Node, _active_buff, _delta: float) -> void:
+	pass

--- a/scripts/Buffs/BL_SharpEyes.gd.uid
+++ b/scripts/Buffs/BL_SharpEyes.gd.uid
@@ -1,0 +1,1 @@
+uid://dpl8kvrfdsvhq

--- a/scripts/Components/buff.gd
+++ b/scripts/Components/buff.gd
@@ -352,6 +352,27 @@ func sync_buff_stacks(buff_id: String, new_stacks: int, new_duration: float) -> 
 		buff_refreshed.emit(buff_id, new_duration)
 
 
+@rpc("authority", "call_local", "reliable")
+func sync_buff_stat_modifiers(buff_id: String, modifier_data: Dictionary) -> void:
+	if multiplayer.is_server():
+		return
+
+	if not _active_buffs.has(buff_id):
+		return
+
+	var active_buff: ActiveBuff = _active_buffs[buff_id]
+	active_buff.buff_data = active_buff.buff_data.duplicate()
+	active_buff.buff_data.stat_modifiers.clear()
+
+	for stat_type_int in modifier_data:
+		var stat_type: Constants.StatType = stat_type_int as Constants.StatType
+		var mod: Dictionary = modifier_data[stat_type_int]
+		var stat_data = StatData.new(stat_type, 0)
+		stat_data.flat_bonus_value = mod.get("flat", 0)
+		stat_data.percent_bonus_value = mod.get("percent", 0.0)
+		active_buff.buff_data.stat_modifiers[stat_type] = stat_data
+
+
 ## [Server->Client] Sends all buff data to a newly connected client in a single RPC.
 func sync_all_buffs_to_client(peer_id: int) -> void:
 	if not multiplayer.is_server():


### PR DESCRIPTION
## Summary
- **Maple Warrior** (Warrior/Crusader): Extended to apply STR/INT/DEX/LUCK % buff to all party members instead of just the caster
- **Sharp Eyes** (Archer/Ranger): New party buff granting +CRITCHANCE% and +CRITDAMAGE% to all party members
- **Meditation** (Mage/Archmage): New party buff granting +MPREGEN (flat) and +MAGICATTACK% to all party members
- **Haste** (Rogue/Assassin): New party buff granting +DEX% and +LUCK% to all party members

All buffs use level-based scaling formulas, apply to party members via PartyManager, and fall back to self-only when not in a party. BuffData is duplicated per member to prevent shared state issues between party members.

Closes #96

## Test plan
- [ ] Cast Maple Warrior as Swordsman/Crusader solo — verify self-only buff with correct stat % increase
- [ ] Create a party with 2+ players, cast Maple Warrior — verify all members receive the buff and stats update
- [ ] Verify buff duration scales with ability level
- [ ] Test Sharp Eyes on Archer — verify CRITCHANCE and CRITDAMAGE increase for party
- [ ] Test Meditation on Mage — verify MPREGEN and MAGICATTACK increase for party
- [ ] Test Haste on Rogue — verify DEX and LUCK increase for party
- [ ] Verify buff expiration correctly removes stat bonuses from all members
- [ ] Test re-casting while buff is active (REFRESH behavior)
- [ ] Verify buff icon appears in buff bar for all party members

🤖 Generated with [Claude Code](https://claude.com/claude-code)