### PR TITLE
Inventory decouple stage 4: drop the bot UI subtree

### DIFF
--- a/scripts/Bot/bot_manager.gd
+++ b/scripts/Bot/bot_manager.gd
@@ -154,6 +154,17 @@ func _on_bot_spawned(bot_id: int) -> void:
 		push_error("BotManager: Could not find player node for bot %d after spawn." % bot_id)
 		return
 
+	# A bot has no client and never opens a window — drop the entire UI subtree
+	# (HUD, mobile buttons, debug panel, hotbar, buffbar, and the draggable
+	# windows). Safe because inventory/equipment data lives in the components
+	# (SlotData), not the windows. Only free once the inventory's SlotData has
+	# been built (it is, by this point — load_player_inventory ran during spawn);
+	# the guard is belt-and-braces against an unexpected spawn ordering.
+	var inv = player_node.inventory_component
+	var canvas_layer := player_node.get_node_or_null("CanvasLayer")
+	if is_instance_valid(canvas_layer) and is_instance_valid(inv) and not inv.slots_data.is_empty():
+		canvas_layer.queue_free()
+
 	var old_brain = player_node.get_node_or_null("BotBrain")
 	if old_brain:
 		old_brain.queue_free()

--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -761,10 +761,11 @@ func _on_class_changed(new_class_name: String) -> void:
 #region #################### Save & Load System ####################
 ## Returns a dictionary of all ability data for saving.
 func save_abilities() -> Dictionary:
+	# `hotbar` is a UI node; a bot frees its UI subtree, so guard the access.
 	return {
 		"ability_levels": _ability_levels.duplicate(),
 		"available_points": _available_ability_points,
-		"hotbar_config": hotbar.save_hotbar_config()
+		"hotbar_config": hotbar.save_hotbar_config() if is_instance_valid(hotbar) else {}
 	}
 
 
@@ -784,7 +785,8 @@ func load_abilities(data: Dictionary) -> void:
 		_ability_levels[ability_id] = saved_levels[ability_id]
 	
 	_available_ability_points = data.get("available_points", 0)
-	hotbar.load_hotbar_config(data.get("hotbar_config", {}))
+	if is_instance_valid(hotbar):
+		hotbar.load_hotbar_config(data.get("hotbar_config", {}))
 	
 	# Re-apply passives and update UI with loaded data
 	_apply_passive_effects()

--- a/scripts/Components/player_inventory.gd
+++ b/scripts/Components/player_inventory.gd
@@ -11,7 +11,8 @@ var _loading_mode: bool = false
 var monies_amount: int = 0:
 	set(value):
 		monies_amount = clampi(value, 0, MAX_MONIES_AMOUNT)
-		if monies_label:
+		# monies_label is a UI node; a bot frees its UI subtree, so validate it.
+		if is_instance_valid(monies_label):
 			monies_label.text = inventory_component.format_number_with_commas(value)
 		if not _loading_mode:
 			_notify_player_data_changed()


### PR DESCRIPTION
## Summary

Stage 4 — the payoff. A spawned bot now **frees its entire `CanvasLayer`** (HUD, mobile buttons, debug panel, hotbar, buffbar, and all five draggable windows) in `BotManager._on_bot_spawned()`. Bots have no client and never open a window.

> Stacked on #127 (Stage 3). Base retargets automatically as the stack merges down.

### Why this is safe now (and wasn't before)

This is exactly what closed PR #121 tried to do — and it was unsafe then because the `EquipmentWindow`/`InventoryWindow` *held the item data*. After Stages 1-3 the data lives in the components as `SlotData`; the `Slot` nodes are pure views. Freeing the views frees nothing load-bearing — the model survives on the component. Every server-side `slots` access is `is_instance_valid`-guarded or never runs for a bot (verified). The `CanvasLayer` is freed only once the inventory's `slots_data` is built (guaranteed by spawn ordering; guarded regardless).

### Why runtime-free instead of a dedicated `bot_player.tscn`

The plan originally called for a hand-surgered `bot_player.tscn`. The runtime free is strictly lower-risk: no 1283-line scene edit, no separate slot-layout config, no spawn-routing changes. The spawn-stagger fix already absorbs the one-frame instantiation cost; this removes the *ongoing* per-frame `_process`/`_input` cost and the memory of every bot UI node — which was the actual goal.

## Test plan

- [ ] Compiles.
- [ ] Spawn bots — no errors referencing freed HUD/window nodes in the server console.
- [ ] Bots fight, loot, equip upgrades, sell, restock, travel, party — all still work.
- [ ] A real player sees each bot's floating name + HP bar (PlayerWorldHUD is kept — not under CanvasLayer).
- [ ] `/bot inspect <name>` still works (the host's inspect window reads the bot's SlotData).
- [ ] Despawn + respawn a bot — inventory/equipment persist.
- [ ] Real players' own HUD and windows are completely unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)