### PR TITLE
A2: Server graceful shutdown

### DIFF
--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -19,6 +19,8 @@ var respawn_point: Vector2 = Vector2.ZERO
 var menu_container: Control
 var _pending_shutdown_reason: String = ""
 var disconnect_reason: String = ""
+var _was_connected_to_server: bool = false
+var _handling_disconnect: bool = false
 
 # === INITIALIZATION ===
 func _ready():
@@ -28,6 +30,18 @@ func _ready():
 	if OS.has_feature("dedicated_server"):
 		var port = NetworkUtils.get_port_from_args(CONFIG.DEFAULT_PORT)
 		ServerManager.start_dedicated_server(port)
+
+func _process(_delta):
+	if multiplayer.is_server():
+		return
+	if not _was_connected_to_server:
+		return
+	if _handling_disconnect:
+		return
+	var peer = multiplayer.multiplayer_peer
+	if not peer or peer.get_connection_status() == MultiplayerPeer.CONNECTION_DISCONNECTED:
+		print("MultiplayerManager: Connection lost detected via poll")
+		_handle_server_disconnect()
 
 func _notification(what):
 	if what == NOTIFICATION_WM_CLOSE_REQUEST:
@@ -76,6 +90,8 @@ func switch_channel(new_port: int):
 
 func reset_data():
 	host_mode_enabled = false
+	_was_connected_to_server = false
+	_handling_disconnect = false
 	# Flush all player saves BEFORE closing the peer — SaveManager._is_server()
 	# returns false once the peer is gone, so saves must complete while it is still active.
 	if multiplayer.is_server():
@@ -100,18 +116,28 @@ func _on_server_started():
 
 func _on_client_connected():
 	print("Successfully connected to server!")
+	_was_connected_to_server = true
+	_handling_disconnect = false
 	_update_ui_for_client()
 
 func _on_client_failed():
 	print("Failed to connect to server")
 
 func _on_server_disconnected():
+	print("MultiplayerManager: server_disconnected signal fired")
+	_handle_server_disconnect()
+
+func _handle_server_disconnect():
 	if ChannelManager.is_switching():
 		return
+	if _handling_disconnect:
+		return
+	_handling_disconnect = true
+	_was_connected_to_server = false
 
 	var reason = _pending_shutdown_reason if _pending_shutdown_reason != "" else "Disconnected from server."
 	_pending_shutdown_reason = ""
-	print(reason)
+	print("MultiplayerManager: Redirecting to login — %s" % reason)
 	disconnect_reason = reason
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
 

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -32,11 +32,7 @@ func _ready():
 		ServerManager.start_dedicated_server(port)
 
 func _process(_delta):
-	if multiplayer.is_server():
-		return
-	if not _was_connected_to_server:
-		return
-	if _handling_disconnect:
+	if _handling_disconnect or not _was_connected_to_server:
 		return
 	var peer = multiplayer.multiplayer_peer
 	if not peer or peer.get_connection_status() == MultiplayerPeer.CONNECTION_DISCONNECTED:
@@ -140,17 +136,24 @@ func _handle_server_disconnect():
 	print("MultiplayerManager: Cleaning up network state...")
 	disconnect_reason = reason
 
-	# Clean up all networked entities and maps before scene change
-	get_tree().call_group("networked_entities", "queue_free")
+	# Kill the peer first to stop all network errors
+	if multiplayer.multiplayer_peer:
+		multiplayer.multiplayer_peer.close()
+		multiplayer.multiplayer_peer = null
+	ClientManager._disconnect()
+
+	# Stop music
+	AudioManager.stop_song()
+
+	# Free all networked entities and maps
+	for node in get_tree().get_nodes_in_group("networked_entities"):
+		node.queue_free()
 	PlayerManager.cleanup()
 	MapManager.reset_client_state()
 	var maps_container = get_tree().root.get_node_or_null("Maps")
 	if maps_container:
