### PR TITLE
Inventory decouple stage 3: UI-independent bot equip-swap

### DIFF
--- a/scripts/Bot/bot_brain.gd
+++ b/scripts/Bot/bot_brain.gd
@@ -807,7 +807,7 @@ func _evaluate_and_equip() -> void:
 	if is_instance_valid(player.class_component):
 		class_type = player.class_component.current_class
 
-	for slot in player.inventory_component.slots:
+	for slot in player.inventory_component.get_slots():
 		if slot.item == null:
 			continue
 		if slot.item is not EquipmentData:
@@ -818,11 +818,9 @@ func _evaluate_and_equip() -> void:
 			continue
 
 		if BotEquipmentLogic.should_equip(target_slot.item, slot.item, class_type):
-			var old_item = target_slot.item
-			target_slot.item = slot.item
-			slot.item = old_item
-			slot.update_display()
-			target_slot.update_display()
+			# UI-independent swap — moves the upgrade into equipment and the
+			# old item back into this inventory slot, with tracking + stats.
+			player.inventory_component.swap_slot_data(slot, target_slot)
 
 
 func _build_ability_lists() -> void:

--- a/scripts/Bot/bot_equipment_logic.gd
+++ b/scripts/Bot/bot_equipment_logic.gd
@@ -76,18 +76,18 @@ static func should_equip(current: ItemData, candidate: ItemData, class_type: Con
 	return candidate_score > score_item(current, class_type)
 
 
-static func get_target_slot(item: ItemData, equipment_component: EquipmentComponent) -> EquipmentSlot:
+static func get_target_slot(item: ItemData, equipment_component: EquipmentComponent) -> SlotData:
 	if item is WeaponData:
-		return equipment_component.weapon_slot
+		return equipment_component.weapon_slot_data
 	elif item is ArmorData:
 		var armor := item as ArmorData
 		match armor.armor_type:
 			Constants.ArmorType.HEAD:
-				return equipment_component.head_slot
+				return equipment_component.head_slot_data
 			Constants.ArmorType.CHEST:
-				return equipment_component.chest_slot
+				return equipment_component.chest_slot_data
 			Constants.ArmorType.LEGS:
-				return equipment_component.legs_slot
+				return equipment_component.legs_slot_data
 			Constants.ArmorType.FEET:
-				return equipment_component.feet_slot
+				return equipment_component.feet_slot_data
 	return null

--- a/scripts/Components/equipment.gd
+++ b/scripts/Components/equipment.gd
@@ -30,6 +30,8 @@ func _ready():
 		# The component owns a SlotData for every equipment key, even when the
 		# matching UI slot is absent (e.g. a headless bot scene).
 		var data := SlotData.new()
+		data.container_kind = SlotData.CONTAINER_EQUIPMENT
+		data.key = armor_type
 		data.allowed_item_type = Constants.ItemType.EQUIPMENT
 		data.allowed_equipment_type = Constants.EquipmentType.ARMOR
 		data.allowed_armor_type = armor_type
@@ -44,6 +46,8 @@ func _ready():
 			slot.bind_slot_data(data)
 
 	var weapon_data := SlotData.new()
+	weapon_data.container_kind = SlotData.CONTAINER_EQUIPMENT
+	weapon_data.key = "WEAPON"
 	weapon_data.allowed_item_type = Constants.ItemType.EQUIPMENT
 	weapon_data.allowed_equipment_type = Constants.EquipmentType.WEAPON
 	slots_data["WEAPON"] = weapon_data

--- a/scripts/Components/inventory.gd
+++ b/scripts/Components/inventory.gd
@@ -97,7 +97,9 @@ func _build_slot_data() -> void:
 		return
 	for i in slots.size():
 		var data := SlotData.new()
+		data.container_kind = SlotData.CONTAINER_INVENTORY
 		data.index = i
+		data.key = i
 		data.allowed_item_type = slots[i].allowed_item_type
 		slots_data.append(data)
 		slots[i].bind_slot_data(data)
@@ -185,6 +187,53 @@ func _apply_equipment_item(key, new_item: ItemData) -> void:
 		return
 	sd.item = new_item
 	equipment_component.refresh_view(key)
+
+
+## Refreshes whichever view (inventory or equipment) is bound to a SlotData.
+func _refresh_slot_data_view(sd: SlotData) -> void:
+	if sd.container_kind == SlotData.CONTAINER_EQUIPMENT:
+		if is_instance_valid(equipment_component):
+			equipment_component.refresh_view(sd.key)
+	else:
+		_refresh_view(sd.index)
+
+
+## Swaps the items of two slots (inventory and/or equipment). UI-independent —
+## the entry point bot equip logic uses, since a bot has no Slot views to drive
+## a normal drag-and-drop transfer.
+func swap_slot_data(from_sd: SlotData, to_sd: SlotData) -> void:
+	if from_sd == null or to_sd == null:
+		return
+
+	var from_item := from_sd.item
+	var to_item := to_sd.item
+	from_sd.item = to_item
+	to_sd.item = from_item
+
+	_update_item_tracking(from_sd, from_item, to_item)
+	_update_item_tracking(to_sd, to_item, from_item)
+
+	_refresh_slot_data_view(from_sd)
+	_refresh_slot_data_view(to_sd)
+
+	var from_is_equipment := from_sd.container_kind == SlotData.CONTAINER_EQUIPMENT
+	var to_is_equipment := to_sd.container_kind == SlotData.CONTAINER_EQUIPMENT
+
+	# An equipment change drives the stats-recalc / save signal chain.
+	if (from_is_equipment or to_is_equipment) and is_instance_valid(equipment_component):
+		equipment_component.mark_changed()
+
+	if multiplayer.is_server():
+		if from_is_equipment:
+			_sync_equipment_slot_to_client(from_sd, true)
+		else:
+			_sync_slot_to_client(from_sd, false)
+		if to_is_equipment:
+			_sync_equipment_slot_to_client(to_sd, true)
+		else:
+			_sync_slot_to_client(to_sd, false)
+
+	_notify_changed()
 
 
 func _sync_slot_to_client(sd: SlotData, trigger_stats_recalc: bool = false):

--- a/scripts/Components/slot_data.gd
+++ b/scripts/Components/slot_data.gd
@@ -10,11 +10,22 @@ extends RefCounted
 ## Server, headless builds, and bots can therefore carry a complete inventory
 ## with zero UI nodes instantiated.
 
+## Which container owns this slot.
+const CONTAINER_INVENTORY := 0
+const CONTAINER_EQUIPMENT := 1
+
 ## The item currently in this slot, or null when empty.
 var item: ItemData = null
 
-## Address key of this slot within its owning container:
-## an int index for inventory slots, set by the component on creation.
+## Owning container kind (CONTAINER_INVENTORY / CONTAINER_EQUIPMENT).
+var container_kind: int = CONTAINER_INVENTORY
+
+## Address key within the owning container: an int index for inventory slots,
+## or the equipment key (ArmorType int / "WEAPON") for equipment slots.
+var key = 0
+
+## Inventory slot index (== key for inventory slots; -1 for equipment slots).
+## Set by the component on creation.
 var index: int = -1
 
 ## Acceptance rules. `allowed_item_type` defaults to ANY (no restriction).


### PR DESCRIPTION
## Summary

Stage 3 — makes the bot equip-swap work with no inventory/equipment UI, the last bot move-path that still touched `Slot` views.

> Stacked on #126 (Stage 2c). Base retargets automatically as the stack merges down.

`bot_brain._evaluate_and_equip()` swapped items by writing `.item` on `Slot` UI nodes and calling `update_display()` — which breaks once a bot scene has no UI.

- New **`InventoryComponent.swap_slot_data(from_sd, to_sd)`** — a UI-independent swap between two `SlotData` (inventory and/or equipment): moves the items, updates tracking, refreshes any bound views, fires the equipment-change signal (drives stats recalc + save), and syncs to the client.
- `SlotData` gains `container_kind` + `key` so a slot is self-addressing.
- `bot_equipment_logic.get_target_slot()` returns a `SlotData`.
- `_evaluate_and_equip()` iterates `get_slots()` and calls `swap_slot_data()`.

### Scope note — why this is smaller than the plan

The plan's Stage 3 also called for an address-based rewrite of the **real-player** transfer/drop RPCs (currently `NodePath`-based). On closer look that's **not needed** for the decouple goal: those RPCs are only ever initiated by real players, and the server keeps real players' full UI, so `NodePath` resolution always succeeds. Bots never touch that path. The bot equip-swap was the only move-path a UI-less bot exercises — so converting it is sufficient. (A future "server spawns UI-less scenes for real players too" effort — already listed as out of scope — would be when the NodePath rewrite becomes worthwhile.)

## Test plan

- [ ] Compiles.
- [ ] Bots pick up gear upgrades and equip them; equipped weapon raises their damage (server-side stat recalc fires).
- [ ] `/bot inspect` shows the bot wearing the upgraded gear.
- [ ] Real players' drag-and-drop equip/unequip/move/drop still work unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)