### PR TITLE
Inventory decouple stage 2a: SlotData accessors & helpers

### DIFF
--- a/scripts/Components/equipment.gd
+++ b/scripts/Components/equipment.gd
@@ -64,7 +64,8 @@ func set_silent_mode(enabled: bool) -> void:
 
 
 # This function is called by the Slot's item setter whenever an item is changed.
-func _update_item_tracking(_slot: Slot, _old_item: ItemData, _new_item: ItemData):
+# `_slot` is untyped — it may be a Slot view or a SlotData, both are ignored here.
+func _update_item_tracking(_slot, _old_item: ItemData, _new_item: ItemData):
 	if _changed_in_frame:
 		return
 	_changed_in_frame = true
@@ -75,9 +76,15 @@ func _emit_equipment_changed_deferred():
 	if _silent_mode:
 		_changed_in_frame = false
 		return
-		
+
 	on_equipment_changed.emit()
 	_changed_in_frame = false
+
+
+## Flags an equipment change so on_equipment_changed fires (deferred). Used by
+## code that mutates a SlotData directly instead of through a Slot view setter.
+func mark_changed() -> void:
+	_update_item_tracking(null, null, null)
 
 
 func get_slots() -> Array[EquipmentSlot]:
@@ -88,3 +95,33 @@ func get_slots() -> Array[EquipmentSlot]:
 	if feet_slot: slots_array.append(feet_slot)
 	if weapon_slot: slots_array.append(weapon_slot)
 	return slots_array
+
+
+# --- SlotData model accessors (UI-independent; safe on a headless bot) ---
+
+func get_slot_data(key) -> SlotData:
+	return slots_data.get(key)
+
+
+func get_all_slot_data() -> Array:
+	return slots_data.values()
+
+
+var weapon_slot_data: SlotData:
+	get: return slots_data.get("WEAPON")
+var head_slot_data: SlotData:
+	get: return slots_data.get(Constants.ArmorType.HEAD)
+var chest_slot_data: SlotData:
+	get: return slots_data.get(Constants.ArmorType.CHEST)
+var legs_slot_data: SlotData:
+	get: return slots_data.get(Constants.ArmorType.LEGS)
+var feet_slot_data: SlotData:
+	get: return slots_data.get(Constants.ArmorType.FEET)
+
+
+## Refreshes the UI view bound to an equipment key, if one exists. A no-op on
+## a headless bot scene (no equipment window).
+func refresh_view(key) -> void:
+	var view = equipment.get(key)
+	if is_instance_valid(view):
+		view.update_display()

--- a/scripts/Components/inventory.gd
+++ b/scripts/Components/inventory.gd
@@ -124,7 +124,9 @@ func _rebuild_item_tracking():
 				item_locations[item_instance_id] = [slot]
 
 
-func _update_item_tracking(slot: Slot, old_item: ItemData, new_item: ItemData):
+## `slot` is untyped — it accepts a Slot view (current callers) or a SlotData
+## (component-driven callers from Stage 2b). It is only used as a collection key.
+func _update_item_tracking(slot, old_item: ItemData, new_item: ItemData):
 	if old_item != null:
 		var old_instance_id = old_item.item_id
 		if old_instance_id in item_counts:
@@ -156,6 +158,33 @@ func _update_item_tracking(slot: Slot, old_item: ItemData, new_item: ItemData):
 func _get_slot_index(slot: Slot) -> int:
 	"""Get the index of a slot in the slots array, or -1 if not found"""
 	return slots.find(slot)
+
+
+## Refreshes the UI view bound to an inventory slot index, if one exists.
+## No-op on a headless bot scene (no inventory window).
+func _refresh_view(index: int) -> void:
+	if index >= 0 and index < slots.size() and is_instance_valid(slots[index]):
+		slots[index].update_display()
+
+
+## Sets a SlotData's item, updates tracking, and refreshes its bound view.
+## The single mutation entry point for component-driven inventory changes.
+func _apply_item(sd: SlotData, new_item: ItemData) -> void:
+	var old_item: ItemData = sd.item
+	sd.item = new_item
+	_update_item_tracking(sd, old_item, new_item)
+	_refresh_view(sd.index)
+
+
+## Sets an equipment SlotData's item and refreshes its bound view.
+func _apply_equipment_item(key, new_item: ItemData) -> void:
+	if not is_instance_valid(equipment_component):
+		return
+	var sd: SlotData = equipment_component.get_slot_data(key)
+	if sd == null:
+		return
+	sd.item = new_item
+	equipment_component.refresh_view(key)
 
 
 func _sync_slot_to_client(slot: Slot, trigger_stats_recalc: bool = false):

--- a/scripts/Components/slot_data.gd.uid
+++ b/scripts/Components/slot_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bb4n18l7wcic5


### PR DESCRIPTION
## Summary

Stage 2a of the inventory/equipment decoupling — additive building blocks for the 2b/2c migrations.

> Stacked on #123 (Stage 1). Base retargets automatically as the stack merges down.

**Nothing calls these yet**, so behavior is unchanged (verifiable like Stage 0).

- **`equipment.gd`** — `get_slot_data()`, `get_all_slot_data()`, `weapon_slot_data`/`head_slot_data`/`chest_slot_data`/`legs_slot_data`/`feet_slot_data`, `refresh_view()`, and `mark_changed()` (fires `on_equipment_changed` for code that mutates a `SlotData` directly rather than via a `Slot` view). `_update_item_tracking()`'s slot param is now untyped so it also accepts a `SlotData`.
- **`inventory.gd`** — `_refresh_view()`, `_apply_item()` (the single mutation entry point: set `SlotData.item` + update tracking + refresh the bound view), `_apply_equipment_item()`. `_update_item_tracking()`'s slot param relaxed likewise.
- Also commits `slot_data.gd.uid` — the import companion for the Stage 0 script (Godot generated it on first project load; it belongs in version control).

## Why it's safe

Pure additions plus two type-hint relaxations (`Slot` → untyped on `_update_item_tracking`, which only uses the param as a collection key). No existing code path changes.

## Test plan

- [ ] Project compiles.
- [ ] Game behaves identically to Stage 1 (no code calls the new helpers yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)