### PR TITLE
Add Daily Co-op Challenges (#100)

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,7 @@ BotManager="*res://scripts/Bot/bot_manager.gd"
 TradeManager="*res://scripts/Trading/trade_manager.gd"
 JobAdvancementManager="*res://scripts/Managers/job_advancement_manager.gd"
 QuestManager="*res://scripts/Managers/quest_manager.gd"
+DailyChallengeManager="*res://scripts/Managers/daily_challenge_manager.gd"
 
 [display]
 
@@ -182,6 +183,11 @@ OpenPartyWindow={
 OpenQuestWindow={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
+OpenDailyChallengeWindow={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":74,"key_label":0,"unicode":106,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=93 format=3 uid="uid://bdtdpx0d05sy3"]
+[gd_scene load_steps=94 format=3 uid="uid://bdtdpx0d05sy3"]
 
 [ext_resource type="Script" uid="uid://yibpus3whwuj" path="res://scripts/Player/multiplayer_controller_v2.gd" id="1_an8q1"]
 [ext_resource type="Script" uid="uid://cy1j38lpy671e" path="res://scripts/Player/multiplayer_input.gd" id="2_hxkm2"]
@@ -34,6 +34,7 @@
 [ext_resource type="PackedScene" uid="uid://dh7yjshjnm377" path="res://scenes/UI/inventory_window.tscn" id="24_e8txv"]
 [ext_resource type="PackedScene" uid="uid://cy54vn8lpmh2s" path="res://scenes/UI/equipment_window.tscn" id="25_7iww4"]
 [ext_resource type="PackedScene" uid="uid://1ufb4svp8iwu" path="res://scenes/UI/quest_window.tscn" id="26_quest"]
+[ext_resource type="PackedScene" uid="uid://dcclwindow1a2b3" path="res://scenes/UI/daily_challenge_window.tscn" id="26_dailychal"]
 [ext_resource type="FontVariation" uid="uid://bpwl38ly8lvyj" path="res://assets/fonts/DamageNumbersFontVariation.tres" id="27_7iww4"]
 [ext_resource type="SpriteFrames" uid="uid://c05dyrlp5i5bj" path="res://resources/Player/SpriteFrames/Swordsman.tres" id="27_e8txv"]
 [ext_resource type="Texture2D" uid="uid://rmxapeohsar7" path="res://assets/sprites/MinifolksHumans/Outline/MiniTemplate.png" id="29_7iww4"]
@@ -1076,6 +1077,20 @@ offset_left = 720.0
 offset_top = 290.0
 offset_right = 1180.0
 offset_bottom = 800.0
+grow_horizontal = 1
+grow_vertical = 1
+
+[node name="DailyChallengeWindow" parent="CanvasLayer/MoveableWindows" instance=ExtResource("26_dailychal")]
+layout_mode = 0
+anchors_preset = 0
+anchor_left = 0.0
+anchor_top = 0.0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_left = 200.0
+offset_top = 300.0
+offset_right = 580.0
+offset_bottom = 600.0
 grow_horizontal = 1
 grow_vertical = 1
 

--- a/scenes/UI/daily_challenge_window.tscn
+++ b/scenes/UI/daily_challenge_window.tscn
@@ -1,0 +1,127 @@
+[gd_scene load_steps=4 format=3 uid="uid://dcclwindow1a2b3"]
+
+[ext_resource type="Theme" uid="uid://dumv2cfji0owj" path="res://assets/themes/UI_Theme.tres" id="1_theme"]
+[ext_resource type="Script" path="res://scripts/UI/daily_challenge_window.gd" id="2_script"]
+[ext_resource type="StyleBox" uid="uid://dm8jxifs8rqrm" path="res://assets/UI/Themes/PanelStyleboxTheme.tres" id="3_panel"]
+
+[node name="DailyChallengeWindow" type="Panel"]
+visible = false
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -190.0
+offset_top = -150.0
+offset_right = 190.0
+offset_bottom = 150.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("1_theme")
+theme_override_styles/panel = ExtResource("3_panel")
+script = ExtResource("2_script")
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 0
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/separation = 4
+
+[node name="TitleBar" type="HBoxContainer" parent="VBoxContainer"]
+custom_minimum_size = Vector2(0, 28)
+layout_mode = 2
+
+[node name="TitleLabel" type="Label" parent="VBoxContainer/TitleBar"]
+unique_name_in_owner = true
+layout_mode = 2
+size_flags_horizontal = 3
+theme_override_colors/font_color = Color(0.905882, 0.890196, 0.34902, 1)
+theme_override_font_sizes/font_size = 16
+text = "    DAILY CO-OP CHALLENGE"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="CloseButton" type="Button" parent="VBoxContainer/TitleBar"]
+unique_name_in_owner = true
+layout_mode = 2
+focus_mode = 0
+text = "X"
+flat = true
+
+[node name="ContentPanel" type="PanelContainer" parent="VBoxContainer"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="ContentMargin" type="MarginContainer" parent="VBoxContainer/ContentPanel"]
+layout_mode = 2
+theme_override_constants/margin_left = 10
+theme_override_constants/margin_top = 8
+theme_override_constants/margin_right = 10
+theme_override_constants/margin_bottom = 8
+
+[node name="ContentVBox" type="VBoxContainer" parent="VBoxContainer/ContentPanel/ContentMargin"]
+layout_mode = 2
+size_flags_vertical = 3
+theme_override_constants/separation = 6
+
+[node name="ChallengeNameLabel" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(1, 0.85, 0.4, 1)
+theme_override_font_sizes/font_size = 15
+text = "Challenge"
+autowrap_mode = 2
+
+[node name="TypeLabel" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.6, 0.8, 1, 1)
+text = "[Type]"
+
+[node name="DescLabel" type="RichTextLabel" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 70)
+layout_mode = 2
+bbcode_enabled = true
+fit_content = true
+scroll_active = false
+
+[node name="ProgressSep" type="HSeparator" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+layout_mode = 2
+
+[node name="ProgressHeader" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+layout_mode = 2
+text = "Progress:"
+
+[node name="ProgressBar" type="ProgressBar" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 18)
+layout_mode = 2
+show_percentage = false
+
+[node name="ProgressLabel" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+horizontal_alignment = 1
+text = "0 / 0"
+
+[node name="RewardLabel" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.4, 0.9, 0.4, 1)
+text = "Reward:"
+autowrap_mode = 2
+
+[node name="Spacer" type="Control" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+layout_mode = 2
+size_flags_vertical = 3
+
+[node name="StatusLabel" type="Label" parent="VBoxContainer/ContentPanel/ContentMargin/ContentVBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_colors/font_color = Color(0.7, 0.85, 1, 1)
+text = "Progress only counts in a party of 2+."
+horizontal_alignment = 1
+autowrap_mode = 2

--- a/scripts/Enemy/enemy_base.gd
+++ b/scripts/Enemy/enemy_base.gd
@@ -238,6 +238,12 @@ func _deferred_death_processing(_killer: Node) -> void:
 			player_node.gain_experience(exp_amount)
 			# Track kill for quest objectives
 			QuestManager.record_enemy_kill(player_node.username, monster_name)
+			# Track kill for daily co-op challenges (party-gated — only counts
+			# while the player is in a party of 2+ on the correct map).
+			DailyChallengeManager.record_party_enemy_kill(
+				player_node.username, monster_name, _get_map_name(), players_to_reward)
+			DailyChallengeManager.record_party_boss_kill(
+				player_node.username, monster_name, players_to_reward)
 			#print("PID: %s (Party) gained %s exp from %s" % [str(member_id), str(exp_amount), name])
 	else:
 		# No party, distribute EXP only to damage dealers
@@ -571,18 +577,20 @@ func _exit_tree():
 	cleanup_before_removal()
 
 
-func _get_players_on_same_map() -> Array:
-	if not multiplayer.is_server(): return []
-	
-	# Try to find map by walking up the tree to find a parent map container
+## Returns the map id this enemy belongs to (e.g. "game"), or "" if unknown.
+func _get_map_name() -> String:
 	var parent = get_parent()
-	var map_name = ""
 	while parent:
 		if parent.name.begins_with("Map_"):
-			map_name = parent.name.replace("Map_", "")
-			break
+			return parent.name.replace("Map_", "")
 		parent = parent.get_parent()
-	
+	return ""
+
+
+func _get_players_on_same_map() -> Array:
+	if not multiplayer.is_server(): return []
+
+	var map_name = _get_map_name()
 	if map_name != "":
 		return MapManager.get_players_on_map(map_name)
 	return []

--- a/scripts/Managers/daily_challenge_manager.gd
+++ b/scripts/Managers/daily_challenge_manager.gd
@@ -1,0 +1,630 @@
+extends Node
+
+## DailyChallengeManager — Server-authoritative Daily Co-op Challenges.
+##
+## Each day a single rotating challenge is active. Challenges grant BONUS
+## rewards for completing content WITH A PARTY (party of 2+). Solo progress
+## never counts — the feature is party-gated by design.
+##
+## The active challenge is chosen DETERMINISTICALLY from a fixed pool using
+## today's date as a seed, so every player (and the server) independently
+## agree on which challenge is active without any shared state.
+##
+## Progress is tracked per-player on the server and persisted through the
+## normal player save flow (see MultiplayerPlayerV2.get_save_data / _load_data).
+##
+## NOTE: This is a separate system from QuestManager (regular quests) and the
+## planned DailyQuestManager (issue #13). Do not merge them.
+
+# ── Signals ──────────────────────────────────────────────────────────────────
+signal challenge_completed(username: String, challenge_id: String)
+signal challenge_progress_updated(username: String, progress: int)
+## Emitted on the client when the server pushes updated UI data.
+signal challenge_ui_data_received(data: Dictionary)
+
+# ── Challenge type enum ─────────────────────────────────────────────────────
+enum ChallengeType {
+	PARTY_KILL,       ## Kill N enemies on a zone with a party of 2+
+	SPEED,            ## Kill N enemies within a time limit with a party of 2+
+	CLASS_DIVERSITY,  ## Kill N enemies with a party that has all 4 classes
+	BOSS_RUSH,        ## Defeat a boss with a full party of 4
+}
+
+# ── Reward type enum ────────────────────────────────────────────────────────
+enum RewardType {
+	BONUS_EXP,        ## Flat bonus EXP granted to the player
+	BONUS_GOLD,       ## Flat bonus coins granted to the player
+	EXP_BUFF,         ## Time-limited EXP multiplier (e.g. double EXP for 30 min)
+	EXTRA_DROP_ROLLS, ## Bonus drop rolls — granted as a bonus loot item bundle
+}
+
+# ── Tunables ────────────────────────────────────────────────────────────────
+## EXP multiplier applied by the Speed Challenge reward buff.
+const EXP_BUFF_MULTIPLIER: float = 2.0
+## Duration of the Speed Challenge EXP buff in seconds (30 minutes).
+const EXP_BUFF_DURATION: float = 1800.0
+
+# ── Challenge Pool (data-driven, defined in code like QuestManager) ─────────
+## Each entry: { id, type, title, description, params{}, reward{} }
+var _challenge_pool: Array = []
+
+# ── Per-player state (server only) ──────────────────────────────────────────
+## Progress for the player's CURRENT active challenge.
+##   username -> { "challenge_id": String, "progress": int, "completed": bool,
+##                 "speed_deadline": float (unix, 0 if n/a) }
+var _player_progress: Dictionary = {}
+## Active EXP buffs from a completed Speed Challenge.
+##   username -> unix timestamp when the buff expires
+var _exp_buff_expiry: Dictionary = {}
+
+## The challenge_id active "today" — recomputed on day rollover.
+var _current_challenge_id: String = ""
+## The date string (YYYY-MM-DD) the current challenge was computed for.
+var _current_date_key: String = ""
+
+# Midnight-rollover check timer.
+var _rollover_timer: Timer
+
+
+func _ready() -> void:
+	_define_challenges()
+	_refresh_active_challenge()
+
+	# Day-rollover watcher — checks once a minute whether the date changed.
+	_rollover_timer = Timer.new()
+	_rollover_timer.name = "RolloverTimer"
+	_rollover_timer.wait_time = 60.0
+	_rollover_timer.autostart = true
+	_rollover_timer.one_shot = false
+	add_child(_rollover_timer)
+	_rollover_timer.timeout.connect(_on_rollover_check)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CHALLENGE DEFINITIONS
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _define_challenges() -> void:
+	# --- Party Kill Challenges (one per combat zone) ---
+	_add_challenge("dc_party_kill_game", ChallengeType.PARTY_KILL,
+		"Party Hunt: Green Fields",
+		"Kill 30 enemies in the Green Fields with a party of 2 or more.",
+		{"map": "game", "amount": 30},
+		{"type": RewardType.EXTRA_DROP_ROLLS, "item": "Coin", "amount": 500})
+
+	_add_challenge("dc_party_kill_game2", ChallengeType.PARTY_KILL,
+		"Party Hunt: Deep Caverns",
+		"Kill 30 enemies in the Deep Caverns with a party of 2 or more.",
+		{"map": "game2", "amount": 30},
+		{"type": RewardType.EXTRA_DROP_ROLLS, "item": "Coin", "amount": 800})
+
+	_add_challenge("dc_party_kill_game3", ChallengeType.PARTY_KILL,
+		"Party Hunt: Astral Reach",
+		"Kill 30 enemies in the Astral Reach with a party of 2 or more.",
+		{"map": "game3", "amount": 30},
+		{"type": RewardType.EXTRA_DROP_ROLLS, "item": "Coin", "amount": 1200})
+
+	# --- Speed Challenge ---
+	_add_challenge("dc_speed", ChallengeType.SPEED,
+		"Blitz Run",
+		"Kill 50 enemies within 10 minutes while in a party of 2 or more. "
+		+ "Reward: double EXP for 30 minutes!",
+		{"amount": 50, "time_limit": 600.0},
+		{"type": RewardType.EXP_BUFF})
+
+	# --- Class Diversity Challenge ---
+	_add_challenge("dc_class_diversity", ChallengeType.CLASS_DIVERSITY,
+		"United We Stand",
+		"Kill 40 enemies in a party that has all 4 classes represented "
+		+ "(Swordsman, Archer, Mage, Rogue).",
+		{"amount": 40},
+		{"type": RewardType.BONUS_EXP, "amount": 5000})
+
+	# --- Boss Rush Challenge ---
+	_add_challenge("dc_boss_rush", ChallengeType.BOSS_RUSH,
+		"Warlord's Bane",
+		"Defeat the Eternal Warlord with a full party of 4.",
+		{"boss": "Eternal Warlord", "party_size": 4},
+		{"type": RewardType.EXTRA_DROP_ROLLS, "item": "Coin", "amount": 3000})
+
+
+func _add_challenge(id: String, type: ChallengeType, title: String,
+		desc: String, params: Dictionary, reward: Dictionary) -> void:
+	_challenge_pool.append({
+		"id": id,
+		"type": type,
+		"title": title,
+		"description": desc,
+		"params": params,
+		"reward": reward,
+	})
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# DETERMINISTIC DAILY SEED
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Returns the date key (YYYY-MM-DD) for the system's current date.
+func _today_key() -> String:
+	var d: Dictionary = Time.get_date_dict_from_system()
+	return "%04d-%02d-%02d" % [d.get("year", 0), d.get("month", 0), d.get("day", 0)]
+
+
+## Deterministically picks the challenge index for a given date key. Every
+## player and the server compute the same value with no shared state.
+func _challenge_index_for_date(date_key: String) -> int:
+	if _challenge_pool.is_empty():
+		return 0
+	# Hash the date string to a stable integer, then mod into the pool.
+	var seed_val: int = abs(date_key.hash())
+	return seed_val % _challenge_pool.size()
+
+
+## Recomputes the active challenge for today. If the day changed, resets all
+## tracked player progress (challenge of the day has rotated).
+func _refresh_active_challenge() -> void:
+	var today: String = _today_key()
+	if today == _current_date_key and not _current_challenge_id.is_empty():
+		return  # No change.
+
+	var idx: int = _challenge_index_for_date(today)
+	var new_id: String = _challenge_pool[idx].get("id", "")
+
+	var day_rolled: bool = not _current_date_key.is_empty() and today != _current_date_key
+	_current_date_key = today
+	_current_challenge_id = new_id
+
+	if day_rolled:
+		# A new day — every player's progress resets to the new challenge.
+		_player_progress.clear()
+		#print("DailyChallengeManager: Day rolled over. New challenge: %s" % new_id)
+
+
+func _on_rollover_check() -> void:
+	var prev_id: String = _current_challenge_id
+	_refresh_active_challenge()
+	if multiplayer.is_server() and _current_challenge_id != prev_id:
+		# Push fresh UI to every connected real player.
+		for node in get_tree().get_nodes_in_group("Players"):
+			if is_instance_valid(node) and "player_id" in node and "username" in node:
+				if not BotManager.is_bot(node.player_id):
+					_send_ui_data(node.player_id, node.username)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PUBLIC API — challenge lookup
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Returns the config dictionary of today's active challenge (or {} if none).
+func get_active_challenge() -> Dictionary:
+	_refresh_active_challenge()
+	for c in _challenge_pool:
+		if c.get("id", "") == _current_challenge_id:
+			return c
+	return {}
+
+
+func get_active_challenge_id() -> String:
+	_refresh_active_challenge()
+	return _current_challenge_id
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# PROGRESS TRACKING — called from game systems (server only)
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Returns the mutable per-player progress record, creating it if needed and
+## migrating it to today's challenge if it is stale.
+func _get_progress_record(username: String) -> Dictionary:
+	var active_id: String = get_active_challenge_id()
+	var rec: Dictionary = _player_progress.get(username, {})
+	if rec.is_empty() or rec.get("challenge_id", "") != active_id:
+		# New player or challenge rotated since last tracked — fresh record.
+		rec = {
+			"challenge_id": active_id,
+			"progress": 0,
+			"completed": false,
+			"speed_deadline": 0.0,
+		}
+		_player_progress[username] = rec
+	return rec
+
+
+## Called from EnemyBase when a player gets credit for an enemy kill.
+## party_member_ids: ids of party members on the same map (incl. the killer);
+## empty/size 1 means the player was effectively solo and it does not count.
+func record_party_enemy_kill(username: String, enemy_name: String, map_id: String,
+		party_member_ids: Array) -> void:
+	if not multiplayer.is_server():
+		return
+
+	# Party gate: must be in a party of 2+.
+	if party_member_ids.size() < 2:
+		return
+
+	var challenge: Dictionary = get_active_challenge()
+	if challenge.is_empty():
+		return
+
+	var type: int = challenge.get("type", -1)
+	match type:
+		ChallengeType.PARTY_KILL:
+			var params: Dictionary = challenge.get("params", {})
+			if map_id != params.get("map", ""):
+				return  # Wrong zone.
+			_advance_kill_progress(username, challenge)
+		ChallengeType.SPEED:
+			_advance_speed_progress(username, challenge)
+		ChallengeType.CLASS_DIVERSITY:
+			if not _party_has_all_classes(party_member_ids):
+				return  # Party does not cover all 4 classes.
+			_advance_kill_progress(username, challenge)
+		ChallengeType.BOSS_RUSH:
+			# Boss kills are handled by record_party_boss_kill, not here.
+			pass
+
+
+## Called from EnemyBase when a boss enemy is defeated by a party.
+func record_party_boss_kill(username: String, boss_name: String,
+		party_member_ids: Array) -> void:
+	if not multiplayer.is_server():
+		return
+
+	var challenge: Dictionary = get_active_challenge()
+	if challenge.is_empty() or challenge.get("type", -1) != ChallengeType.BOSS_RUSH:
+		return
+
+	var params: Dictionary = challenge.get("params", {})
+	if boss_name != params.get("boss", ""):
+		return
+	if party_member_ids.size() < params.get("party_size", 4):
+		return  # Needs a full party.
+
+	var rec: Dictionary = _get_progress_record(username)
+	if rec.get("completed", false):
+		return
+	rec["progress"] = 1
+	rec["completed"] = true
+	_player_progress[username] = rec
+	_grant_reward(username, challenge)
+	_finish_challenge(username, challenge)
+
+
+func _advance_kill_progress(username: String, challenge: Dictionary) -> void:
+	var rec: Dictionary = _get_progress_record(username)
+	if rec.get("completed", false):
+		return
+
+	var goal: int = challenge.get("params", {}).get("amount", 1)
+	rec["progress"] = min(rec.get("progress", 0) + 1, goal)
+	_player_progress[username] = rec
+
+	challenge_progress_updated.emit(username, rec["progress"])
+
+	if rec["progress"] >= goal:
+		rec["completed"] = true
+		_player_progress[username] = rec
+		_grant_reward(username, challenge)
+		_finish_challenge(username, challenge)
+	else:
+		_save_progress(username)
+		_push_ui_update(username)
+
+
+func _advance_speed_progress(username: String, challenge: Dictionary) -> void:
+	var rec: Dictionary = _get_progress_record(username)
+	if rec.get("completed", false):
+		return
+
+	var now: float = Time.get_unix_time_from_system()
+	var time_limit: float = challenge.get("params", {}).get("time_limit", 600.0)
+	var deadline: float = rec.get("speed_deadline", 0.0)
+
+	# Start the timer on the first qualifying kill, or restart it if the
+	# previous window already expired without completing.
+	if deadline <= 0.0 or now > deadline:
+		rec["speed_deadline"] = now + time_limit
+		rec["progress"] = 0
+
+	rec["progress"] = rec.get("progress", 0) + 1
+	_player_progress[username] = rec
+
+	var goal: int = challenge.get("params", {}).get("amount", 50)
+	challenge_progress_updated.emit(username, rec["progress"])
+
+	if rec["progress"] >= goal:
+		# Completed in time (deadline freshly checked above).
+		rec["completed"] = true
+		_player_progress[username] = rec
+		_grant_reward(username, challenge)
+		_finish_challenge(username, challenge)
+	else:
+		_save_progress(username)
+		_push_ui_update(username)
+
+
+func _finish_challenge(username: String, challenge: Dictionary) -> void:
+	challenge_completed.emit(username, challenge.get("id", ""))
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	if pid != -1:
+		_send_message(pid, "[Daily Challenge] COMPLETED: %s!" % challenge.get("title", ""), Color.GOLD)
+	_save_progress(username)
+	_push_ui_update(username)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# CLASS DIVERSITY HELPER
+# ═══════════════════════════════════════════════════════════════════════════
+
+## True if the given party covers all 4 base class archetypes. Advanced
+## classes count as their base archetype (Crusader -> Swordsman, etc.).
+func _party_has_all_classes(member_ids: Array) -> bool:
+	var archetypes: Dictionary = {}
+	for mid in member_ids:
+		var node: Node = PlayerManager.get_player_node(mid)
+		if not is_instance_valid(node) or not is_instance_valid(node.class_component):
+			continue
+		archetypes[_base_archetype(node.class_component.current_class)] = true
+	return archetypes.has(Constants.ClassType.SWORDSMAN) \
+		and archetypes.has(Constants.ClassType.ARCHER) \
+		and archetypes.has(Constants.ClassType.MAGE) \
+		and archetypes.has(Constants.ClassType.ROGUE)
+
+
+func _base_archetype(class_type: int) -> int:
+	match class_type:
+		Constants.ClassType.CRUSADER:
+			return Constants.ClassType.SWORDSMAN
+		Constants.ClassType.RANGER:
+			return Constants.ClassType.ARCHER
+		Constants.ClassType.ARCHMAGE:
+			return Constants.ClassType.MAGE
+		Constants.ClassType.ASSASSIN:
+			return Constants.ClassType.ROGUE
+		_:
+			return class_type
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# REWARD GRANTING
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _grant_reward(username: String, challenge: Dictionary) -> void:
+	var reward: Dictionary = challenge.get("reward", {})
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	var player_node: MultiplayerPlayerV2 = null
+	if pid != -1:
+		player_node = PlayerManager.get_player_node(pid)
+
+	match reward.get("type", -1):
+		RewardType.BONUS_EXP:
+			var exp: int = reward.get("amount", 0)
+			if is_instance_valid(player_node) and exp > 0:
+				player_node.gain_experience(exp)
+			if pid != -1:
+				_send_message(pid, "  +%d bonus EXP" % exp, Color.GREEN)
+
+		RewardType.BONUS_GOLD:
+			var gold: int = reward.get("amount", 0)
+			_grant_coins(player_node, gold)
+			if pid != -1:
+				_send_message(pid, "  +%d bonus Coins" % gold, Color.GOLD)
+
+		RewardType.EXP_BUFF:
+			# Activate a server-tracked double-EXP window. gain_experience()
+			# multiplies all EXP gains while this is active.
+			var expiry: float = Time.get_unix_time_from_system() + EXP_BUFF_DURATION
+			_exp_buff_expiry[username] = expiry
+			if pid != -1:
+				_send_message(pid, "  Double EXP active for %d minutes!" % int(EXP_BUFF_DURATION / 60.0), Color.GREEN)
+
+		RewardType.EXTRA_DROP_ROLLS:
+			# "Extra drop rolls" are realised as a guaranteed bonus loot bundle
+			# — the daily challenge has no enemy to roll against on completion.
+			var item_name: String = reward.get("item", "Coin")
+			var amount: int = reward.get("amount", 1)
+			if item_name == "Coin":
+				_grant_coins(player_node, amount)
+			elif is_instance_valid(player_node) and is_instance_valid(player_node.inventory_component):
+				var item = ResourceManager.get_item_by_name(item_name)
+				if item:
+					var item_copy = item.duplicate_with_path()
+					player_node.inventory_component.add_item(item_copy)
+			if pid != -1:
+				_send_message(pid, "  Bonus loot: %dx %s" % [amount, item_name], Color.GOLD)
+
+
+func _grant_coins(player_node: MultiplayerPlayerV2, amount: int) -> void:
+	if amount <= 0 or not is_instance_valid(player_node):
+		return
+	if is_instance_valid(player_node.player_inventory):
+		player_node.player_inventory.monies_amount += amount
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# EXP BUFF — queried by MultiplayerPlayerV2.gain_experience()
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Returns the EXP multiplier currently in effect for a player (1.0 = none).
+func get_exp_multiplier(username: String) -> float:
+	if not _exp_buff_expiry.has(username):
+		return 1.0
+	if Time.get_unix_time_from_system() >= _exp_buff_expiry[username]:
+		_exp_buff_expiry.erase(username)
+		return 1.0
+	return EXP_BUFF_MULTIPLIER
+
+
+## Remaining seconds on the EXP buff (0 if inactive).
+func get_exp_buff_remaining(username: String) -> float:
+	if not _exp_buff_expiry.has(username):
+		return 0.0
+	var remaining: float = _exp_buff_expiry[username] - Time.get_unix_time_from_system()
+	return max(0.0, remaining)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# SAVE / LOAD — integrated with the player save flow
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Serialized into player_<username>.json under the "daily_challenge" key.
+func save_challenge_data(username: String) -> Dictionary:
+	var rec: Dictionary = _player_progress.get(username, {})
+	return {
+		"date_key": _current_date_key,
+		"challenge_id": rec.get("challenge_id", ""),
+		"progress": rec.get("progress", 0),
+		"completed": rec.get("completed", false),
+		"speed_deadline": rec.get("speed_deadline", 0.0),
+		"exp_buff_expiry": _exp_buff_expiry.get(username, 0.0),
+	}
+
+
+func load_challenge_data(username: String, data: Dictionary) -> void:
+	if not multiplayer.is_server() or data.is_empty():
+		return
+
+	_refresh_active_challenge()
+
+	# Restore the EXP buff only if it has not yet expired.
+	var buff_expiry: float = float(data.get("exp_buff_expiry", 0.0))
+	if buff_expiry > Time.get_unix_time_from_system():
+		_exp_buff_expiry[username] = buff_expiry
+
+	# Progress is only valid if it belongs to TODAY's challenge. If the saved
+	# data is from a previous day (or a different challenge), it is discarded —
+	# _get_progress_record will create a fresh record on the next kill.
+	var saved_date: String = str(data.get("date_key", ""))
+	var saved_challenge: String = str(data.get("challenge_id", ""))
+	if saved_date == _current_date_key and saved_challenge == _current_challenge_id \
+			and not saved_challenge.is_empty():
+		_player_progress[username] = {
+			"challenge_id": saved_challenge,
+			"progress": int(data.get("progress", 0)),
+			"completed": bool(data.get("completed", false)),
+			"speed_deadline": float(data.get("speed_deadline", 0.0)),
+		}
+	#print("DailyChallengeManager: Loaded challenge data for '%s'." % username)
+
+
+func _save_progress(username: String) -> void:
+	# Route through the player's normal debounced save flow.
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	if pid != -1:
+		var pn = PlayerManager.get_player_node(pid)
+		if pn and SaveManager:
+			SaveManager.queue_save(username, "all", pn)
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# UI DATA — RPC methods for the DailyChallengeWindow client UI
+# ═══════════════════════════════════════════════════════════════════════════
+
+## Client → Server: request today's challenge + this player's progress.
+@rpc("any_peer", "call_remote", "reliable")
+func request_challenge_ui_data() -> void:
+	if not multiplayer.is_server():
+		return
+	var requester_id: int = multiplayer.get_remote_sender_id()
+	var player_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(requester_id)
+	if not player_node:
+		return
+	_send_ui_data(requester_id, player_node.username)
+
+
+## Server → Client: deliver serialized challenge UI data.
+@rpc("authority", "call_remote", "reliable")
+func _receive_challenge_ui_data(data: Dictionary) -> void:
+	challenge_ui_data_received.emit(data)
+
+
+func _send_ui_data(peer_id: int, username: String) -> void:
+	if BotManager.is_bot(peer_id):
+		return
+	var data: Dictionary = _build_ui_data(username)
+	if multiplayer.get_unique_id() == peer_id:
+		# Host mode — emit directly, no RPC.
+		challenge_ui_data_received.emit(data)
+	else:
+		_receive_challenge_ui_data.rpc_id(peer_id, data)
+
+
+func _push_ui_update(username: String) -> void:
+	var pid: int = PlayerManager.get_player_id_from_name(username)
+	if pid != -1:
+		_send_ui_data(pid, username)
+
+
+## Builds the UI data dictionary. Safe to call on host directly; the
+## DailyChallengeWindow uses it both in host mode and via RPC.
+func _build_ui_data(username: String) -> Dictionary:
+	var challenge: Dictionary = get_active_challenge()
+	if challenge.is_empty():
+		return {"has_challenge": false}
+
+	var rec: Dictionary = _player_progress.get(username, {})
+	# Treat stale progress (different challenge id) as zero.
+	var progress: int = 0
+	var completed: bool = false
+	var speed_deadline: float = 0.0
+	if rec.get("challenge_id", "") == challenge.get("id", ""):
+		progress = rec.get("progress", 0)
+		completed = rec.get("completed", false)
+		speed_deadline = rec.get("speed_deadline", 0.0)
+
+	var params: Dictionary = challenge.get("params", {})
+	var goal: int = params.get("amount", 1)
+	if challenge.get("type", -1) == ChallengeType.BOSS_RUSH:
+		goal = 1
+
+	return {
+		"has_challenge": true,
+		"id": challenge.get("id", ""),
+		"title": challenge.get("title", ""),
+		"description": challenge.get("description", ""),
+		"type_name": _type_name(challenge.get("type", -1)),
+		"reward_text": _reward_text(challenge.get("reward", {})),
+		"progress": progress,
+		"goal": goal,
+		"completed": completed,
+		"speed_deadline": speed_deadline,
+		"exp_buff_remaining": get_exp_buff_remaining(username),
+	}
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# HELPERS
+# ═══════════════════════════════════════════════════════════════════════════
+
+func _type_name(type: int) -> String:
+	match type:
+		ChallengeType.PARTY_KILL:      return "Party Kill"
+		ChallengeType.SPEED:           return "Speed"
+		ChallengeType.CLASS_DIVERSITY: return "Class Diversity"
+		ChallengeType.BOSS_RUSH:       return "Boss Rush"
+		_:                             return "Challenge"
+
+
+func _reward_text(reward: Dictionary) -> String:
+	match reward.get("type", -1):
+		RewardType.BONUS_EXP:
+			return "+%d bonus EXP" % reward.get("amount", 0)
+		RewardType.BONUS_GOLD:
+			return "+%d bonus Coins" % reward.get("amount", 0)
+		RewardType.EXP_BUFF:
+			return "Double EXP for %d min" % int(EXP_BUFF_DURATION / 60.0)
+		RewardType.EXTRA_DROP_ROLLS:
+			return "Bonus loot: %dx %s" % [reward.get("amount", 1), reward.get("item", "Coin")]
+		_:
+			return "Reward"
+
+
+func _send_message(peer_id: int, text: String, color: Color) -> void:
+	if BotManager.is_bot(peer_id):
+		return
+	_client_receive_challenge_message.rpc_id(peer_id, text, color)
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_receive_challenge_message(text: String, color: Color) -> void:
+	ChatManager.add_system_message(text, color)

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -228,6 +228,13 @@ func gain_experience(amount: int) -> void:
 	if is_instance_valid(health_component) and health_component.is_dead:
 		return
 
+	# Apply the Daily Challenge double-EXP buff (Speed Challenge reward), if active.
+	# Server-authoritative: only the server scales, so all EXP grants stay consistent.
+	if multiplayer.is_server() and not username.is_empty():
+		var mult: float = DailyChallengeManager.get_exp_multiplier(username)
+		if mult != 1.0:
+			amount = int(round(amount * mult))
+
 	if level_component and level_component.has_method("add_exp"):
 		level_component.add_exp(amount)
 
@@ -510,6 +517,7 @@ func get_save_data(update_type: String = "all") -> Dictionary:
 
 	if update_type == "all":
 		data['quests'] = QuestManager.save_quests(username)
+		data['daily_challenge'] = DailyChallengeManager.save_challenge_data(username)
 
 	return data
 
@@ -599,6 +607,11 @@ func _load_data(data: Dictionary) -> void:
 	var quest_data = data.get("quests", {})
 	if not quest_data.is_empty():
 		QuestManager.load_quests(username, quest_data)
+
+	# Load daily co-op challenge progress
+	var daily_challenge_data = data.get("daily_challenge", {})
+	if not daily_challenge_data.is_empty():
+		DailyChallengeManager.load_challenge_data(username, daily_challenge_data)
 
 	_is_loading_data = false
 

--- a/scripts/UI/daily_challenge_window.gd
+++ b/scripts/UI/daily_challenge_window.gd
@@ -1,0 +1,133 @@
+class_name DailyChallengeWindow
+extends Panel
+
+## Daily Co-op Challenge window — shows today's rotating party challenge,
+## the player's progress, the reward, and any active EXP buff.
+##
+## Toggled with the OpenDailyChallengeWindow input action. Draggable by its
+## title bar, like the other moveable windows. Data is requested from the
+## server via DailyChallengeManager (or built directly in host mode).
+
+@onready var title_label: Label = %TitleLabel
+@onready var close_button: Button = %CloseButton
+@onready var challenge_name_label: Label = %ChallengeNameLabel
+@onready var type_label: Label = %TypeLabel
+@onready var desc_label: RichTextLabel = %DescLabel
+@onready var progress_bar: ProgressBar = %ProgressBar
+@onready var progress_label: Label = %ProgressLabel
+@onready var reward_label: Label = %RewardLabel
+@onready var status_label: Label = %StatusLabel
+
+var player: MultiplayerPlayerV2
+
+var is_dragging: bool = false
+var drag_offset: Vector2 = Vector2.ZERO
+
+var _cached_data: Dictionary = {}
+
+
+func _ready() -> void:
+	add_to_group("ui_window")
+
+	if owner is MultiplayerPlayerV2:
+		player = owner as MultiplayerPlayerV2
+
+	close_button.pressed.connect(func(): self.visible = false)
+	DailyChallengeManager.challenge_ui_data_received.connect(_on_data_received)
+
+	_clear_panel()
+
+
+func _process(_delta: float) -> void:
+	if not is_instance_valid(player):
+		return
+
+	if multiplayer.get_unique_id() == player.player_id:
+		if Input.is_action_just_pressed("OpenDailyChallengeWindow"):
+			if self.visible:
+				self.visible = false
+			elif not InputManager.is_locked():
+				self.visible = true
+				_request_data()
+
+	if is_dragging:
+		var new_pos := get_global_mouse_position() - drag_offset
+		var vp := get_viewport_rect().size
+		var win := size
+		new_pos.x = clamp(new_pos.x, 0, vp.x - win.x)
+		new_pos.y = clamp(new_pos.y, 0, vp.y - win.y)
+		global_position = new_pos
+
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			if title_label.get_global_rect().has_point(get_global_mouse_position()):
+				is_dragging = true
+				drag_offset = get_global_mouse_position() - global_position
+				self.move_to_front()
+		else:
+			is_dragging = false
+
+
+# ── Data fetching ────────────────────────────────────────────────────────────
+
+func _request_data() -> void:
+	if not is_instance_valid(player):
+		return
+	if multiplayer.is_server():
+		# Host mode — build data directly.
+		_on_data_received(DailyChallengeManager._build_ui_data(player.username))
+	else:
+		DailyChallengeManager.request_challenge_ui_data.rpc_id(1)
+
+
+func _on_data_received(data: Dictionary) -> void:
+	_cached_data = data
+	_refresh()
+
+
+# ── Rendering ─────────────────────────────────────────────────────────────────
+
+func _refresh() -> void:
+	if _cached_data.is_empty() or not _cached_data.get("has_challenge", false):
+		_clear_panel()
+		challenge_name_label.text = "No challenge available."
+		return
+
+	challenge_name_label.text = _cached_data.get("title", "")
+	type_label.text = "[%s]" % _cached_data.get("type_name", "")
+
+	desc_label.clear()
+	desc_label.add_text(_cached_data.get("description", ""))
+
+	var progress: int = _cached_data.get("progress", 0)
+	var goal: int = max(1, _cached_data.get("goal", 1))
+	var completed: bool = _cached_data.get("completed", false)
+
+	progress_bar.max_value = goal
+	progress_bar.value = progress
+	progress_label.text = "%d / %d" % [progress, goal]
+
+	reward_label.text = "Reward: %s" % _cached_data.get("reward_text", "")
+
+	if completed:
+		status_label.text = "COMPLETED — come back tomorrow!"
+		status_label.add_theme_color_override("font_color", Color.GOLD)
+	else:
+		status_label.add_theme_color_override("font_color", Color(0.7, 0.85, 1.0))
+		var buff_remaining: float = _cached_data.get("exp_buff_remaining", 0.0)
+		if buff_remaining > 0.0:
+			status_label.text = "Double EXP active: %d min left" % int(buff_remaining / 60.0)
+		else:
+			status_label.text = "Progress only counts in a party of 2+."
+
+
+func _clear_panel() -> void:
+	challenge_name_label.text = ""
+	type_label.text = ""
+	desc_label.clear()
+	progress_bar.value = 0
+	progress_label.text = ""
+	reward_label.text = ""
+	status_label.text = ""


### PR DESCRIPTION
## Summary

Implements **Daily Co-op Challenges** (issue #100). Each day a single rotating challenge is active that grants **bonus rewards** for completing content **with a party of 2+**. Solo progress never counts — the feature is party-gated by design.

Closes #100

## How it works

- **New `DailyChallengeManager` autoload** — kept deliberately separate from `QuestManager` and the planned `DailyQuestManager` (#13) to avoid collision.
- **Deterministic daily seed** — the active challenge is picked by hashing `Time.get_date_dict_from_system()`'s date string into the challenge pool. Every player and the server independently agree on today's challenge with **zero shared state**.
- **Server-authoritative progress** — tracked per-player on the server, persisted under a new `daily_challenge` key in `player_<username>.json` via the existing save flow (`get_save_data` / `_load_data`).
- **Reset at midnight** — a 60s rollover timer detects the date change, clears all in-memory progress, and refreshes connected players' UI.
- **Challenge pool is data** — defined in code as an array of config dictionaries (type, params, reward), mirroring how `QuestManager` defines quests.
- **UI** — a small draggable `DailyChallengeWindow` HUD panel showing today's challenge, progress bar, reward, and active EXP-buff status. Toggled with the **J** key (new `OpenDailyChallengeWindow` input action).

## Challenge types implemented

| Type | Goal | Reward |
|---|---|---|
| **Party Kill** | Kill 30 enemies in a specific zone with a party of 2+ | Bonus loot bundle |
| **Speed** | Kill 50 enemies within 10 min with a party | Double EXP for 30 min |
| **Class Diversity** | Kill 40 enemies in a party covering all 4 classes | +5000 bonus EXP |
| **Boss Rush** | Defeat the Eternal Warlord with a full party of 4 | Bonus loot bundle |

**Survival Challenge was skipped** — the game has no zone-clear / instanced-dungeon concept to anchor "clear a zone without a death" cleanly, so implementing it would have required inventing a new system. The other four cover the spectrum (kill count, timed, composition, boss) well.

### Notes on rewards
- The Speed Challenge's "double EXP buff" is implemented as a server-tracked expiry timestamp queried by `gain_experience()` — the existing buff system only modifies stats, so a stat-based buff could not produce an EXP multiplier.
- "Extra drop rolls" are realised as a guaranteed bonus loot bundle, since a completed challenge has no enemy to roll loot against.

## Hook points

- `EnemyBase._deferred_death_processing` calls `record_party_enemy_kill` / `record_party_boss_kill` only on the party-reward path (already filtered to party members on the same map).
- `MultiplayerPlayerV2.gain_experience` applies the EXP multiplier server-side.

## Edge cases handled

- **Player leaves party mid-progress** — kills simply stop counting until they re-party; existing progress is retained.
- **Save/load round-trip** — saved progress is only restored if its `date_key` + `challenge_id` match today's challenge; stale data is discarded. The EXP buff is restored only if not yet expired.
- **Day rollover while logged in** — the rollover timer resets progress and pushes fresh UI to connected players.

## Test plan

- [ ] Host + join a second client, form a party of 2, kill enemies on the challenge zone — progress advances; verify it does **not** advance solo.
- [ ] Complete a Party Kill challenge — verify bonus loot is granted and the window shows "COMPLETED".
- [ ] Complete the Speed Challenge — verify double EXP applies for 30 min and the window shows remaining buff time.
- [ ] Relog mid-progress — verify progress persists for the same day and resets on a new day.
- [ ] Press J — verify the Daily Challenge window opens, is draggable, and closes with the X button / Esc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)