### PR TITLE
Inventory decouple stage 1: components own SlotData

### DIFF
--- a/scripts/Components/equipment.gd
+++ b/scripts/Components/equipment.gd
@@ -10,6 +10,9 @@ signal on_equipment_changed
 @export var weapon_slot: EquipmentSlot
 
 var equipment: Dictionary = {}
+# The component-owned data model: equipment key -> SlotData. This is the real
+# storage; the EquipmentSlot UI nodes are views bound to these.
+var slots_data: Dictionary = {}
 var _changed_in_frame: bool = false
 var _silent_mode: bool = false
 
@@ -21,25 +24,39 @@ func _ready():
 		Constants.ArmorType.LEGS: legs_slot,
 		Constants.ArmorType.FEET: feet_slot,
 	}
-	
+
 	for armor_type in armor_slots:
 		var slot = armor_slots[armor_type]
+		# The component owns a SlotData for every equipment key, even when the
+		# matching UI slot is absent (e.g. a headless bot scene).
+		var data := SlotData.new()
+		data.allowed_item_type = Constants.ItemType.EQUIPMENT
+		data.allowed_equipment_type = Constants.EquipmentType.ARMOR
+		data.allowed_armor_type = armor_type
+		slots_data[armor_type] = data
+
 		if is_instance_valid(slot):
 			equipment[armor_type] = slot
 			slot.set_inventory(self)
 			slot.allowed_item_type = Constants.ItemType.EQUIPMENT
 			slot.allowed_equipment_type = Constants.EquipmentType.ARMOR
 			slot.allowed_armor_type = armor_type
+			slot.bind_slot_data(data)
+
+	var weapon_data := SlotData.new()
+	weapon_data.allowed_item_type = Constants.ItemType.EQUIPMENT
+	weapon_data.allowed_equipment_type = Constants.EquipmentType.WEAPON
+	slots_data["WEAPON"] = weapon_data
 
 	if weapon_slot:
 		equipment["WEAPON"] = weapon_slot
 		weapon_slot.set_inventory(self)
 		weapon_slot.allowed_item_type = Constants.ItemType.EQUIPMENT
 		weapon_slot.allowed_equipment_type = Constants.EquipmentType.WEAPON
+		weapon_slot.bind_slot_data(weapon_data)
 
 	# When equipment changes on the server, persist the player's data
 	# Logic moved to multiplayer_controller_v2.gd to handle both client and server
-	pass
 
 
 func set_silent_mode(enabled: bool) -> void:

--- a/scripts/Components/inventory.gd
+++ b/scripts/Components/inventory.gd
@@ -12,6 +12,9 @@ signal inventory_saved(inventory: InventoryComponent)
 
 
 var slots: Array[Slot] = []
+# Component-owned data model, kept 1:1 and in index order with `slots`. The
+# item data lives here; the Slot nodes are views bound to these entries.
+var slots_data: Array[SlotData] = []
 var item_counts: Dictionary = {} # item_id -> total_count
 var item_locations: Dictionary = {} # item_id -> Array[Slot]
 
@@ -74,6 +77,8 @@ func _ensure_slots_initialized() -> void:
 			slot.set_inventory(self)
 		slot.add_to_group("inventory_slots")
 
+	_build_slot_data()
+
 
 func setup_slots(slot_array: Array[Slot]):
 	slots = slot_array
@@ -81,7 +86,21 @@ func setup_slots(slot_array: Array[Slot]):
 		if slot.has_method("set_inventory"):
 			slot.set_inventory(self)
 		slot.add_to_group("inventory_slots")
+	_build_slot_data()
 	_rebuild_item_tracking()
+
+
+## Creates one SlotData per UI slot (in index order) and binds them. After this
+## the data model lives in the component; the Slot nodes are pure views.
+func _build_slot_data() -> void:
+	if not slots_data.is_empty():
+		return
+	for i in slots.size():
+		var data := SlotData.new()
+		data.index = i
+		data.allowed_item_type = slots[i].allowed_item_type
+		slots_data.append(data)
+		slots[i].bind_slot_data(data)
 
 
 func _rebuild_item_tracking():