-		maps_container.queue_free()
-	ClientManager._disconnect()
-	if multiplayer.multiplayer_peer:
-		multiplayer.multiplayer_peer.close()
-		multiplayer.multiplayer_peer = null
+		get_tree().root.remove_child(maps_container)
+		maps_container.free()
 
 	print("MultiplayerManager: Redirecting to login — %s" % reason)
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -17,14 +17,23 @@ const CONFIG = {
 var host_mode_enabled: bool = false
 var respawn_point: Vector2 = Vector2.ZERO
 var menu_container: Control
+var _pending_shutdown_reason: String = ""
 
 # === INITIALIZATION ===
 func _ready():
 	_setup_signals()
-	
+	get_tree().set_auto_accept_quit(false)
+
 	if OS.has_feature("dedicated_server"):
 		var port = NetworkUtils.get_port_from_args(CONFIG.DEFAULT_PORT)
 		ServerManager.start_dedicated_server(port)
+
+func _notification(what):
+	if what == NOTIFICATION_WM_CLOSE_REQUEST:
+		if multiplayer.is_server():
+			_graceful_shutdown()
+		else:
+			get_tree().quit()
 
 func _setup_signals():
 	# Forward signals from components
@@ -98,11 +107,29 @@ func _on_client_failed():
 func _on_server_disconnected():
 	if ChannelManager.is_switching():
 		return
-	
-	print("Disconnected from server")
-	menu_container._connection_status_label.text = "Disconnected from server."
+
+	var reason = _pending_shutdown_reason if _pending_shutdown_reason != "" else "Disconnected from server."
+	_pending_shutdown_reason = ""
+	print(reason)
+	if menu_container and is_instance_valid(menu_container) and menu_container.has_node("_connection_status_label"):
+		menu_container._connection_status_label.text = reason
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
-	
+
+
+# === GRACEFUL SHUTDOWN ===
+
+func _graceful_shutdown():
+	print("Server shutting down gracefully...")
+	_notify_clients_shutdown.rpc()
+	await PlayerManager.save_all_players()
+	get_tree().quit()
+
+@rpc("authority", "call_local", "reliable")
+func _notify_clients_shutdown():
+	if multiplayer.is_server():
+		return
+	_pending_shutdown_reason = "Server is shutting down."
+
 
 # === UTILITY METHODS ===
 # These methods are deprecated - kept for backward compatibility with main_menu

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -157,6 +157,8 @@ func _handle_server_disconnect():
 
 	print("MultiplayerManager: Redirecting to login — %s" % reason)
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
+	await get_tree().tree_changed
+	get_tree().reload_current_scene()
 
 
 # === GRACEFUL SHUTDOWN ===

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -158,7 +158,7 @@ func _handle_server_disconnect():
 	print("MultiplayerManager: Redirecting to login — %s" % reason)
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
 	await get_tree().tree_changed
-	get_tree().reload_current_scene()
+	#get_tree().reload_current_scene()
 
 
 # === GRACEFUL SHUTDOWN ===

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -121,7 +121,17 @@ func _on_server_disconnected():
 func _graceful_shutdown():
 	print("Server shutting down gracefully...")
 	_notify_clients_shutdown.rpc()
+	# Let the RPC packet actually send before we start tearing down
+	await get_tree().create_timer(0.5).timeout
 	await PlayerManager.save_all_players()
+	# Close the peer properly so clients get a clean ENet disconnect
+	# instead of waiting for the ~30s timeout
+	ServerManager.stop_server()
+	if multiplayer.multiplayer_peer:
+		multiplayer.multiplayer_peer.close()
+		multiplayer.multiplayer_peer = null
+	# Brief delay for disconnect packets to propagate
+	await get_tree().create_timer(0.2).timeout
 	get_tree().quit()
 
 @rpc("authority", "call_local", "reliable")

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -137,8 +137,18 @@ func _handle_server_disconnect():
 
 	var reason = _pending_shutdown_reason if _pending_shutdown_reason != "" else "Disconnected from server."
 	_pending_shutdown_reason = ""
-	print("MultiplayerManager: Redirecting to login — %s" % reason)
+	print("MultiplayerManager: Cleaning up network state...")
 	disconnect_reason = reason
+
+	# Clean up all networked entities before scene change
+	get_tree().call_group("networked_entities", "queue_free")
+	PlayerManager.cleanup()
+	ClientManager._disconnect()
+	if multiplayer.multiplayer_peer:
+		multiplayer.multiplayer_peer.close()
+		multiplayer.multiplayer_peer = null
+
+	print("MultiplayerManager: Redirecting to login — %s" % reason)
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
 
 

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -18,6 +18,7 @@ var host_mode_enabled: bool = false
 var respawn_point: Vector2 = Vector2.ZERO
 var menu_container: Control
 var _pending_shutdown_reason: String = ""
+var disconnect_reason: String = ""
 
 # === INITIALIZATION ===
 func _ready():
@@ -111,8 +112,7 @@ func _on_server_disconnected():
 	var reason = _pending_shutdown_reason if _pending_shutdown_reason != "" else "Disconnected from server."
 	_pending_shutdown_reason = ""
 	print(reason)
-	if menu_container and is_instance_valid(menu_container) and menu_container.has_node("_connection_status_label"):
-		menu_container._connection_status_label.text = reason
+	disconnect_reason = reason
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
 
 

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -140,9 +140,13 @@ func _handle_server_disconnect():
 	print("MultiplayerManager: Cleaning up network state...")
 	disconnect_reason = reason
 
-	# Clean up all networked entities before scene change
+	# Clean up all networked entities and maps before scene change
 	get_tree().call_group("networked_entities", "queue_free")
 	PlayerManager.cleanup()
+	MapManager.reset_client_state()
+	var maps_container = get_tree().root.get_node_or_null("Maps")
+	if maps_container:
+		maps_container.queue_free()
 	ClientManager._disconnect()
 	if multiplayer.multiplayer_peer:
 		multiplayer.multiplayer_peer.close()

--- a/scripts/Managers/save_manager.gd
+++ b/scripts/Managers/save_manager.gd
@@ -173,9 +173,15 @@ func flush_save(username: String) -> void:
 	# API keeps stale data — and loads always read from the API first.
 	if _in_flight_username != "":
 		print("SaveManager: Flush for '%s' — waiting for in-flight save ('%s') to finish." % [username, _in_flight_username])
-		while _in_flight_username != "":
+		var wait_frames := 0
+		while _in_flight_username != "" and wait_frames < 300:
 			await get_tree().process_frame
-		print("SaveManager: In-flight save finished, proceeding with flush for '%s'." % username)
+			wait_frames += 1
+		if wait_frames >= 300:
+			push_error("SaveManager: Timed out waiting for in-flight save, forcing continue")
+			_in_flight_username = ""
+		else:
+			print("SaveManager: In-flight save finished, proceeding with flush for '%s'." % username)
 
 	# Send via HTTP (blocking via await)
 	info.dirty_categories.clear()

--- a/scripts/UI/LoginScreen.gd
+++ b/scripts/UI/LoginScreen.gd
@@ -44,6 +44,11 @@ func _ready():
 	
 	_setup_backend_display()
 
+	if MultiplayerManager.disconnect_reason != "":
+		status_label.text = MultiplayerManager.disconnect_reason
+		status_label.add_theme_color_override("font_color", Color.RED)
+		MultiplayerManager.disconnect_reason = ""
+
 
 func _setup_backend_display():
 	# Initialize with current backend URL


### PR DESCRIPTION
## Summary
- Fix `flush_save()` hang: add 300-frame timeout to in-flight wait loop
- Hook `NOTIFICATION_WM_CLOSE_REQUEST` to save all players before exit
- Broadcast "Server is shutting down" RPC to clients before closing
- Null-safe `_on_server_disconnected()` with pending shutdown reason

## Test plan
- [ ] Close server window → verify all player data saved
- [ ] Verify clients see "Server is shutting down" before disconnect
- [ ] Verify `flush_save()` doesn't hang if backend is down
- [ ] Verify `set_auto_accept_quit(false)` prevents instant close

🤖 Generated with [Claude Code](https://claude.com/claude-code)