### PR TITLE
Client-side bot visibility & interaction

### DIFF
--- a/scripts/Bot/bot_manager.gd
+++ b/scripts/Bot/bot_manager.gd
@@ -10,6 +10,9 @@ var _used_names: Dictionary = {}
 var _bot_def_map: Dictionary = {}  # { bot_id: bot_def Dictionary from config }
 var _inspect_window: BotInspectWindow = null
 
+## Emitted (on any peer) when a requested bot data snapshot arrives.
+signal bot_snapshot_received(bot_id: int, snapshot: Dictionary)
+
 const NAME_PREFIXES: Array[String] = [
 	"Shadow", "Iron", "Storm", "Frost", "Fire", "Dark", "Silver", "Golden",
 	"Brave", "Swift", "Wild", "Stone", "Moon", "Star", "Thunder", "Ice",
@@ -186,6 +189,81 @@ func _on_bot_spawned(bot_id: int) -> void:
 			active_bots[bot_id]["map_id"] = current_map
 
 	#print("BotManager: Bot %d brain attached and running." % bot_id)
+
+
+# --- Client-side bot data sync (on-demand snapshots) ---
+
+## [Client -> Server] Request a full data snapshot of a bot. The server
+## replies via receive_bot_snapshot to the requester only.
+@rpc("any_peer", "call_local", "reliable")
+func request_bot_snapshot(bot_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var requester := multiplayer.get_remote_sender_id()
+	if requester == 0:
+		requester = multiplayer.get_unique_id()  # local (host) call
+	receive_bot_snapshot.rpc_id(requester, bot_id, _gather_bot_snapshot(bot_id))
+
+
+## [Server -> Client] Delivers a bot snapshot; listeners use bot_snapshot_received.
+@rpc("authority", "call_local", "reliable")
+func receive_bot_snapshot(bot_id: int, snapshot: Dictionary) -> void:
+	bot_snapshot_received.emit(bot_id, snapshot)
+
+
+## Server-side: collects a bot's full state into an RPC-serializable Dictionary.
+func _gather_bot_snapshot(bot_id: int) -> Dictionary:
+	var node := PlayerManager.get_player_node(bot_id)
+	if not is_instance_valid(node):
+		return {}
+
+	var snap: Dictionary = {
+		"name": node.username,
+		"class": node.class_component.current_class if is_instance_valid(node.class_component) else 0,
+		"level": node.level_component.level if is_instance_valid(node.level_component) else 1,
+		"hp": node.health_component.current_health if is_instance_valid(node.health_component) else 0,
+		"max_hp": node.health_component.max_health if is_instance_valid(node.health_component) else 0,
+		"mp": node.mana_component.current_mana if is_instance_valid(node.mana_component) else 0,
+		"max_mp": node.mana_component.max_mana if is_instance_valid(node.mana_component) else 0,
+		"gold": node.player_inventory.monies_amount if is_instance_valid(node.player_inventory) else 0,
+		"map": MapManager.get_player_map(bot_id),
+		"action": "",
+	}
+
+	var brain = node.get_node_or_null("BotBrain")
+	if brain:
+		snap["action"] = brain.current_action
+
+	# Equipment — keyed by str(equipment key); {} for an empty slot.
+	var eq: Dictionary = {}
+	if is_instance_valid(node.equipment_component):
+		for key in node.equipment_component.slots_data:
+			var esd: SlotData = node.equipment_component.slots_data[key]
+			eq[str(key)] = esd.item.to_dictionary() if esd and esd.item else {}
+	snap["equipment"] = eq
+
+	# Inventory — non-empty slots only.
+	var inv: Array = []
+	if is_instance_valid(node.inventory_component):
+		var slot_list: Array = node.inventory_component.get_slots()
+		for i in slot_list.size():
+			if slot_list[i].item:
+				inv.append({"slot_index": i, "item": slot_list[i].item.to_dictionary()})
+	snap["inventory"] = inv
+
+	# Stats — total/base/bonus per StatType.
+	var stats: Dictionary = {}
+	if is_instance_valid(node.stats_component):
+		for stat_type in node.stats_component.stats:
+			var stat: StatData = node.stats_component.stats[stat_type]
+			stats[stat_type] = {
+				"total": stat.total_value,
+				"base": stat.base_value,
+				"bonus": stat.combined_bonus_value,
+			}
+	snap["stats"] = stats
+
+	return snap
 
 
 func _form_squad_on_map(map_id: String, bot_ids: Array) -> void:

--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -578,10 +578,17 @@ func spawn_projectile(ability: AbilityData, level_stats: AbilityLevelData, targe
 	if current_map and current_map.is_in_group("map_base"):
 		var map_name = current_map.name.replace("Map_", "")
 		var players_on_map = MapManager.get_real_players_on_map(map_name)
+		# A bot's AbilityComponent node may not exist on a client (e.g. mid
+		# map-transition), which makes a node-addressed RPC fail. Route bot
+		# projectiles through MapManager — an autoload that always resolves.
+		var caster_is_bot := BotManager.is_bot(owner.player_id)
 
 		for peer_id in players_on_map:
 			if peer_id != 1: # Server already has it
-				spawn_projectile_client.rpc_id(peer_id, ability.ability_id, level_stats.level, spawn_pos, initial_direction, target_path)
+				if caster_is_bot:
+					MapManager.spawn_bot_projectile.rpc_id(peer_id, owner.player_id, ability.ability_id, level_stats.level, spawn_pos, initial_direction, target_path)
+				else:
+					spawn_projectile_client.rpc_id(peer_id, ability.ability_id, level_stats.level, spawn_pos, initial_direction, target_path)
 	else:
 		# Fallback
 		spawn_projectile_client.rpc(ability.ability_id, level_stats.level, spawn_pos, initial_direction, target_path)

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -176,7 +176,7 @@ func _finalize_player_spawn(player_id: int, map_id: String, spawn_point_name: St
 		if existing_node:
 			# Tell the new player to spawn the existing player (skip for bots)
 			if not _joiner_is_bot:
-				client_spawn_player.rpc_id(player_id, existing_id, existing_node.global_position)
+				client_spawn_player.rpc_id(player_id, existing_id, existing_node.global_position, _player_username(existing_id))
 			# Also update visibility for the existing player
 			update_visibility_for_player(existing_id)
 
@@ -240,7 +240,7 @@ func _spawn_player_on_server_map(player_id: int, map_id: String, spawn_point_nam
 		if BotManager.is_bot(peer_id):
 			continue
 		# RPC each peer to spawn this new player
-		client_spawn_player.rpc_id(peer_id, player_id, player_char.global_position)
+		client_spawn_player.rpc_id(peer_id, player_id, player_char.global_position, _player_username(player_id))
 
 	# Explicitly tell the client which node is theirs (for PlayerManager init)
 	if not BotManager.is_bot(player_id):
@@ -526,33 +526,41 @@ func client_identify_player(player_node_path: String):
 
 
 @rpc("authority", "call_local", "reliable")
-func client_spawn_player(new_player_id: int, spawn_pos: Vector2):
+func client_spawn_player(new_player_id: int, spawn_pos: Vector2, username: String = ""):
 	"""Client: Instantiate a player node manually."""
 	if not is_instance_valid(current_map_instance):
 		return
-	
+
 	var players_node = current_map_instance.get_node_or_null("Players")
 	if not players_node:
 		push_error("Client: Current map missing Players node!")
 		return
-	
+
 	if players_node.has_node(str(new_player_id)):
 		# Already exists
 		if multiplayer.is_server():
 			# Server is authority, do not reset position of existing players
 			return
-			
+
 		var p = players_node.get_node(str(new_player_id))
 		p.global_position = spawn_pos
+		if not username.is_empty():
+			p.set_username(username)
 		return
-		
+
 	var player_scene = load("res://scenes/Player/player.tscn")
 	var player_node = player_scene.instantiate()
 	player_node.name = str(new_player_id)
 	player_node.player_id = new_player_id
 	player_node.global_position = spawn_pos
-	
+
 	players_node.add_child(player_node)
+
+	# Apply the player's name so the floating label and right-click context
+	# menu show it — covers bots, whose username is otherwise never sent to
+	# clients (bot state is server-authoritative).
+	if not username.is_empty():
+		player_node.set_username(username)
 	
 	# Set public_visibility=false for player synchronizers (client-side)
 	# if not multiplayer.is_server():
@@ -656,6 +664,12 @@ func get_real_players_on_map(map_id: String) -> Array:
 func get_player_map(player_id: int) -> String:
 	if not multiplayer.is_server(): return ""
 	return player_current_maps.get(player_id, "")
+
+
+## Username for a player/bot id, used to pass names to clients on spawn.
+func _player_username(id: int) -> String:
+	var info: Dictionary = PlayerManager.get_player_info(id)
+	return info.get("username", "")
 	
 func get_player_map_node(player_id: int) -> Node:
 	if not multiplayer.is_server(): return null

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -581,6 +581,19 @@ func client_despawn_player(player_id_to_remove: int):
 		#print("Client: Despawned player %d" % player_id_to_remove)
 
 
+## [Server -> Client] Spawns a bot's projectile visual. Routed through
+## MapManager (an autoload that always resolves) rather than addressed to the
+## bot's AbilityComponent node, which a client may lack during map transitions.
+@rpc("authority", "call_remote", "reliable")
+func spawn_bot_projectile(caster_id: int, ability_id: String, level: int, start_pos: Vector2, direction: Vector2, target_path: NodePath) -> void:
+	if multiplayer.is_server():
+		return
+	var caster = PlayerManager.get_player_node(caster_id)
+	if not is_instance_valid(caster) or not is_instance_valid(caster.ability_component):
+		return  # bot not present on this client — skip the visual, no error
+	caster.ability_component.spawn_projectile_client(ability_id, level, start_pos, direction, target_path)
+
+
 # === SERVER-SIDE ACKS FROM CLIENTS ===
 
 @rpc("any_peer", "call_local", "reliable")

--- a/scripts/UI/bot_inspect_window.gd
+++ b/scripts/UI/bot_inspect_window.gd
@@ -9,6 +9,8 @@ var scroll_container: ScrollContainer
 var _current_bot_id: int = 0
 var _refresh_timer: float = 0.0
 var _built := false
+## Latest data snapshot for the inspected bot (populated via BotManager RPC).
+var _snapshot: Dictionary = {}
 
 const WINDOW_WIDTH: float = 320.0
 const WINDOW_HEIGHT: float = 500.0
@@ -54,6 +56,7 @@ static func create() -> BotInspectWindow:
 	window.add_theme_stylebox_override("panel", bg)
 
 	window._build_ui()
+	BotManager.bot_snapshot_received.connect(window._on_bot_snapshot)
 	return window
 
 
@@ -214,8 +217,24 @@ func _build_sections() -> void:
 func show_bot(bot_id: int) -> void:
 	_current_bot_id = bot_id
 	_refresh_timer = 0.0
+	_snapshot = {}
 	_built = false
 	_build_sections()
+	_update_content()
+	_request_snapshot()
+
+
+## Asks the server for a fresh snapshot of the inspected bot.
+func _request_snapshot() -> void:
+	if _current_bot_id == 0:
+		return
+	BotManager.request_bot_snapshot.rpc_id(1, _current_bot_id)
+
+
+func _on_bot_snapshot(bot_id: int, snapshot: Dictionary) -> void:
+	if bot_id != _current_bot_id or not visible:
+		return
+	_snapshot = snapshot
 	_update_content()
 
 	var vp_size := get_viewport_rect().size
@@ -227,116 +246,94 @@ func show_bot(bot_id: int) -> void:
 	scroll_container.scroll_vertical = 0
 
 
+## Populates the window from `_snapshot` (filled by the BotManager RPC), so it
+## works on a client where the bot's live components hold no data.
 func _update_content() -> void:
-	if not _built:
-		return
-	var player_node := PlayerManager.get_player_node(_current_bot_id)
-	if not is_instance_valid(player_node):
-		visible = false
+	if not _built or _snapshot.is_empty():
 		return
 
-	var display_name: String
-	if BotManager.is_bot(_current_bot_id):
-		var bot_info: Dictionary = BotManager.active_bots.get(_current_bot_id, {})
-		display_name = bot_info.get("username", "Bot %d" % _current_bot_id)
-	else:
-		display_name = player_node.username if not player_node.username.is_empty() else str(_current_bot_id)
-
+	var display_name: String = _snapshot.get("name", "")
+	if display_name.is_empty():
+		display_name = "Bot %d" % _current_bot_id
 	title_label.text = "Inspect: %s" % display_name
 	_name_label.text = display_name
 
-	var class_str := "Unknown"
-	if is_instance_valid(player_node.class_component):
-		class_str = Constants.ClassType.find_key(player_node.class_component.current_class)
-	var level := 1
-	if is_instance_valid(player_node.level_component):
-		level = player_node.level_component.level
-	_level_label.text = "Level %d %s" % [level, class_str]
+	_level_label.text = "Level %d %s" % [
+		_snapshot.get("level", 1),
+		Constants.ClassType.find_key(_snapshot.get("class", 0)),
+	]
 
-	if is_instance_valid(player_node.health_component):
-		_hp_value.text = "%d / %d" % [player_node.health_component.current_health, player_node.health_component.max_health]
-	else:
-		_hp_value.text = "?"
-	if is_instance_valid(player_node.mana_component):
-		_mp_value.text = "%d / %d" % [player_node.mana_component.current_mana, player_node.mana_component.max_mana]
-	else:
-		_mp_value.text = "?"
-	if is_instance_valid(player_node.player_inventory):
-		_gold_value.text = str(player_node.player_inventory.monies_amount)
-	else:
-		_gold_value.text = "0"
+	_hp_value.text = "%d / %d" % [_snapshot.get("hp", 0), _snapshot.get("max_hp", 0)]
+	_mp_value.text = "%d / %d" % [_snapshot.get("mp", 0), _snapshot.get("max_mp", 0)]
+	_gold_value.text = str(_snapshot.get("gold", 0))
+	_map_value.text = _snapshot.get("map", "")
 
-	_map_value.text = MapManager.get_player_map(player_node.player_id)
+	var action: String = _snapshot.get("action", "")
+	_action_row.visible = not action.is_empty()
+	_action_value.text = action
 
-	var brain = player_node.get_node_or_null("BotBrain")
-	if brain:
-		_action_row.visible = true
-		_action_value.text = brain.current_action
-	else:
-		_action_row.visible = false
+	# --- Equipment (5 fixed rows: Weapon, Head, Chest, Legs, Feet) ---
+	var equipment: Dictionary = _snapshot.get("equipment", {})
+	var eq_keys := [
+		"WEAPON",
+		str(Constants.ArmorType.HEAD), str(Constants.ArmorType.CHEST),
+		str(Constants.ArmorType.LEGS), str(Constants.ArmorType.FEET),
+	]
+	for i in 5:
+		var eq_item_dict: Dictionary = equipment.get(eq_keys[i], {})
+		var eq_item: ItemData = ItemData.from_dictionary(eq_item_dict) if not eq_item_dict.is_empty() else null
+		_update_item_row(_equip_rows[i], eq_item)
 
-	# --- Equipment (update 5 fixed rows in place) ---
-	if is_instance_valid(player_node.equipment_component):
-		var eq = player_node.equipment_component
-		# Access the actual ItemData resources from the SlotData model
-		var slots := [
-		eq.weapon_slot_data.item if eq.weapon_slot_data else null,
-		eq.head_slot_data.item if eq.head_slot_data else null,
-		eq.chest_slot_data.item if eq.chest_slot_data else null,
-		eq.legs_slot_data.item if eq.legs_slot_data else null,
-		eq.feet_slot_data.item if eq.feet_slot_data else null]
-		for i in 5:
-			_update_item_row(_equip_rows[i], slots[i])
-
-	# --- Stats (update value labels in place) ---
-	if is_instance_valid(player_node.stats_component):
-		var stats: Dictionary = player_node.stats_component.stats
-		for stat_type in _stat_rows:
-			var value_label: Label = _stat_rows[stat_type]
-			if stats.has(stat_type):
-				var stat_data = stats[stat_type]
-				var total: int = stat_data.total_value
-				var base: int = stat_data.base_value
-				var bonus: int = stat_data.combined_bonus_value
-				if bonus > 0:
-					value_label.text = "%d (%d+%d)" % [total, base, bonus]
-				else:
-					value_label.text = "%d" % total
+	# --- Stats ---
+	var stats: Dictionary = _snapshot.get("stats", {})
+	for stat_type in _stat_rows:
+		var value_label: Label = _stat_rows[stat_type]
+		if stats.has(stat_type):
+			var s: Dictionary = stats[stat_type]
+			var total: int = s.get("total", 0)
+			var bonus: int = s.get("bonus", 0)
+			if bonus > 0:
+				value_label.text = "%d (%d+%d)" % [total, s.get("base", 0), bonus]
 			else:
-				value_label.text = "0"
+				value_label.text = "%d" % total
+		else:
+			value_label.text = "0"
 
-	# --- Inventory (update value labels in place, rebuild notable list) ---
-	if is_instance_valid(player_node.inventory_component):
-		var equip_count := 0
-		var consumable_count := 0
-		var other_count := 0
-		var total_items := 0
+	# --- Inventory ---
+	var inventory: Array = _snapshot.get("inventory", [])
+	var equip_count := 0
+	var consumable_count := 0
+	var other_count := 0
+	var notable: Array = []
+	for entry in inventory:
+		var inv_item_dict: Dictionary = entry.get("item", {})
+		if inv_item_dict.is_empty():
+			continue
+		var inv_item: ItemData = ItemData.from_dictionary(inv_item_dict)
+		if not inv_item:
+			continue
+		if inv_item is EquipmentData:
+			equip_count += 1
+			if notable.size() < 5:
+				notable.append(inv_item)
+		elif inv_item is ConsumableData:
+			consumable_count += 1
+		else:
+			other_count += 1
 
-		for slot in player_node.inventory_component.get_slots():
-			if slot.item:
-				total_items += 1
-				if slot.item is EquipmentData:
-					equip_count += 1
-				elif slot.item is ConsumableData:
-					consumable_count += 1
-				else:
-					other_count += 1
+	_inv_total_value.text = str(inventory.size())
+	_inv_equip_value.text = str(equip_count)
+	_inv_consumable_value.text = str(consumable_count)
+	_inv_other_value.text = str(other_count)
+	_inv_other_row.visible = other_count > 0
 
-		_inv_total_value.text = str(total_items)
-		_inv_equip_value.text = str(equip_count)
-		_inv_consumable_value.text = str(consumable_count)
-		_inv_other_value.text = str(other_count)
-		_inv_other_row.visible = other_count > 0
-
-		for child in _inv_notable_section.get_children():
-			child.queue_free()
-		var notable_count := 0
-		for slot in player_node.inventory_component.get_slots():
-			if slot.item and slot.item is EquipmentData and notable_count < 5:
-				if notable_count == 0:
-					_inv_notable_section.add_child(_make_label("Notable Items:", 10, Color(0.6, 0.6, 0.7)))
-				_inv_notable_section.add_child(_make_label("  %s (Lv.%d)" % [slot.item.name, slot.item.item_level], 9, Color(0.6, 0.7, 0.8)))
-				notable_count += 1
+	for child in _inv_notable_section.get_children():
+		child.queue_free()
+	for i in notable.size():
+		if i == 0:
+			_inv_notable_section.add_child(_make_label("Notable Items:", 10, Color(0.6, 0.6, 0.7)))
+		var n_item: ItemData = notable[i]
+		_inv_notable_section.add_child(_make_label("  %s (Lv.%d)" % [n_item.name, n_item.item_level], 9, Color(0.6, 0.7, 0.8)))
 
 
 # --- Node Factories (return nodes, don't add to tree) ---
@@ -466,7 +463,7 @@ func _process(delta: float) -> void:
 		_refresh_timer += delta
 		if _refresh_timer >= REFRESH_INTERVAL:
 			_refresh_timer = 0.0
-			_update_content()
+			_request_snapshot()
 
 
 func _gui_input(event: InputEvent) -> void:

--- a/scripts/UI/player_context_menu.gd
+++ b/scripts/UI/player_context_menu.gd
@@ -109,16 +109,20 @@ func _add_separator() -> void:
 
 
 func _get_target_name() -> String:
+	# The spawned node carries the username on every peer (set in
+	# client_spawn_player), so this works for bots on clients too.
+	var player_node := PlayerManager.get_player_node(_target_id)
+	if is_instance_valid(player_node) and not player_node.username.is_empty():
+		return player_node.username
+
+	# Server-side fallbacks (BotManager.active_bots is empty on clients).
 	if _target_is_bot:
 		var bot_info: Dictionary = BotManager.active_bots.get(_target_id, {})
 		return bot_info.get("username", "Bot %d" % _target_id)
-	else:
-		var player_node := PlayerManager.get_player_node(_target_id)
-		if is_instance_valid(player_node) and not player_node.username.is_empty():
-			return player_node.username
-		var player_info = PlayerManager.get_player_info(_target_id)
-		if player_info:
-			return player_info.get("username", str(_target_id))
+
+	var player_info = PlayerManager.get_player_info(_target_id)
+	if player_info:
+		return player_info.get("username", str(_target_id))
 	return str(_target_id)
 
 

--- a/scripts/UI/trade_window.gd
+++ b/scripts/UI/trade_window.gd
@@ -6,6 +6,8 @@ var drag_offset := Vector2()
 var _built := false
 var _target_id: int = 0
 var _refresh_timer: float = 0.0
+## Latest data snapshot for the trade target (their inventory is server-only).
+var _bot_snapshot: Dictionary = {}
 
 const WINDOW_WIDTH: float = 500.0
 const WINDOW_HEIGHT: float = 520.0
@@ -51,6 +53,7 @@ static func create() -> TradeWindow:
 	window._normal_bg = StyleBoxEmpty.new()
 
 	window._build_ui()
+	BotManager.bot_snapshot_received.connect(window._on_bot_snapshot)
 	return window
 
 
@@ -196,6 +199,8 @@ func _create_button_pool(container: VBoxContainer) -> Array[Button]:
 func show_for_target(target_id: int) -> void:
 	_target_id = target_id
 	_refresh_timer = 0.0
+	_bot_snapshot = {}
+	_request_target_snapshot()
 	_refresh_lists()
 
 	var target_name := _get_target_name()
@@ -208,61 +213,84 @@ func show_for_target(target_id: int) -> void:
 	move_to_front()
 
 
+## Asks the server for a fresh snapshot of the trade target (their inventory
+## is server-authoritative — not present on this client).
+func _request_target_snapshot() -> void:
+	if _target_id != 0:
+		BotManager.request_bot_snapshot.rpc_id(1, _target_id)
+
+
+func _on_bot_snapshot(bot_id: int, snapshot: Dictionary) -> void:
+	if bot_id != _target_id or not visible:
+		return
+	_bot_snapshot = snapshot
+	_refresh_lists()
+
+
 func _refresh_lists() -> void:
 	if not _built:
 		return
 
 	var local_player := _get_local_player()
-	var target_node := PlayerManager.get_player_node(_target_id)
-
-	if not is_instance_valid(local_player) or not is_instance_valid(target_node):
+	if not is_instance_valid(local_player):
 		visible = false
 		return
 
 	if is_instance_valid(local_player.player_inventory):
 		_my_gold_label.text = "Gold: %d" % local_player.player_inventory.monies_amount
-	if is_instance_valid(target_node.player_inventory):
-		_bot_gold_label.text = "Gold: %d" % target_node.player_inventory.monies_amount
+	_bot_gold_label.text = "Gold: %d" % int(_bot_snapshot.get("gold", 0))
 
-	_update_button_list(_my_buttons, _my_button_slot, local_player, true)
-	_update_button_list(_bot_buttons, _bot_button_slot, target_node, false)
+	# My items — read live from my own inventory.
+	var my_items: Array = []
+	if is_instance_valid(local_player.inventory_component):
+		var slots: Array = local_player.inventory_component.get_slots()
+		for i in slots.size():
+			if slots[i].item:
+				my_items.append({"index": i, "item": slots[i].item})
+	_update_button_list(_my_buttons, _my_button_slot, my_items, true)
+
+	# Their items — from the snapshot (the target's inventory is server-only).
+	var their_items: Array = []
+	for entry in _bot_snapshot.get("inventory", []):
+		var item: ItemData = ItemData.from_dictionary(entry.get("item", {}))
+		if item:
+			their_items.append({"index": int(entry.get("slot_index", -1)), "item": item})
+	_update_button_list(_bot_buttons, _bot_button_slot, their_items, false)
 
 
-func _update_button_list(buttons: Array[Button], slot_map: Array[int], player_node: MultiplayerPlayerV2, is_mine: bool) -> void:
+## `items` is an Array of { "index": int, "item": ItemData }.
+func _update_button_list(buttons: Array[Button], slot_map: Array[int], items: Array, is_mine: bool) -> void:
 	var btn_idx := 0
 
-	if is_instance_valid(player_node.inventory_component):
-		var slots := player_node.inventory_component.get_slots()
-		for i in slots.size():
-			if btn_idx >= buttons.size():
-				break
-			var slot: SlotData = slots[i]
-			if not slot.item:
-				continue
+	for entry in items:
+		if btn_idx >= buttons.size():
+			break
+		var item: ItemData = entry["item"]
+		var slot_idx: int = entry["index"]
 
-			var btn := buttons[btn_idx]
-			var item_text := slot.item.name
-			if slot.item.can_stack and slot.item.current_stack_amount > 1:
-				item_text += " x%d" % slot.item.current_stack_amount
-			if slot.item is EquipmentData:
-				item_text += " (Lv.%d)" % slot.item.item_level
+		var btn := buttons[btn_idx]
+		var item_text := item.name
+		if item.can_stack and item.current_stack_amount > 1:
+			item_text += " x%d" % item.current_stack_amount
+		if item is EquipmentData:
+			item_text += " (Lv.%d)" % item.item_level
 
-			btn.text = item_text
-			btn.tooltip_text = _build_item_tooltip(slot.item)
-			btn.add_theme_color_override("font_color", _get_rarity_color(slot.item))
-			btn.visible = true
+		btn.text = item_text
+		btn.tooltip_text = _build_item_tooltip(item)
+		btn.add_theme_color_override("font_color", _get_rarity_color(item))
+		btn.visible = true
 
-			# Only reconnect if the slot index changed
-			if slot_map[btn_idx] != i:
-				_disconnect_all(btn)
-				var slot_idx := i
-				if is_mine:
-					btn.pressed.connect(func(): _give_item(slot_idx))
-				else:
-					btn.pressed.connect(func(): _take_item(slot_idx))
-				slot_map[btn_idx] = i
+		# Only reconnect if the slot index changed
+		if slot_map[btn_idx] != slot_idx:
+			_disconnect_all(btn)
+			var captured_idx := slot_idx
+			if is_mine:
+				btn.pressed.connect(func(): _give_item(captured_idx))
+			else:
+				btn.pressed.connect(func(): _take_item(captured_idx))
+			slot_map[btn_idx] = slot_idx
 
-			btn_idx += 1
+		btn_idx += 1
 
 	# Hide remaining buttons
 	for j in range(btn_idx, buttons.size()):
@@ -358,12 +386,16 @@ func _build_item_tooltip(item: ItemData) -> String:
 
 
 func _get_target_name() -> String:
-	if BotManager.is_bot(_target_id):
-		var bot_info: Dictionary = BotManager.active_bots.get(_target_id, {})
-		return bot_info.get("username", "Bot %d" % _target_id)
+	# Prefer the snapshot, then the node's username (set on every peer at spawn).
+	var snap_name: String = _bot_snapshot.get("name", "")
+	if not snap_name.is_empty():
+		return snap_name
 	var player_node := PlayerManager.get_player_node(_target_id)
 	if is_instance_valid(player_node) and not player_node.username.is_empty():
 		return player_node.username
+	if BotManager.is_bot(_target_id):
+		var bot_info: Dictionary = BotManager.active_bots.get(_target_id, {})
+		return bot_info.get("username", "Bot %d" % _target_id)
 	return str(_target_id)
 
 
@@ -409,4 +441,5 @@ func _process(delta: float) -> void:
 		_refresh_timer += delta
 		if _refresh_timer >= REFRESH_INTERVAL:
 			_refresh_timer = 0.0
+			_request_target_snapshot()
 			_refresh_lists()


### PR DESCRIPTION
## Summary

Bots are server-authoritative — clients spawn a bot's *node* but receive none of its data. That broke every bot interaction on a client: name showed `Bot -N`, Inspect was empty, Trade showed only gold, and bot ability use spammed `node not found` errors. This makes bots properly visible/interactable from clients.

### 1. Bot name on clients
`client_spawn_player` now carries the player's `username` and applies it to the spawned node. Covers the floating label, the right-click context menu, and late-joiners. `player_context_menu._get_target_name()` reads the node's username (was reading `BotManager.active_bots`, empty on clients).

### 2. Bot snapshot RPC — Inspect & Trade
New on-demand snapshot, mirroring `MerchantInventory.request_shop_data`:
- `BotManager.request_bot_snapshot` (client→server) gathers name/class/level/HP/MP/gold/map/action/equipment/inventory/stats into an RPC dict; `receive_bot_snapshot` returns it + emits `bot_snapshot_received`.
- `bot_inspect_window` and `trade_window` request a snapshot on open + on their existing refresh timers, and populate from the dict. Host uses `call_local` → instant; one uniform path.

### 3. Bot ability projectile RPC
Bot projectile spawns now route through `MapManager.spawn_bot_projectile` (an autoload — always resolves) instead of being addressed to the bot's `AbilityComponent` node, which a client may lack mid map-transition. Real-player projectiles are unchanged.

## Known follow-up (not in this PR)

`trade_window`'s give/take (`_give_item`/`_take_item`) still mutate inventories locally — so the actual item **transfer** only works host-side. The display is fixed for clients; routing the transfer through a server RPC is a separate change. Flagging so it's not a surprise.

## Test plan

Host + one client + docker, with bots:
- Client sees real bot names (floating label + context menu), not `Bot -N`.
- Client → right-click bot → Inspect → correct level/HP/MP/gold/equipment/inventory/stats; updates live.
- Client → Trade with a bot → sees the bot's items + gold (transfer works host-side).
- Bots cast abilities near a client → no `node not found` errors.
- Host behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)