--- a/scripts/UI/slot.gd
+++ b/scripts/UI/slot.gd
@@ -20,14 +20,25 @@ var item_container: Node = null
 
 @export var allowed_item_type: Constants.ItemType = Constants.ItemType.ANY
 
-@export var item: ItemData = null:
+# The data model this view is bound to. While unbound, the slot falls back to
+# its own _legacy_item storage — that fallback is removed once every slot is
+# bound (Stage 2). The data lives in the component, not in this UI node.
+var slot_data: SlotData = null
+var _legacy_item: ItemData = null
+
+var item: ItemData:
+	get:
+		return slot_data.item if slot_data != null else _legacy_item
 	set(value):
-		var old_item = item
-		item = value
+		var old_item: ItemData = item
+		if slot_data != null:
+			slot_data.item = value
+		else:
+			_legacy_item = value
 		update_display()
-		
+
 		if is_instance_valid(item_container) and item_container.has_method("_update_item_tracking"):
-			item_container._update_item_tracking(self, old_item, item)
+			item_container._update_item_tracking(self, old_item, value)
 
 # Drag state variables
 var is_dragging: bool = false
@@ -80,6 +91,15 @@ func _reset_slot_border() -> void:
 
 func set_inventory(inv: Node):
 	item_container = inv
+
+
+## Binds this view to a SlotData model owned by a component. After binding, the
+## SlotData is the single source of truth and this node only renders it.
+func bind_slot_data(data: SlotData) -> void:
+	slot_data = data
+	# Refresh now if the node is ready; otherwise _ready()'s update_display() covers it.
+	if is_node_ready():
+		update_display()
 
 
 func _drop_data(_at_position: Vector2, data: Variant) -> void:


### PR DESCRIPTION
## Summary

Stage 1 of the inventory/equipment decoupling. The authoritative item data now lives in **component-owned `SlotData` objects** instead of inside the `Slot` UI nodes.

> Stacked on #122 (Stage 0). Base will retarget to `feature/player-bots` once #122 merges.

> **Re-staging note:** the approved plan split equipment (stage 1) and inventory (stage 2) into separate PRs, but `Slot` is a shared base class and transfers swap items *across* the inventory/equipment boundary — so the data-ownership move is done for **both at once** here. Consumer migration is the next PR.

### Changes

- **`slot.gd`** — `item` becomes a computed property backed by a bound `SlotData`, with a transitional `_legacy_item` fallback for any slot not yet bound. Adds `bind_slot_data()`. The setter still calls `update_display()` and `item_container._update_item_tracking()` exactly as before.
- **`equipment.gd`** — owns `slots_data` (`equipment key → SlotData`), created in `_ready()` and bound to the `EquipmentSlot` views.
- **`inventory.gd`** — owns `slots_data` (`Array[SlotData]`, 1:1 and index-ordered with `slots`), built by `_build_slot_data()` and bound to the `Slot` views.

### Why this is safe

**No behaviour should change.** There are no consumer changes, no addressing changes, no save-format changes, and no sync changes. Every existing code path still goes through `slot.item`, which now transparently reads/writes the bound `SlotData`. The data simply moved out of the UI node into the component. The UI is still present on every peer (the lightweight bot scene is a later stage), so all `slot.item` access still resolves.

## Test plan

- [ ] Project compiles.
- [ ] Pick up / move / stack / split / drop / equip / unequip items as a real player — identical to before.
- [ ] Relog and confirm inventory + equipment persisted (diff `player_*.json`).
- [ ] Buy/sell at a merchant incl. buyback; player↔player and player↔bot trades.
- [ ] Bots loot, equip upgrades, sell, restock potions.
- [ ] Trigger an inventory desync (rapid drags) — `send_inventory_correction` still restores state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)