### PR TITLE
Add Daily Quests: 3 rotating deterministic daily objectives

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,7 @@ BotManager="*res://scripts/Bot/bot_manager.gd"
 TradeManager="*res://scripts/Trading/trade_manager.gd"
 JobAdvancementManager="*res://scripts/Managers/job_advancement_manager.gd"
 QuestManager="*res://scripts/Managers/quest_manager.gd"
+DailyQuestManager="*res://scripts/Managers/daily_quest_manager.gd"
 
 [display]
 
@@ -182,6 +183,11 @@ OpenPartyWindow={
 OpenQuestWindow={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
+OpenDailyQuestWindow={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":85,"key_label":0,"unicode":117,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=93 format=3 uid="uid://bdtdpx0d05sy3"]
+[gd_scene load_steps=94 format=3 uid="uid://bdtdpx0d05sy3"]
 
 [ext_resource type="Script" uid="uid://yibpus3whwuj" path="res://scripts/Player/multiplayer_controller_v2.gd" id="1_an8q1"]
 [ext_resource type="Script" uid="uid://cy1j38lpy671e" path="res://scripts/Player/multiplayer_input.gd" id="2_hxkm2"]
@@ -34,6 +34,7 @@
 [ext_resource type="PackedScene" uid="uid://dh7yjshjnm377" path="res://scenes/UI/inventory_window.tscn" id="24_e8txv"]
 [ext_resource type="PackedScene" uid="uid://cy54vn8lpmh2s" path="res://scenes/UI/equipment_window.tscn" id="25_7iww4"]
 [ext_resource type="PackedScene" uid="uid://1ufb4svp8iwu" path="res://scenes/UI/quest_window.tscn" id="26_quest"]
+[ext_resource type="PackedScene" uid="uid://dqwnd0w5p3k7m" path="res://scenes/UI/daily_quest_window.tscn" id="26_daily"]
 [ext_resource type="FontVariation" uid="uid://bpwl38ly8lvyj" path="res://assets/fonts/DamageNumbersFontVariation.tres" id="27_7iww4"]
 [ext_resource type="SpriteFrames" uid="uid://c05dyrlp5i5bj" path="res://resources/Player/SpriteFrames/Swordsman.tres" id="27_e8txv"]
 [ext_resource type="Texture2D" uid="uid://rmxapeohsar7" path="res://assets/sprites/MinifolksHumans/Outline/MiniTemplate.png" id="29_7iww4"]
@@ -1079,6 +1080,20 @@ offset_bottom = 800.0
 grow_horizontal = 1
 grow_vertical = 1
 
+[node name="DailyQuestWindow" parent="CanvasLayer/MoveableWindows" instance=ExtResource("26_daily")]
+layout_mode = 0
+anchors_preset = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 760.0
+offset_top = 320.0
+offset_right = 1140.0
+offset_bottom = 760.0
+grow_horizontal = 1
+grow_vertical = 1
+
 [node name="PlayerWorldHUD" type="Control" parent="."]
 layout_mode = 3
 anchors_preset = 15
@@ -1281,3 +1296,4 @@ animation_name = "hit"
 [editable path="CanvasLayer/MoveableWindows/InventoryWindow"]
 [editable path="CanvasLayer/MoveableWindows/EquipmentWindow"]
 [editable path="CanvasLayer/MoveableWindows/QuestWindow"]
+[editable path="CanvasLayer/MoveableWindows/DailyQuestWindow"]

--- a/scenes/UI/daily_quest_window.tscn
+++ b/scenes/UI/daily_quest_window.tscn
@@ -1,0 +1,84 @@
+[gd_scene load_steps=4 format=3 uid="uid://dqwnd0w5p3k7m"]
+
+[ext_resource type="Theme" uid="uid://dumv2cfji0owj" path="res://assets/themes/UI_Theme.tres" id="1_theme"]
+[ext_resource type="Script" uid="uid://dq8wn3rkx5p2a" path="res://scripts/UI/daily_quest_window.gd" id="2_script"]
+[ext_resource type="StyleBox" uid="uid://dm8jxifs8rqrm" path="res://assets/UI/Themes/PanelStyleboxTheme.tres" id="3_panel"]
+
+[node name="DailyQuestWindow" type="Panel"]
+visible = false
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -190.0
+offset_top = -220.0
+offset_right = 190.0
+offset_bottom = 220.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_styles/panel = ExtResource("3_panel")
+script = ExtResource("2_script")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 0
+
+[node name="TitleBar" type="HBoxContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 28)
+layout_mode = 2
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer/TitleBar"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.905882, 0.890196, 0.34902, 1)
+theme_override_font_sizes/font_size = 16
+text = "    DAILY QUESTS"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="CloseButton" type="Button" parent="VBoxContainer/TitleBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+text = "X"
+flat = true
+
+[node name="DateLabel" type="Label" parent="VBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+theme_override_font_sizes/font_size = 12
+text = "Today:"
+horizontal_alignment = 1
+
+[node name="HSeparator" type="HSeparator" parent="VBoxContainer"]
+layout_mode = 2
+
+[node name="ContentPanel" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ContentMargin" type="MarginContainer" parent="VBoxContainer/ContentPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 6
+theme_override_constants/margin_top = 6
+theme_override_constants/margin_right = 6
+theme_override_constants/margin_bottom = 6
+
+[node name="QuestListScroll" type="ScrollContainer" parent="VBoxContainer/ContentPanel/ContentMargin"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+
+[node name="QuestListContainer" type="VBoxContainer" parent="VBoxContainer/ContentPanel/ContentMargin/QuestListScroll"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_constants/separation = 6

--- a/scripts/Enemy/enemy_base.gd
+++ b/scripts/Enemy/enemy_base.gd
@@ -238,6 +238,7 @@ func _deferred_death_processing(_killer: Node) -> void:
 			player_node.gain_experience(exp_amount)
 			# Track kill for quest objectives
 			QuestManager.record_enemy_kill(player_node.username, monster_name)
+			DailyQuestManager.record_enemy_kill(player_node.username, monster_name, MapManager.get_player_map(member_id))
 			#print("PID: %s (Party) gained %s exp from %s" % [str(member_id), str(exp_amount), name])
 	else:
 		# No party, distribute EXP only to damage dealers
@@ -253,7 +254,8 @@ func _deferred_death_processing(_killer: Node) -> void:
 				player_node.gain_experience(exp_amount)
 				# Track kill for quest objectives
 				QuestManager.record_enemy_kill(player_node.username, monster_name)
-				
+				DailyQuestManager.record_enemy_kill(player_node.username, monster_name, MapManager.get_player_map(player_id))
+
 	# Spawn drops for all eligible players
 	if not eligible_player_ids_for_drops.is_empty():
 		_spawn_drops(eligible_player_ids_for_drops)

--- a/scripts/Managers/daily_quest_manager.gd
+++ b/scripts/Managers/daily_quest_manager.gd
@@ -1,0 +1,414 @@
+extends Node
+
+## DailyQuestManager — Server-authoritative rotating daily quests.
+##
+## Each day there are exactly 3 daily quests, drawn deterministically from a
+## pool of DailyQuestTemplate definitions. The day's set is derived from a
+## date-based seed (Time.get_date_dict_from_system()), so every player gets the
+## same 3 quests and no server state is needed to decide them.
+##
+## Progress is tracked per-player on the server and persisted through the normal
+## player save flow (the "quests" save category, under the "daily" sub-key).
+## When the calendar date changes, progress and the quest set roll over.
+##
+## On completing a daily quest the server auto-grants EXP + coins via the
+## player's existing gain_experience() / inventory monies functions.
+
+# ── Signals ──────────────────────────────────────────────────────────────────
+signal daily_quest_completed(username: String, template_id: String)
+## Emitted on the client when the server pushes refreshed UI data.
+signal daily_quest_ui_data_received(data: Dictionary)
+
+# ── Quest pool ────────────────────────────────────────────────────────────────
+## How many quests are active each day.
+const DAILY_QUEST_COUNT: int = 3
+
+## All daily-quest templates keyed by template_id.
+var _templates: Dictionary = {}  # template_id -> DailyQuestTemplate
+## Stable, sorted list of template ids (deterministic ordering for the seed).
+var _template_ids: Array[String] = []
+
+# ── Per-player state (server only) ───────────────────────────────────────────
+## Progress: username -> { template_id -> current_count }
+var _progress: Dictionary = {}
+## Claimed (rewarded) daily quests: username -> Array[String] of template_ids
+var _claimed: Dictionary = {}
+## The date string (YYYY-MM-DD) each player's data was last valid for.
+var _player_date: Dictionary = {}
+
+# ── Day-rollover watcher ─────────────────────────────────────────────────────
+var _rollover_timer: Timer
+var _cached_date_seed: int = 0
+
+
+func _ready() -> void:
+	_define_templates()
+	_cached_date_seed = _get_date_seed()
+
+	if not multiplayer or not multiplayer.has_multiplayer_peer() or multiplayer.is_server():
+		# A lightweight timer that checks for a date change while players are
+		# logged in, so quests roll over at midnight without a restart.
+		_rollover_timer = Timer.new()
+		_rollover_timer.name = "DailyRolloverTimer"
+		_rollover_timer.wait_time = 60.0
+		_rollover_timer.one_shot = false
+		_rollover_timer.autostart = true
+		add_child(_rollover_timer)
+		_rollover_timer.timeout.connect(_on_rollover_check)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DAILY QUEST POOL (data — kept as a config array; edit freely)
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _define_templates() -> void:
+	# Kill objectives ----------------------------------------------------------
+	_add_template("dq_kill_any_20", DailyQuestTemplate.DailyObjectiveType.KILL_ENEMIES,
+		"Daily Hunt", "Defeat 20 monsters of any kind.", 20, "", "", 400, 80)
+	_add_template("dq_kill_slime_15", DailyQuestTemplate.DailyObjectiveType.KILL_ENEMIES,
+		"Slime Patrol", "Defeat 15 Slimes.", 15, "Slime", "", 350, 70)
+	_add_template("dq_kill_mushroom_15", DailyQuestTemplate.DailyObjectiveType.KILL_ENEMIES,
+		"Fungal Cleanup", "Defeat 15 Mushrooms.", 15, "Mushroom", "", 350, 70)
+	_add_template("dq_kill_any_40", DailyQuestTemplate.DailyObjectiveType.KILL_ENEMIES,
+		"Monster Purge", "Defeat 40 monsters of any kind.", 40, "", "", 700, 140)
+
+	# Collect objectives -------------------------------------------------------
+	_add_template("dq_collect_any_25", DailyQuestTemplate.DailyObjectiveType.COLLECT_ITEMS,
+		"Daily Forage", "Collect 25 items of any kind.", 25, "", "", 350, 70)
+	_add_template("dq_collect_coin_200", DailyQuestTemplate.DailyObjectiveType.COLLECT_ITEMS,
+		"Coin Run", "Collect 200 Coins from fallen monsters.", 200, "Coin", "", 300, 0)
+	_add_template("dq_collect_any_50", DailyQuestTemplate.DailyObjectiveType.COLLECT_ITEMS,
+		"Pack Rat", "Collect 50 items of any kind.", 50, "", "", 600, 120)
+
+	# Party-quest objective ----------------------------------------------------
+	_add_template("dq_party_quest_1", DailyQuestTemplate.DailyObjectiveType.COMPLETE_PARTY_QUEST,
+		"Team Effort", "Complete a quest while in a party.", 1, "", "", 500, 100)
+	_add_template("dq_party_quest_2", DailyQuestTemplate.DailyObjectiveType.COMPLETE_PARTY_QUEST,
+		"Comrades in Arms", "Complete 2 quests while in a party.", 2, "", "", 800, 160)
+
+	_template_ids = []
+	for id in _templates:
+		_template_ids.append(id)
+	_template_ids.sort()  # stable order so the daily seed is reproducible
+
+
+func _add_template(id: String, obj_type: int, title: String, desc: String,
+		amount: int, target: String, zone: String, exp: int, coins: int) -> void:
+	var t := DailyQuestTemplate.new()
+	t.template_id = id
+	t.objective_type = obj_type
+	t.title = title
+	t.description = desc
+	t.amount = amount
+	t.target = target
+	t.zone = zone
+	t.reward_exp = exp
+	t.reward_coins = coins
+	_templates[id] = t
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DETERMINISTIC DAILY SELECTION
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Current local date as a "YYYY-MM-DD" string. Used as the rollover key.
+func get_today_string() -> String:
+	var d: Dictionary = Time.get_date_dict_from_system()
+	return "%04d-%02d-%02d" % [d.get("year", 0), d.get("month", 0), d.get("day", 0)]
+
+
+## A deterministic integer seed derived from today's date.
+func _get_date_seed() -> int:
+	var d: Dictionary = Time.get_date_dict_from_system()
+	# Distinct multipliers so adjacent days produce very different seeds.
+	return int(d.get("year", 0)) * 10000 + int(d.get("month", 0)) * 100 + int(d.get("day", 0))
+
+
+## The 3 template_ids active today — identical for everyone, no state needed.
+func get_today_template_ids() -> Array:
+	var ids: Array = []
+	if _template_ids.is_empty():
+		return ids
+
+	var count: int = min(DAILY_QUEST_COUNT, _template_ids.size())
+	var rng := RandomNumberGenerator.new()
+	rng.seed = _get_date_seed()
+
+	# Fisher-Yates style draw without replacement from a copy of the id list.
+	var pool: Array = _template_ids.duplicate()
+	for i in range(count):
+		var pick: int = rng.randi_range(0, pool.size() - 1)
+		ids.append(pool[pick])
+		pool.remove_at(pick)
+	return ids
+
+
+func get_template(template_id: String) -> DailyQuestTemplate:
+	return _templates.get(template_id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PROGRESS HOOKS — called from server-side game events
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Called when a player kills an enemy. `zone` is the killer's current map id.
+func record_enemy_kill(username: String, enemy_name: String, zone: String = "") -> void:
+	if not multiplayer.is_server():
+		return
+	_advance(username, DailyQuestTemplate.DailyObjectiveType.KILL_ENEMIES, enemy_name, zone, 1)
+
+
+## Called when a player picks up / collects items.
+func record_item_collected(username: String, item_name: String, amount: int = 1) -> void:
+	if not multiplayer.is_server():
+		return
+	_advance(username, DailyQuestTemplate.DailyObjectiveType.COLLECT_ITEMS, item_name, "", amount)
+
+
+## Called when a player completes a (regular) quest. Counts toward the
+## "Complete a Party Quest" objective only if the player is currently in a
+## party — and only once per quest completion.
+func record_party_quest_completed(username: String) -> void:
+	if not multiplayer.is_server():
+		return
+	_advance(username, DailyQuestTemplate.DailyObjectiveType.COMPLETE_PARTY_QUEST, "", "", 1)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# INTERNAL — PROGRESS TRACKING
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _advance(username: String, obj_type: int, target: String, zone: String, amount: int) -> void:
+	if username.is_empty() or amount <= 0:
+		return
+
+	_ensure_current_day(username)
+
+	var progress: Dictionary = _progress.get(username, {})
+	var claimed: Array = _claimed.get(username, [])
+	var changed: bool = false
+
+	for template_id in get_today_template_ids():
+		if template_id in claimed:
+			continue  # already completed & rewarded today
+		var t: DailyQuestTemplate = _templates.get(template_id)
+		if t == null or t.objective_type != obj_type:
+			continue
+		# Target / zone filters — empty filter means "any".
+		if not t.target.is_empty() and t.target != target:
+			continue
+		if not t.zone.is_empty() and t.zone != zone:
+			continue
+
+		var old_val: int = int(progress.get(template_id, 0))
+		if old_val >= t.amount:
+			continue
+		# Clamp so progress never exceeds the target.
+		var new_val: int = min(old_val + amount, t.amount)
+		progress[template_id] = new_val
+		changed = true
+
+		if new_val >= t.amount:
+			_grant_reward(username, t)
+
+	if changed:
+		_progress[username] = progress
+		_save(username)
+		_push_ui_update(username)
+
+
+func _grant_reward(username: String, t: DailyQuestTemplate) -> void:
+	if not _claimed.has(username):
+		_claimed[username] = []
+	if t.template_id in _claimed[username]:
+		return  # guard against double-grant
+	_claimed[username].append(t.template_id)
+
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	var player_node: MultiplayerPlayerV2 = null
+	if pid != -1:
+		player_node = PlayerManager.get_player_node(pid)
+
+	if is_instance_valid(player_node):
+		if t.reward_exp > 0:
+			player_node.gain_experience(t.reward_exp)
+		if t.reward_coins > 0 and is_instance_valid(player_node.player_inventory):
+			player_node.player_inventory.monies_amount += t.reward_coins
+
+		if not BotManager.is_bot(pid):
+			_send_message(pid, "[Daily Quest] COMPLETED: %s!" % t.title, Color.GOLD)
+			if t.reward_exp > 0:
+				_send_message(pid, "  +%d EXP" % t.reward_exp, Color.GREEN)
+			if t.reward_coins > 0:
+				_send_message(pid, "  +%d Coins" % t.reward_coins, Color.GREEN)
+
+	daily_quest_completed.emit(username, t.template_id)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DAY ROLLOVER
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Ensure a player's progress belongs to the current day; reset it if stale.
+func _ensure_current_day(username: String) -> void:
+	var today: String = get_today_string()
+	if _player_date.get(username, "") != today:
+		_progress[username] = {}
+		_claimed[username] = []
+		_player_date[username] = today
+
+
+func _on_rollover_check() -> void:
+	if not multiplayer.is_server():
+		return
+	var seed_now: int = _get_date_seed()
+	if seed_now == _cached_date_seed:
+		return
+	# The calendar date changed — roll over every tracked player.
+	_cached_date_seed = seed_now
+	var today: String = get_today_string()
+	for username in _progress.keys():
+		_progress[username] = {}
+		_claimed[username] = []
+		_player_date[username] = today
+		_save(username)
+		_push_ui_update(username)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SAVE / LOAD — integrated with player save data (under data["quests"]["daily"])
+# ═══════════════════════════════════════════════════════════════════════════
+
+func save_daily(username: String) -> Dictionary:
+	return {
+		"date": _player_date.get(username, get_today_string()),
+		"progress": _progress.get(username, {}),
+		"claimed": _claimed.get(username, []),
+	}
+
+
+func load_daily(username: String, data: Dictionary) -> void:
+	if not multiplayer.is_server():
+		return
+
+	var saved_date: String = str(data.get("date", ""))
+	var today: String = get_today_string()
+
+	if saved_date != today:
+		# Stale save from a previous day — start fresh for today.
+		_progress[username] = {}
+		_claimed[username] = []
+		_player_date[username] = today
+		return
+
+	var progress: Dictionary = {}
+	var raw_progress = data.get("progress", {})
+	if raw_progress is Dictionary:
+		for key in raw_progress:
+			progress[str(key)] = int(raw_progress[key])
+
+	var claimed: Array = []
+	for cid in data.get("claimed", []):
+		claimed.append(str(cid))
+
+	_progress[username] = progress
+	_claimed[username] = claimed
+	_player_date[username] = today
+
+
+func unregister_player(_username: String) -> void:
+	# Keep data in memory — it's persisted through the save system.
+	pass
+
+
+func _save(username: String) -> void:
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	if pid != -1:
+		var pn = PlayerManager.get_player_node(pid)
+		if pn and SaveManager:
+			SaveManager.queue_save(username, "all", pn)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# UI DATA — RPC bridge to the DailyQuestWindow client UI
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Client → Server: request today's daily-quest UI data.
+@rpc("any_peer", "call_remote", "reliable")
+func request_daily_quest_ui_data() -> void:
+	if not multiplayer.is_server():
+		return
+	var requester_id: int = multiplayer.get_remote_sender_id()
+	var player_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(requester_id)
+	if not player_node:
+		return
+	_send_ui_data(requester_id, player_node.username)
+
+
+## Server → Client: deliver serialized daily-quest UI data.
+@rpc("authority", "call_remote", "reliable")
+func _receive_daily_quest_ui_data(data: Dictionary) -> void:
+	daily_quest_ui_data_received.emit(data)
+
+
+func _push_ui_update(username: String) -> void:
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	if pid == -1:
+		return
+	_send_ui_data(pid, username)
+
+
+func _send_ui_data(peer_id: int, username: String) -> void:
+	if BotManager.is_bot(peer_id):
+		return
+	var data := build_ui_data(username)
+	if multiplayer.get_unique_id() == peer_id:
+		# Host mode: emit directly, no RPC needed.
+		daily_quest_ui_data_received.emit(data)
+	else:
+		_receive_daily_quest_ui_data.rpc_id(peer_id, data)
+
+
+## Build the full daily-quest UI payload for a player. Safe to call directly
+## in host mode; used internally before RPC otherwise.
+func build_ui_data(username: String) -> Dictionary:
+	if multiplayer.is_server():
+		_ensure_current_day(username)
+
+	var progress: Dictionary = _progress.get(username, {})
+	var claimed: Array = _claimed.get(username, [])
+
+	var quests: Array = []
+	for template_id in get_today_template_ids():
+		var t: DailyQuestTemplate = _templates.get(template_id)
+		if t == null:
+			continue
+		var current: int = int(progress.get(template_id, 0))
+		quests.append({
+			"id": t.template_id,
+			"title": t.title,
+			"description": t.description,
+			"amount": t.amount,
+			"current": min(current, t.amount),
+			"completed": current >= t.amount or t.template_id in claimed,
+			"reward_exp": t.reward_exp,
+			"reward_coins": t.reward_coins,
+		})
+
+	return {
+		"date": get_today_string(),
+		"quests": quests,
+	}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# HELPERS
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _send_message(peer_id: int, text: String, color: Color) -> void:
+	_client_receive_daily_message.rpc_id(peer_id, text, color)
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_receive_daily_message(text: String, color: Color) -> void:
+	ChatManager.add_system_message(text, color)

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -394,6 +394,11 @@ func _complete_quest(username: String, quest_id: String) -> void:
 	for item_name in quest.reward_items:
 		_send_message(sender_id, "  +%s" % item_name, Color.GREEN)
 
+	# Count toward the "Complete a Party Quest" daily objective if the player
+	# finished this quest while in a party.
+	if PartyManager.get_player_party_id(sender_id) != -1:
+		DailyQuestManager.record_party_quest_completed(username)
+
 	quest_completed.emit(username, quest_id)
 	_save_quest_data(username)
 	# Push updated quest UI data to the client

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -510,6 +510,7 @@ func get_save_data(update_type: String = "all") -> Dictionary:
 
 	if update_type == "all":
 		data['quests'] = QuestManager.save_quests(username)
+		data['daily_quests'] = DailyQuestManager.save_daily(username)
 
 	return data
 
@@ -599,6 +600,11 @@ func _load_data(data: Dictionary) -> void:
 	var quest_data = data.get("quests", {})
 	if not quest_data.is_empty():
 		QuestManager.load_quests(username, quest_data)
+
+	# Load daily-quest progress (rolls over automatically if the date changed)
+	var daily_quest_data = data.get("daily_quests", {})
+	if not daily_quest_data.is_empty():
+		DailyQuestManager.load_daily(username, daily_quest_data)
 
 	_is_loading_data = false
 

--- a/scripts/Resources/ItemSystem/DroppedItem.gd
+++ b/scripts/Resources/ItemSystem/DroppedItem.gd
@@ -206,6 +206,7 @@ func _pickup_item(picking_player: MultiplayerPlayerV2 = null) -> void:
 
 		# Track item collection for quest objectives
 		QuestManager.record_item_collected(player_to_give_item.username, item_data.name, stack_amount)
+		DailyQuestManager.record_item_collected(player_to_give_item.username, item_data.name, stack_amount)
 
 	# RPC to client to show log message
 		if not BotManager.is_bot(player_to_give_item.player_id):

--- a/scripts/Resources/QuestSystem/DailyQuestTemplate.gd
+++ b/scripts/Resources/QuestSystem/DailyQuestTemplate.gd
@@ -1,0 +1,32 @@
+class_name DailyQuestTemplate
+extends Resource
+
+## Defines a single daily-quest template that can be drawn into the day's
+## rotating pool. A deterministic daily seed picks 3 of these each day, so the
+## set is identical for every player and requires no server state to decide.
+
+enum DailyObjectiveType {
+	KILL_ENEMIES,      # Kill `amount` enemies (optionally a specific type)
+	COLLECT_ITEMS,     # Collect `amount` items (optionally a specific item)
+	COMPLETE_PARTY_QUEST,  # Complete a quest while in a party
+}
+
+## Stable identifier used in save data — must stay unique within the pool.
+@export var template_id: String = ""
+## Objective category this template tracks.
+@export var objective_type: DailyObjectiveType = DailyObjectiveType.KILL_ENEMIES
+## Display name shown in the UI.
+@export var title: String = ""
+## Longer description shown in the UI.
+@export_multiline var description: String = ""
+## How many of the objective must be done to complete the quest.
+@export var amount: int = 1
+## Optional filter — for KILL_ENEMIES the enemy monster_name, for
+## COLLECT_ITEMS the item name. Empty string means "any".
+@export var target: String = ""
+## Optional zone/map id filter for KILL_ENEMIES. Empty means "any zone".
+@export var zone: String = ""
+
+# ── Rewards ──────────────────────────────────────────────────────────────────
+@export var reward_exp: int = 0
+@export var reward_coins: int = 0

--- a/scripts/Resources/QuestSystem/DailyQuestTemplate.gd.uid
+++ b/scripts/Resources/QuestSystem/DailyQuestTemplate.gd.uid
@@ -1,0 +1,1 @@
+uid://dq7tmp4lb8c3v

--- a/scripts/UI/daily_quest_window.gd
+++ b/scripts/UI/daily_quest_window.gd
@@ -1,0 +1,171 @@
+class_name DailyQuestWindow
+extends Panel
+
+## Daily Quests window — shows today's 3 rotating daily objectives, each with a
+## progress bar (e.g. 7/20) and an auto-grant indicator on completion.
+##
+## Rewards are granted automatically by the server the moment a quest's
+## objective is met; this panel is purely a tracker. Data is requested from the
+## server via RPC (or built directly in host mode).
+
+@onready var title_label: Label = %TitleLabel
+@onready var close_button: Button = %CloseButton
+@onready var date_label: Label = %DateLabel
+@onready var quest_list: VBoxContainer = %QuestListContainer
+
+var player: MultiplayerPlayerV2
+
+var is_dragging: bool = false
+var drag_offset: Vector2 = Vector2.ZERO
+
+
+func _ready() -> void:
+	add_to_group("ui_window")
+
+	if owner is MultiplayerPlayerV2:
+		player = owner as MultiplayerPlayerV2
+
+	close_button.pressed.connect(func(): self.visible = false)
+	DailyQuestManager.daily_quest_ui_data_received.connect(_on_data_received)
+
+
+func _process(_delta: float) -> void:
+	if not is_instance_valid(player):
+		return
+
+	if multiplayer.get_unique_id() == player.player_id:
+		if Input.is_action_just_pressed("OpenDailyQuestWindow"):
+			if self.visible:
+				self.visible = false
+			elif not InputManager.is_locked():
+				self.visible = true
+				_request_data()
+
+	if is_dragging:
+		var new_pos := get_global_mouse_position() - drag_offset
+		var vp := get_viewport_rect().size
+		var win := size
+		new_pos.x = clamp(new_pos.x, 0, vp.x - win.x)
+		new_pos.y = clamp(new_pos.y, 0, vp.y - win.y)
+		global_position = new_pos
+
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			if title_label.get_global_rect().has_point(get_global_mouse_position()):
+				is_dragging = true
+				drag_offset = get_global_mouse_position() - global_position
+				self.move_to_front()
+		else:
+			is_dragging = false
+
+
+# ── Data fetching ────────────────────────────────────────────────────────────
+
+func _request_data() -> void:
+	if not is_instance_valid(player):
+		return
+	if multiplayer.is_server():
+		# Host mode: build data directly.
+		_on_data_received(DailyQuestManager.build_ui_data(player.username))
+	else:
+		DailyQuestManager.request_daily_quest_ui_data.rpc_id(1)
+
+
+func _on_data_received(data: Dictionary) -> void:
+	# Only react when this window is visible to avoid needless rebuilds.
+	if not visible:
+		return
+	_refresh(data)
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+func _refresh(data: Dictionary) -> void:
+	date_label.text = "Today: %s" % data.get("date", "")
+
+	for child in quest_list.get_children():
+		child.queue_free()
+
+	var quests: Array = data.get("quests", [])
+	if quests.is_empty():
+		var empty := Label.new()
+		empty.text = "No daily quests available."
+		empty.add_theme_color_override("font_color", Color(0.7, 0.7, 0.7))
+		quest_list.add_child(empty)
+		return
+
+	for q in quests:
+		quest_list.add_child(_build_quest_entry(q))
+
+
+func _build_quest_entry(q: Dictionary) -> Control:
+	var completed: bool = q.get("completed", false)
+	var current: int = q.get("current", 0)
+	var amount: int = max(1, q.get("amount", 1))
+
+	var panel := PanelContainer.new()
+	panel.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", 8)
+	margin.add_theme_constant_override("margin_right", 8)
+	margin.add_theme_constant_override("margin_top", 6)
+	margin.add_theme_constant_override("margin_bottom", 6)
+	panel.add_child(margin)
+
+	var vbox := VBoxContainer.new()
+	vbox.add_theme_constant_override("separation", 4)
+	margin.add_child(vbox)
+
+	# Title row — name + status badge.
+	var title_row := HBoxContainer.new()
+	var name_lbl := Label.new()
+	name_lbl.text = q.get("title", "")
+	name_lbl.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	if completed:
+		name_lbl.add_theme_color_override("font_color", Color.GREEN)
+	else:
+		name_lbl.add_theme_color_override("font_color", Color(0.95, 0.85, 0.4))
+	title_row.add_child(name_lbl)
+
+	var status_lbl := Label.new()
+	status_lbl.text = "CLAIMED" if completed else "%d / %d" % [current, amount]
+	status_lbl.add_theme_color_override("font_color",
+		Color.GREEN if completed else Color(0.7, 0.85, 1.0))
+	title_row.add_child(status_lbl)
+	vbox.add_child(title_row)
+
+	# Description.
+	var desc_lbl := Label.new()
+	desc_lbl.text = q.get("description", "")
+	desc_lbl.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	desc_lbl.add_theme_color_override("font_color", Color(0.8, 0.8, 0.8))
+	desc_lbl.add_theme_font_size_override("font_size", 12)
+	vbox.add_child(desc_lbl)
+
+	# Progress bar.
+	var bar := ProgressBar.new()
+	bar.min_value = 0
+	bar.max_value = amount
+	bar.value = current
+	bar.show_percentage = false
+	bar.custom_minimum_size = Vector2(0, 14)
+	vbox.add_child(bar)
+
+	# Rewards line.
+	var reward_lbl := Label.new()
+	var parts: Array = []
+	var exp: int = q.get("reward_exp", 0)
+	var coins: int = q.get("reward_coins", 0)
+	if exp > 0:
+		parts.append("%d EXP" % exp)
+	if coins > 0:
+		parts.append("%d Coins" % coins)
+	reward_lbl.text = "Reward: " + (", ".join(PackedStringArray(parts)) if not parts.is_empty() else "—")
+	reward_lbl.add_theme_color_override("font_color", Color.GOLD)
+	reward_lbl.add_theme_font_size_override("font_size", 12)
+	vbox.add_child(reward_lbl)
+
+	return panel

--- a/scripts/UI/daily_quest_window.gd.uid
+++ b/scripts/UI/daily_quest_window.gd.uid
@@ -1,0 +1,1 @@
+uid://dq8wn3rkx5p2a


### PR DESCRIPTION
## Summary

Implements **Daily Quests** (issue #13): 3 rotating daily objectives that grant EXP + coins.

- New `DailyQuestManager` autoload — server-authoritative, self-contained (named distinctly from any future `DailyChallengeManager`).
- New `DailyQuestTemplate` resource defines the objective pool and reward values as data.
- Each day's 3 quests are drawn **deterministically** from the pool using a date-based seed (`Time.get_date_dict_from_system()`), so every player gets the same set with zero server state needed to decide them.
- Objective types: **Kill X enemies** (optional type/zone filter), **Collect Y items** (optional item filter), **Complete a Party Quest** (counts a regular quest completed while in a party).
- Progress is tracked per-player on the server and persisted via the existing save flow (`daily_quests` key in player save data). Resets at midnight server time — when the date changes, progress and the quest set roll over (a lightweight 60s timer rolls over logged-in players; stale saves roll over on load).
- On completion the server auto-grants EXP + coins via the existing `gain_experience()` / inventory monies functions, and notifies the player in chat.
- Draggable `DailyQuestWindow` UI panel (toggle with the **U** key) showing today's 3 quests with progress bars (e.g. 7/20), reward info, and a CLAIMED badge.

## Implementation notes

- Hooks into existing server-side events instead of polling: enemy death (`enemy_base.gd`), item pickup (`DroppedItem.gd`), and quest completion (`quest_manager.gd`).
- Edge cases handled: progress clamped to target (no overshoot), save/load round-trip, day rollover while logged in, party-quest counted once per quest completion.

## Test plan

- [ ] Kill enemies / collect items and confirm daily progress advances and clamps at the target
- [ ] Complete a regular quest while in a party and confirm the PQ daily objective advances
- [ ] Confirm EXP + coins are granted automatically on completion and a chat message appears
- [ ] Open the panel with `U`, verify it is draggable and shows 3 quests with progress bars
- [ ] Verify progress survives a save/load round-trip and rolls over when the date changes

Closes #13