### PR TITLE
Strip client-only UI from bot player nodes

### DIFF
--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -78,6 +78,17 @@ const GAME_MENU_SCENE = preload("res://scenes/UI/game_menu.tscn")
 func _ready() -> void:
 	var _is_bot := BotManager.is_bot(player_id)
 
+	# Bots have no client-side interface — drop the entire CanvasLayer subtree
+	# (on-screen HUD, mobile buttons, debug panel, hotbar, buffbar, and the
+	# draggable windows) on every peer that instantiates this node. This frees
+	# the memory and removes the per-frame _process / _input cost of every UI
+	# node a bot would otherwise carry. Gameplay nodes and the floating
+	# PlayerWorldHUD (name + HP bar that real players see) are kept.
+	if _is_bot:
+		var bot_canvas_layer := get_node_or_null("CanvasLayer")
+		if is_instance_valid(bot_canvas_layer):
+			bot_canvas_layer.queue_free()
+
 	if not _is_bot and multiplayer.get_unique_id() == player_id:
 		ChatManager.register_local_player(self)
 		# Request the sprite states of all other players from the server.


### PR DESCRIPTION
## Summary

Follow-up bot optimization — bots instantiated the full player scene, including UI a headless bot never uses.

A bot's `CanvasLayer` subtree contains: the on-screen HUD (health/mana/exp bars), 4 mobile touch buttons, the debug panel, the hotbar, the buffbar, and 5 draggable windows (Ability/Stats/Inventory/Equipment/Quest). Every one of those nodes — and their scripts' `_process` / `_input` handlers — ran for nothing on each bot.

In `multiplayer_controller_v2.gd._ready()`, bots now free the entire `CanvasLayer` subtree on whichever peer instantiated the node (the server, and every client that renders the bot).

**Kept** (still needed): all gameplay nodes, the `MultiplayerSynchronizer`s, and the floating `PlayerWorldHUD` (name label + HP bar that real players see above the bot).

**Why it's safe:**
- All `CanvasLayer` access is already gated behind `not _is_bot` checks (`_setup_client_visuals`, debug-component setup) or `is_instance_valid()` guards.
- `HealthComponent.health_bar` points to `PlayerWorldHUD/HealthBar`, **not** `CanvasLayer` — confirmed in `player.tscn` (`health_bar_path = "../../PlayerWorldHUD/HealthBar"`).
- `_setup_signals()` (which runs for bots) only wires component→controller signals; no HUD references.
- Draggable windows / context menus only ever resolve the *local* player's `MoveableWindows`, never a bot's.

## Not done (bigger / higher-risk, noted for later)

- A dedicated lightweight bot scene would also save the *instantiation* cost (the spawn stagger currently hides that).
- Disabling the bot's `InputSynchronizer` (a bot has no client input to replicate).

## Test plan

- [ ] Spawn bots — confirm they still fight, loot, equip, level, buff, party, travel
- [ ] A real player sees each bot's floating name + HP bar update correctly
- [ ] Inspect a bot (`/bot inspect`) — the host's inspect window still works
- [ ] Trade with a bot — trade window opens on the player side
- [ ] No errors referencing freed HUD/window nodes in the server console

🤖 Generated with [Claude Code](https://claude.com/claude-code)