### PR TITLE
Add crafting system (issue #99)

### DIFF
--- a/resources/Crafting/Recipe_Bronze_Dagger.tres
+++ b/resources/Crafting/Recipe_Bronze_Dagger.tres
@@ -1,0 +1,14 @@
+[gd_resource type="Resource" script_class="CraftingRecipeData" load_steps=5 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/CraftingRecipeData.gd" id="1_recipe"]
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="2_itemdata"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Wolf_Fang.tres" id="3_wolffang"]
+[ext_resource type="Resource" path="res://resources/Items/Weapons/Bronze_Dagger.tres" id="4_result"]
+
+[resource]
+script = ExtResource("1_recipe")
+recipe_name = "Bronze Dagger"
+ingredients = Array[ExtResource("2_itemdata")]([ExtResource("3_wolffang")])
+ingredient_counts = Array[int]([5])
+result = ExtResource("4_result")
+result_count = 1

--- a/resources/Crafting/Recipe_Health_Potion.tres
+++ b/resources/Crafting/Recipe_Health_Potion.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="CraftingRecipeData" load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/CraftingRecipeData.gd" id="1_recipe"]
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="2_itemdata"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Mushroom_Cap.tres" id="3_mushroom"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Slime_Gel.tres" id="4_slimegel"]
+[ext_resource type="Resource" uid="uid://cjl5ggbs3c237" path="res://resources/Items/Consumables/Grape_Potion.tres" id="5_result"]
+
+[resource]
+script = ExtResource("1_recipe")
+recipe_name = "Health Potion"
+ingredients = Array[ExtResource("2_itemdata")]([ExtResource("3_mushroom"), ExtResource("4_slimegel")])
+ingredient_counts = Array[int]([3, 2])
+result = ExtResource("5_result")
+result_count = 1

--- a/resources/Crafting/Recipe_Leather_Cap.tres
+++ b/resources/Crafting/Recipe_Leather_Cap.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="CraftingRecipeData" load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/CraftingRecipeData.gd" id="1_recipe"]
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="2_itemdata"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Wolf_Fang.tres" id="3_wolffang"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Mushroom_Cap.tres" id="4_mushroom"]
+[ext_resource type="Resource" path="res://resources/Items/Armor/Leather_Cap.tres" id="5_result"]
+
+[resource]
+script = ExtResource("1_recipe")
+recipe_name = "Leather Cap"
+ingredients = Array[ExtResource("2_itemdata")]([ExtResource("3_wolffang"), ExtResource("4_mushroom")])
+ingredient_counts = Array[int]([3, 3])
+result = ExtResource("5_result")
+result_count = 1

--- a/resources/Crafting/Recipe_Mana_Potion.tres
+++ b/resources/Crafting/Recipe_Mana_Potion.tres
@@ -1,0 +1,15 @@
+[gd_resource type="Resource" script_class="CraftingRecipeData" load_steps=6 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/CraftingRecipeData.gd" id="1_recipe"]
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="2_itemdata"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Slime_Gel.tres" id="3_slimegel"]
+[ext_resource type="Resource" path="res://resources/Items/Materials/Wolf_Fang.tres" id="4_wolffang"]
+[ext_resource type="Resource" uid="uid://bwlru2cwcphdy" path="res://resources/Items/Consumables/Mana_Potion.tres" id="5_result"]
+
+[resource]
+script = ExtResource("1_recipe")
+recipe_name = "Mana Potion"
+ingredients = Array[ExtResource("2_itemdata")]([ExtResource("3_slimegel"), ExtResource("4_wolffang")])
+ingredient_counts = Array[int]([4, 2])
+result = ExtResource("5_result")
+result_count = 1

--- a/resources/Enemies/Boar/ED_Boar.tres
+++ b/resources/Enemies/Boar/ED_Boar.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="EnemyData" load_steps=12 format=3 uid="uid://bliarhg40csoo"]
+[gd_resource type="Resource" script_class="EnemyData" load_steps=13 format=3 uid="uid://bliarhg40csoo"]
 
 [ext_resource type="Script" uid="uid://cucvsoha2s1kj" path="res://scripts/Resources/ItemSystem/ItemDrop.gd" id="1_drop"]
 [ext_resource type="Script" uid="uid://dv7aj5x3e50cg" path="res://scripts/Resources/EnemyData.gd" id="2_ed"]
@@ -26,6 +26,14 @@ min_amount = 10
 max_amount = 16
 metadata/_custom_type_script = "uid://cucvsoha2s1kj"
 
+[sub_resource type="Resource" id="Resource_material"]
+script = ExtResource("1_drop")
+item_name = "Wolf Fang"
+drop_chance = 0.7
+min_amount = 1
+max_amount = 3
+metadata/_custom_type_script = "uid://cucvsoha2s1kj"
+
 [resource]
 script = ExtResource("2_ed")
 monster_name = "Boar"
@@ -35,5 +43,5 @@ sprite_frames = ExtResource("3_sf")
 character_collision_shape = SubResource("Shape_col")
 body_hitbox_shape = SubResource("Shape_body")
 attack_hitbox_shape = SubResource("Shape_atk")
-item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4")])
+item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), SubResource("Resource_material"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4")])
 metadata/_custom_type_script = "uid://dv7aj5x3e50cg"

--- a/resources/Enemies/Goblin/ED_Goblin.tres
+++ b/resources/Enemies/Goblin/ED_Goblin.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="EnemyData" load_steps=14 format=3 uid="uid://cvctd6i3vmgiy"]
+[gd_resource type="Resource" script_class="EnemyData" load_steps=15 format=3 uid="uid://cvctd6i3vmgiy"]
 
 [ext_resource type="Script" uid="uid://cucvsoha2s1kj" path="res://scripts/Resources/ItemSystem/ItemDrop.gd" id="1_drop"]
 [ext_resource type="Script" uid="uid://dv7aj5x3e50cg" path="res://scripts/Resources/EnemyData.gd" id="2_ed"]
@@ -28,6 +28,14 @@ min_amount = 10
 max_amount = 16
 metadata/_custom_type_script = "uid://cucvsoha2s1kj"
 
+[sub_resource type="Resource" id="Resource_material"]
+script = ExtResource("1_drop")
+item_name = "Mushroom Cap"
+drop_chance = 0.7
+min_amount = 1
+max_amount = 3
+metadata/_custom_type_script = "uid://cucvsoha2s1kj"
+
 [resource]
 script = ExtResource("2_ed")
 monster_name = "Goblin"
@@ -37,5 +45,5 @@ sprite_frames = ExtResource("3_sf")
 character_collision_shape = SubResource("Shape_col")
 body_hitbox_shape = SubResource("Shape_body")
 attack_hitbox_shape = SubResource("Shape_atk")
-item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4"), ExtResource("d_5"), ExtResource("d_6")])
+item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), SubResource("Resource_material"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4"), ExtResource("d_5"), ExtResource("d_6")])
 metadata/_custom_type_script = "uid://dv7aj5x3e50cg"

--- a/resources/Enemies/Slime/ED_Slime.tres
+++ b/resources/Enemies/Slime/ED_Slime.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="EnemyData" load_steps=11 format=3 uid="uid://c6pskfllhxxrd"]
+[gd_resource type="Resource" script_class="EnemyData" load_steps=12 format=3 uid="uid://c6pskfllhxxrd"]
 
 [ext_resource type="Script" uid="uid://cucvsoha2s1kj" path="res://scripts/Resources/ItemSystem/ItemDrop.gd" id="1_drop"]
 [ext_resource type="Script" uid="uid://dv7aj5x3e50cg" path="res://scripts/Resources/EnemyData.gd" id="2_ed"]
@@ -22,6 +22,14 @@ min_amount = 10
 max_amount = 16
 metadata/_custom_type_script = "uid://cucvsoha2s1kj"
 
+[sub_resource type="Resource" id="Resource_material"]
+script = ExtResource("1_drop")
+item_name = "Slime Gel"
+drop_chance = 0.7
+min_amount = 1
+max_amount = 3
+metadata/_custom_type_script = "uid://cucvsoha2s1kj"
+
 [resource]
 script = ExtResource("2_ed")
 monster_name = "Slime"
@@ -31,5 +39,5 @@ sprite_frames = ExtResource("3_sf")
 character_collision_shape = SubResource("Shape_col")
 body_hitbox_shape = SubResource("Shape_col")
 attack_hitbox_shape = SubResource("Shape_atk")
-item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4")])
+item_drops = Array[ExtResource("1_drop")]([SubResource("Resource_coin"), SubResource("Resource_material"), ExtResource("d_1"), ExtResource("d_2"), ExtResource("d_3"), ExtResource("d_4")])
 metadata/_custom_type_script = "uid://dv7aj5x3e50cg"

--- a/resources/Items/Materials/Mushroom_Cap.tres
+++ b/resources/Items/Materials/Mushroom_Cap.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="ItemData" load_steps=4 format=3]
+
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="1_item"]
+[ext_resource type="Texture2D" uid="uid://yhl18c6ei5o6" path="res://assets/sprites/fruit.png" id="2_tex"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_mushroomcap"]
+atlas = ExtResource("2_tex")
+region = Rect2(16, 0, 16, 16)
+
+[resource]
+script = ExtResource("1_item")
+item_id = "craft-material-mushroom-cap-0001"
+name = "Mushroom Cap"
+rarity = 0
+icon = SubResource("AtlasTexture_mushroomcap")
+description = "A spongy mushroom cap. A crafting material."
+item_type = 3
+item_level = -1
+custom_item_value = 10
+can_stack = true
+max_stack_amount = 99
+current_stack_amount = 1
+metadata/_custom_type_script = "uid://ob3kriis8m08"

--- a/resources/Items/Materials/Slime_Gel.tres
+++ b/resources/Items/Materials/Slime_Gel.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="ItemData" load_steps=4 format=3]
+
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="1_item"]
+[ext_resource type="Texture2D" uid="uid://yhl18c6ei5o6" path="res://assets/sprites/fruit.png" id="2_tex"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_slimegel"]
+atlas = ExtResource("2_tex")
+region = Rect2(0, 16, 16, 16)
+
+[resource]
+script = ExtResource("1_item")
+item_id = "craft-material-slime-gel-0001"
+name = "Slime Gel"
+rarity = 0
+icon = SubResource("AtlasTexture_slimegel")
+description = "A blob of sticky slime residue. A crafting material."
+item_type = 3
+item_level = -1
+custom_item_value = 8
+can_stack = true
+max_stack_amount = 99
+current_stack_amount = 1
+metadata/_custom_type_script = "uid://ob3kriis8m08"

--- a/resources/Items/Materials/Wolf_Fang.tres
+++ b/resources/Items/Materials/Wolf_Fang.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="ItemData" load_steps=4 format=3]
+
+[ext_resource type="Script" uid="uid://ob3kriis8m08" path="res://scripts/Resources/ItemSystem/ItemData.gd" id="1_item"]
+[ext_resource type="Texture2D" uid="uid://yhl18c6ei5o6" path="res://assets/sprites/fruit.png" id="2_tex"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wolffang"]
+atlas = ExtResource("2_tex")
+region = Rect2(0, 0, 16, 16)
+
+[resource]
+script = ExtResource("1_item")
+item_id = "craft-material-wolf-fang-0001"
+name = "Wolf Fang"
+rarity = 0
+icon = SubResource("AtlasTexture_wolffang")
+description = "A sharp fang torn from a beast. A crafting material."
+item_type = 3
+item_level = -1
+custom_item_value = 15
+can_stack = true
+max_stack_amount = 99
+current_stack_amount = 1
+metadata/_custom_type_script = "uid://ob3kriis8m08"

--- a/scenes/Levels/town.tscn
+++ b/scenes/Levels/town.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=18 format=4 uid="uid://ykvov1wfh1gv"]
+[gd_scene load_steps=19 format=4 uid="uid://ykvov1wfh1gv"]
 
 [ext_resource type="Script" uid="uid://dfj1ny2sygjrj" path="res://scripts/Gameplay/map_base.gd" id="1_as7l3"]
 [ext_resource type="Script" uid="uid://b1ruh77vt7mdu" path="res://scripts/VFX/damage_numbers.gd" id="2_bkv3e"]
@@ -12,6 +12,7 @@
 [ext_resource type="Resource" uid="uid://bwlru2cwcphdy" path="res://resources/Items/Consumables/Mana_Potion.tres" id="16_um1b1"]
 [ext_resource type="Resource" uid="uid://jwwtuktlssm4" path="res://resources/Items/Consumables/Exp_Potion.tres" id="17_1o3m4"]
 [ext_resource type="Script" uid="uid://igk1rxt26f2i" path="res://scripts/UI/global_drop_handler.gd" id="18_a3rpc"]
+[ext_resource type="PackedScene" uid="uid://b1craftnpc0001" path="res://scenes/NPC/crafting_npc.tscn" id="19_craft"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_lnu2h"]
 texture = ExtResource("5_t0e5x")
@@ -598,6 +599,9 @@ offset_left = 563.0
 offset_top = 254.0
 offset_right = 1313.0
 offset_bottom = 854.0
+
+[node name="CraftingNPC" parent="." instance=ExtResource("19_craft")]
+position = Vector2(-120, -674)
 
 [node name="GlobalDropHandler" type="Control" parent="."]
 layout_mode = 3

--- a/scenes/NPC/crafting_npc.tscn
+++ b/scenes/NPC/crafting_npc.tscn
@@ -1,0 +1,103 @@
+[gd_scene load_steps=12 format=3 uid="uid://b1craftnpc0001"]
+
+[ext_resource type="Script" path="res://scripts/NPC/crafting_npc_interaction.gd" id="1_interact"]
+[ext_resource type="Texture2D" uid="uid://bovy7ly4pd77y" path="res://assets/sprites/MinifolksVillagers2/Original/Outline/MiniBlacksmith.png" id="2_sprite"]
+[ext_resource type="Script" path="res://scripts/Components/crafting_station.gd" id="3_station"]
+[ext_resource type="PackedScene" uid="uid://b1craftwindow01" path="res://scenes/UI/crafting_window.tscn" id="4_window"]
+[ext_resource type="FontFile" uid="uid://c8e0uior67hgl" path="res://assets/fonts/PixelOperator8.ttf" id="5_font"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_f0"]
+atlas = ExtResource("2_sprite")
+region = Rect2(0, 0, 32, 32)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_f1"]
+atlas = ExtResource("2_sprite")
+region = Rect2(32, 0, 32, 32)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_f2"]
+atlas = ExtResource("2_sprite")
+region = Rect2(64, 0, 32, 32)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_f3"]
+atlas = ExtResource("2_sprite")
+region = Rect2(96, 0, 32, 32)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_idle"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_f0")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_f1")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_f2")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_f3")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 8.0
+}]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_prompt"]
+content_margin_left = 20.0
+content_margin_top = 10.0
+content_margin_right = 20.0
+content_margin_bottom = 10.0
+bg_color = Color(0.0470588, 0.0470588, 0.0470588, 0.937255)
+border_width_left = 3
+border_width_top = 3
+border_width_right = 3
+border_width_bottom = 3
+border_color = Color(0.871141, 0.871141, 0.871141, 1)
+corner_radius_top_left = 6
+corner_radius_top_right = 6
+corner_radius_bottom_right = 6
+corner_radius_bottom_left = 6
+
+[node name="CraftingNPC" type="Node2D" node_paths=PackedStringArray("crafting_window_scene", "crafting_station", "prompt_label", "clickable_overlay")]
+script = ExtResource("1_interact")
+crafting_window_scene = NodePath("CanvasLayer/CraftingWindow")
+crafting_station = NodePath("CraftingStation")
+prompt_label = NodePath("Label")
+clickable_overlay = NodePath("ClickableOverlay")
+
+[node name="Sprite" type="AnimatedSprite2D" parent="."]
+z_index = -1
+scale = Vector2(1.2, 1.2)
+sprite_frames = SubResource("SpriteFrames_idle")
+animation = &"idle"
+autoplay = "idle"
+
+[node name="ClickableOverlay" type="TextureButton" parent="."]
+offset_left = -7.0
+offset_top = 2.0
+offset_right = 8.0
+offset_bottom = 18.0
+mouse_filter = 1
+
+[node name="CraftingStation" type="Node" parent="."]
+script = ExtResource("3_station")
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="CraftingWindow" parent="CanvasLayer" node_paths=PackedStringArray("crafting_station") instance=ExtResource("4_window")]
+visible = false
+crafting_station = NodePath("../../CraftingStation")
+
+[node name="Label" type="Label" parent="."]
+visible = false
+offset_left = -30.0
+offset_top = -11.0
+offset_right = 165.0
+offset_bottom = 17.0
+scale = Vector2(0.3, 0.3)
+theme_override_fonts/font = ExtResource("5_font")
+theme_override_font_sizes/font_size = 8
+theme_override_styles/normal = SubResource("StyleBoxFlat_prompt")
+text = "Right-click to craft."
+horizontal_alignment = 1
+vertical_alignment = 1

--- a/scenes/UI/crafting_window.tscn
+++ b/scenes/UI/crafting_window.tscn
@@ -1,0 +1,138 @@
+[gd_scene load_steps=8 format=3 uid="uid://b1craftwindow01"]
+
+[ext_resource type="StyleBox" uid="uid://dm8jxifs8rqrm" path="res://assets/UI/Themes/PanelStyleboxTheme.tres" id="1_panel"]
+[ext_resource type="Script" path="res://scripts/UI/crafting_window.gd" id="2_script"]
+[ext_resource type="Theme" uid="uid://bg5sc8rk63fi6" path="res://assets/UI/Themes/ScrollContainerTheme.tres" id="3_scroll"]
+[ext_resource type="FontFile" uid="uid://4wxt0g33xdbi" path="res://assets/fonts/PixelOperator8-Bold.ttf" id="4_font"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_header"]
+bg_color = Color(0.06, 0.06, 0.08, 1)
+border_width_bottom = 1
+border_color = Color(0.3, 0.3, 0.35, 1)
+corner_radius_top_left = 4
+corner_radius_top_right = 4
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_panel"]
+content_margin_left = 8.0
+content_margin_top = 8.0
+content_margin_right = 8.0
+content_margin_bottom = 8.0
+bg_color = Color(0.06, 0.06, 0.08, 1)
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_footer"]
+content_margin_left = 12.0
+content_margin_top = 8.0
+content_margin_right = 12.0
+content_margin_bottom = 8.0
+bg_color = Color(0.06, 0.06, 0.08, 1)
+border_width_top = 1
+border_color = Color(0.3, 0.3, 0.35, 1)
+
+[node name="CraftingWindow" type="Panel"]
+offset_left = 400.0
+offset_top = 180.0
+offset_right = 800.0
+offset_bottom = 660.0
+theme_override_styles/panel = ExtResource("1_panel")
+script = ExtResource("2_script")
+
+[node name="HeaderPanel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 10
+anchor_right = 1.0
+offset_bottom = 45.0
+grow_horizontal = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_header")
+
+[node name="Title" type="Label" parent="HeaderPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.905882, 0.890196, 0.34902, 1)
+theme_override_fonts/font = ExtResource("4_font")
+theme_override_font_sizes/font_size = 16
+text = "CRAFTING"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="CloseButton" type="Button" parent="HeaderPanel"]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -40.0
+offset_top = 5.0
+offset_right = -5.0
+offset_bottom = 40.0
+grow_horizontal = 0
+focus_mode = 0
+theme_override_colors/font_color = Color(0.9, 0.9, 0.95, 1)
+theme_override_colors/font_hover_color = Color(1, 0.4, 0.4, 1)
+theme_override_font_sizes/font_size = 20
+text = "×"
+flat = true
+
+[node name="ContentPanel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = 55.0
+offset_right = -12.0
+offset_bottom = -60.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_panel")
+
+[node name="RecipeScroll" type="ScrollContainer" parent="ContentPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 8.0
+offset_top = 8.0
+offset_right = -8.0
+offset_bottom = -8.0
+grow_horizontal = 2
+grow_vertical = 2
+theme = ExtResource("3_scroll")
+horizontal_scroll_mode = 0
+
+[node name="RecipeList" type="VBoxContainer" parent="ContentPanel/RecipeScroll"]
+layout_mode = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
+theme_override_constants/separation = 6
+
+[node name="FooterPanel" type="Panel" parent="."]
+layout_mode = 1
+anchors_preset = 12
+anchor_top = 1.0
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_left = 12.0
+offset_top = -48.0
+offset_right = -12.0
+offset_bottom = -12.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_styles/panel = SubResource("StyleBoxFlat_footer")
+
+[node name="StatusLabel" type="Label" parent="FooterPanel"]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_colors/font_color = Color(0.8, 0.8, 0.85, 1)
+theme_override_font_sizes/font_size = 11
+text = "Select a recipe to craft."
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[connection signal="pressed" from="HeaderPanel/CloseButton" to="." method="hide"]

--- a/scripts/Components/crafting_station.gd
+++ b/scripts/Components/crafting_station.gd
@@ -1,0 +1,119 @@
+## crafting_station.gd
+## Server-authoritative crafting logic. A client sends a "craft recipe X"
+## intent via RPC; the server validates the requesting player's inventory has
+## every ingredient in the required count, removes them, and adds the result.
+## There is no client-side crafting — clients only display recipes and send
+## intent. Mirrors the RPC pattern used by MerchantInventory.
+class_name CraftingStation
+extends Node
+
+## Reference to the CraftingWindow instance, set when the window is opened.
+@export var crafting_window: Panel
+
+
+## Finds a player node in the "Players" group by peer id.
+func get_player_by_id(peer_id: int) -> Node:
+	var players = get_tree().get_nodes_in_group("Players")
+	for p in players:
+		if p.player_id == peer_id:
+			return p
+	return null
+
+
+## Client requests to craft the recipe identified by [param recipe_name].
+## All validation and mutation happen here on the server.
+@rpc("any_peer", "call_local", "reliable")
+func request_craft(recipe_name: String) -> void:
+	if not multiplayer.is_server():
+		return
+
+	var sender_id = multiplayer.get_remote_sender_id()
+	if sender_id == 0:
+		sender_id = 1  # Local call from host
+
+	var player = get_player_by_id(sender_id)
+	if not player or not player.inventory_component:
+		_notify_result(sender_id, recipe_name, false, "Player not found.")
+		return
+
+	var recipe: CraftingRecipeData = ResourceManager.get_recipe_by_name(recipe_name)
+	if recipe == null or not recipe.is_valid():
+		_notify_result(sender_id, recipe_name, false, "Unknown recipe.")
+		return
+
+	var inventory: InventoryComponent = player.inventory_component
+
+	# Validate: the inventory has every required ingredient in the needed count.
+	# Counts are aggregated so a recipe that lists the same item twice is summed.
+	var required: Dictionary = recipe.get_required_counts()
+	for item_id in required:
+		if inventory.get_item_count(item_id) < required[item_id]:
+			_notify_result(sender_id, recipe_name, false, "Missing materials.")
+			return
+
+	# Validate: there is room for the result. A non-stackable result needs an
+	# empty slot; a stackable result can also merge into an existing stack.
+	if not _has_room_for_result(inventory, recipe, required):
+		_notify_result(sender_id, recipe_name, false, "Inventory full.")
+		return
+
+	# Consume ingredients. Each item_id may be spread across multiple stacks,
+	# so remove from each stack until the required amount is satisfied.
+	for item_id in required:
+		var remaining: int = required[item_id]
+		while remaining > 0:
+			var slots_with_item: Array = inventory.get_all_items_of_id(item_id)
+			if slots_with_item.is_empty():
+				break
+			var slot = slots_with_item[0]
+			var item: ItemData = slot.item
+			if item == null:
+				break
+			var to_remove: int = min(remaining, item.current_stack_amount)
+			inventory.remove_item_from_stack(item, to_remove, "crafted")
+			remaining -= to_remove
+
+	# Produce the result.
+	for i in recipe.result_count:
+		inventory.server_add_item(recipe.result.item_id)
+
+	# Persist the change so a map switch or disconnect doesn't lose it.
+	if player.username and SaveManager:
+		SaveManager.queue_save(player.username, "inventory", player)
+
+	_notify_result(sender_id, recipe_name, true, "Crafted %s!" % recipe.result.name)
+
+
+## Returns true when the inventory can hold [param recipe]'s result. Treats a
+## free empty slot as sufficient; for stackable results also accepts an
+## existing stack with enough remaining space. [param freed] maps each
+## ingredient item_id to the total amount the craft consumes — when a recipe
+## consumes every copy of an ingredient, the slots holding it become free,
+## which matters when the inventory is otherwise full.
+func _has_room_for_result(inventory: InventoryComponent, recipe: CraftingRecipeData, freed: Dictionary) -> bool:
+	var result_item: ItemData = recipe.result
+	var empty_slots: int = inventory.get_empty_slots().size()
+
+	# An ingredient whose entire owned amount is consumed frees all its slots.
+	# (Conservative: only counts when the craft empties the item completely.)
+	for item_id in freed:
+		if inventory.get_item_count(item_id) <= freed[item_id]:
+			empty_slots += inventory.get_all_items_of_id(item_id).size()
+
+	if empty_slots > 0:
+		return true
+
+	# No empty slots — a stackable result can still fit into an existing stack.
+	if result_item.can_stack:
+		for slot in inventory.get_all_items_of_id(result_item.item_id):
+			var item: ItemData = slot.item
+			if item and item.current_stack_amount < item.max_stack_amount:
+				return true
+
+	return false
+
+
+## Sends the craft outcome back to the requesting client's window.
+func _notify_result(player_id: int, recipe_name: String, success: bool, message: String) -> void:
+	if crafting_window:
+		crafting_window.receive_craft_result.rpc_id(player_id, recipe_name, success, message)

--- a/scripts/Managers/resource_manager.gd
+++ b/scripts/Managers/resource_manager.gd
@@ -13,12 +13,16 @@ var ability_by_name: Dictionary[String, AbilityData] = {}
 var buff_data: Dictionary[String, BuffData] = {}
 var buffs_by_name: Dictionary[String, BuffData] = {}
 
+var crafting_recipes: Array[CraftingRecipeData] = []
+var recipe_by_name: Dictionary[String, CraftingRecipeData] = {}
+
 func _ready() -> void:
 	_load_class_data()
 	_load_item_data()
 	_load_ability_data()
 	_load_buff_data()
-	
+	_load_crafting_data()
+
 
 #region Item Data Functions
 
@@ -198,6 +202,30 @@ func get_buff_by_name(buff_name: String) -> BuffData:
 	return buffs_by_name.get(buff_name)
 
 		
+#endregion
+
+
+#region Crafting Data Functions
+
+func _load_crafting_data() -> void:
+	var crafting_folder: String = "res://resources/Crafting/"
+
+	var process_recipe = func(resource, _path):
+		if resource is CraftingRecipeData:
+			crafting_recipes.append(resource)
+			recipe_by_name[resource.recipe_name] = resource
+			#print("Loaded recipe: %s from path: %s" % [resource.recipe_name, _path])
+
+	_load_resources_recursively(crafting_folder, process_recipe)
+
+
+func get_crafting_recipes() -> Array[CraftingRecipeData]:
+	return crafting_recipes
+
+
+func get_recipe_by_name(recipe_name: String) -> CraftingRecipeData:
+	return recipe_by_name.get(recipe_name)
+
 #endregion
 
 

--- a/scripts/NPC/crafting_npc_interaction.gd
+++ b/scripts/NPC/crafting_npc_interaction.gd
@@ -1,0 +1,65 @@
+## crafting_npc_interaction.gd
+## A world NPC (blacksmith) the player right-clicks to open the crafting UI.
+## Mirrors NPCInteraction (the merchant): a clickable overlay opens a window
+## that is a child of this NPC's CanvasLayer, shared by the local client.
+class_name CraftingNPCInteraction
+extends Node2D
+
+@export var crafting_window_scene: Panel
+@export var crafting_station: CraftingStation
+@export var prompt_label: Label = null
+@export var clickable_overlay: TextureButton
+
+
+func _ready() -> void:
+	if not crafting_window_scene:
+		push_error("CraftingNPCInteraction: crafting_window_scene missing!")
+	if not crafting_station:
+		push_error("CraftingNPCInteraction: crafting_station missing!")
+	if not clickable_overlay:
+		push_error("CraftingNPCInteraction: clickable_overlay (TextureButton) missing!")
+		return
+
+	clickable_overlay.gui_input.connect(_on_gui_input)
+	clickable_overlay.mouse_entered.connect(_on_mouse_entered)
+	clickable_overlay.mouse_exited.connect(_on_mouse_exited)
+
+	if prompt_label:
+		prompt_label.visible = false
+
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton:
+		if event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
+			_open_crafting(multiplayer.get_unique_id())
+			get_viewport().set_input_as_handled()
+
+
+func _on_mouse_entered() -> void:
+	if prompt_label:
+		prompt_label.visible = true
+
+
+func _on_mouse_exited() -> void:
+	if prompt_label:
+		prompt_label.visible = false
+
+
+func _open_crafting(player_id: int) -> void:
+	if crafting_window_scene and crafting_window_scene.visible:
+		return  # Already open
+
+	var player_inv: PlayerInventory = _get_local_player_inventory(player_id)
+	if not player_inv:
+		push_warning("CraftingNPCInteraction: Could not find local PlayerInventory for player %d" % player_id)
+		return
+
+	crafting_window_scene.open_crafting(player_inv, crafting_station)
+
+
+func _get_local_player_inventory(player_id: int) -> PlayerInventory:
+	var players = get_tree().get_nodes_in_group("Players")
+	for p in players:
+		if p.player_id == player_id:
+			return p.player_inventory as PlayerInventory
+	return null

--- a/scripts/Resources/CraftingRecipeData.gd
+++ b/scripts/Resources/CraftingRecipeData.gd
@@ -1,0 +1,51 @@
+@tool
+class_name CraftingRecipeData
+extends Resource
+
+## A crafting recipe: combine a set of ingredient items (in fixed counts) into
+## a result item. Recipes are data-driven .tres files in resources/Crafting/,
+## auto-loaded by ResourceManager. Crafting is gated only by having the
+## materials — there is no crafting skill or level.
+
+## Display name shown in the crafting UI.
+@export var recipe_name: String = ""
+
+## The items required to craft. Index-matched with [member ingredient_counts].
+@export var ingredients: Array[ItemData] = []
+
+## How many of each ingredient is required. Index-matched with [member ingredients].
+@export var ingredient_counts: Array[int] = []
+
+## The item produced by the recipe.
+@export var result: ItemData
+
+## How many copies of [member result] are produced per craft.
+@export var result_count: int = 1
+
+
+## Returns true when the recipe is well-formed (has a result and at least one
+## valid ingredient with a positive count).
+func is_valid() -> bool:
+	if result == null:
+		return false
+	if ingredients.is_empty():
+		return false
+	if ingredients.size() != ingredient_counts.size():
+		return false
+	for i in ingredients.size():
+		if ingredients[i] == null or ingredient_counts[i] <= 0:
+			return false
+	return result_count > 0
+
+
+## Aggregates ingredients into a {item_id: total_required} dictionary, summing
+## counts when the same item appears more than once in the ingredient list.
+func get_required_counts() -> Dictionary:
+	var required: Dictionary = {}
+	for i in ingredients.size():
+		var ingredient: ItemData = ingredients[i]
+		if ingredient == null:
+			continue
+		var count: int = ingredient_counts[i] if i < ingredient_counts.size() else 0
+		required[ingredient.item_id] = required.get(ingredient.item_id, 0) + count
+	return required

--- a/scripts/UI/crafting_window.gd
+++ b/scripts/UI/crafting_window.gd
@@ -1,0 +1,193 @@
+## crafting_window.gd
+## Draggable crafting UI. Lists every recipe loaded from resources/Crafting/,
+## shows each recipe's ingredients with the player's owned count, and enables
+## the Craft button only when the player has enough materials. Crafting itself
+## is performed by the server (CraftingStation); this window only displays
+## state and sends "craft" intents.
+extends Panel
+
+@export var crafting_station: CraftingStation
+
+@onready var recipe_list: VBoxContainer = $ContentPanel/RecipeScroll/RecipeList
+@onready var status_label: Label = $FooterPanel/StatusLabel
+@onready var window_title: Label = $HeaderPanel/Title
+
+var player_inventory: PlayerInventory
+var player_inv_component: InventoryComponent
+
+var _is_dragging: bool = false
+var _drag_offset: Vector2 = Vector2()
+
+
+func _ready() -> void:
+	add_to_group("ui_window")
+	visible = false
+
+
+func _process(_delta: float) -> void:
+	if _is_dragging:
+		var new_position: Vector2 = get_global_mouse_position() - _drag_offset
+		var viewport_size: Vector2 = get_viewport_rect().size
+		new_position.x = clamp(new_position.x, 0, viewport_size.x - size.x)
+		new_position.y = clamp(new_position.y, 0, viewport_size.y - size.y)
+		global_position = new_position
+
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			if window_title and window_title.get_global_rect().has_point(get_global_mouse_position()):
+				_is_dragging = true
+				_drag_offset = get_global_mouse_position() - global_position
+				move_to_front()
+		else:
+			_is_dragging = false
+
+
+## Opens the crafting window for the given player. Called by the crafting
+## station NPC on the local client.
+func open_crafting(player_inv: PlayerInventory, station: CraftingStation) -> void:
+	player_inventory = player_inv
+	player_inv_component = player_inv.inventory_component
+	crafting_station = station
+	crafting_station.crafting_window = self
+
+	status_label.text = "Select a recipe to craft."
+	_refresh_recipes()
+	visible = true
+	move_to_front()
+
+
+func close_crafting() -> void:
+	visible = false
+
+
+## Rebuilds the recipe list from ResourceManager, computing craftability
+## against the local player's inventory.
+func _refresh_recipes() -> void:
+	for child in recipe_list.get_children():
+		child.queue_free()
+
+	var recipes: Array = ResourceManager.get_crafting_recipes()
+	if recipes.is_empty():
+		var empty := Label.new()
+		empty.text = "No recipes available."
+		empty.add_theme_color_override("font_color", Color(0.7, 0.7, 0.75, 1))
+		recipe_list.add_child(empty)
+		return
+
+	for recipe in recipes:
+		if recipe.is_valid():
+			_add_recipe_row(recipe)
+
+
+## Returns how many of an item the local player owns.
+func _get_owned_count(item_id: String) -> int:
+	if player_inv_component == null:
+		return 0
+	return player_inv_component.get_item_count(item_id)
+
+
+## Builds a single recipe entry: result name, ingredient lines (owned/required),
+## and a Craft button enabled only when every ingredient requirement is met.
+func _add_recipe_row(recipe: CraftingRecipeData) -> void:
+	var panel := PanelContainer.new()
+	var panel_style := StyleBoxFlat.new()
+	panel_style.bg_color = Color(0.1, 0.1, 0.13, 1)
+	panel_style.content_margin_left = 8
+	panel_style.content_margin_right = 8
+	panel_style.content_margin_top = 6
+	panel_style.content_margin_bottom = 6
+	panel_style.corner_radius_top_left = 4
+	panel_style.corner_radius_top_right = 4
+	panel_style.corner_radius_bottom_left = 4
+	panel_style.corner_radius_bottom_right = 4
+	panel_style.border_width_left = 1
+	panel_style.border_width_top = 1
+	panel_style.border_width_right = 1
+	panel_style.border_width_bottom = 1
+	panel_style.border_color = Color(0.25, 0.25, 0.3, 1)
+	panel.add_theme_stylebox_override("panel", panel_style)
+
+	var row := HBoxContainer.new()
+	row.add_theme_constant_override("separation", 10)
+
+	# Result icon.
+	var icon := TextureRect.new()
+	icon.texture = recipe.result.icon
+	icon.custom_minimum_size = Vector2(36, 36)
+	icon.stretch_mode = TextureRect.STRETCH_KEEP_ASPECT_CENTERED
+	row.add_child(icon)
+
+	# Result name + ingredient breakdown.
+	var info := VBoxContainer.new()
+	info.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	info.add_theme_constant_override("separation", 2)
+
+	var name_label := Label.new()
+	var result_text: String = recipe.result.name
+	if recipe.result_count > 1:
+		result_text += " x" + str(recipe.result_count)
+	name_label.text = result_text
+	name_label.add_theme_color_override("font_color", Color(0.95, 0.9, 0.5, 1))
+	name_label.add_theme_font_size_override("font_size", 12)
+	info.add_child(name_label)
+
+	# Determine craftability while building the ingredient lines.
+	var can_craft: bool = true
+	for i in recipe.ingredients.size():
+		var ingredient: ItemData = recipe.ingredients[i]
+		if ingredient == null:
+			can_craft = false
+			continue
+		var needed: int = recipe.ingredient_counts[i] if i < recipe.ingredient_counts.size() else 0
+		var owned: int = _get_owned_count(ingredient.item_id)
+		var has_enough: bool = owned >= needed
+		if not has_enough:
+			can_craft = false
+
+		var ing_label := Label.new()
+		ing_label.text = "%s  %d/%d" % [ingredient.name, owned, needed]
+		ing_label.add_theme_font_size_override("font_size", 10)
+		if has_enough:
+			ing_label.add_theme_color_override("font_color", Color(0.6, 0.85, 0.6, 1))
+		else:
+			ing_label.add_theme_color_override("font_color", Color(0.85, 0.5, 0.5, 1))
+		info.add_child(ing_label)
+
+	row.add_child(info)
+
+	# Craft button.
+	var craft_button := Button.new()
+	craft_button.text = "Craft"
+	craft_button.focus_mode = Control.FOCUS_NONE
+	craft_button.custom_minimum_size = Vector2(70, 32)
+	craft_button.disabled = not can_craft
+	craft_button.pressed.connect(_on_craft_pressed.bind(recipe.recipe_name))
+	row.add_child(craft_button)
+
+	panel.add_child(row)
+	recipe_list.add_child(panel)
+
+
+## Sends a craft intent to the server. The server validates and mutates the
+## inventory; the result comes back via receive_craft_result.
+func _on_craft_pressed(recipe_name: String) -> void:
+	if crafting_station == null:
+		return
+	status_label.text = "Crafting %s..." % recipe_name
+	if multiplayer.is_server():
+		crafting_station.request_craft(recipe_name)
+	else:
+		crafting_station.request_craft.rpc_id(1, recipe_name)
+
+
+## Server -> client: the outcome of a craft attempt.
+@rpc("authority", "call_local", "reliable")
+func receive_craft_result(_recipe_name: String, success: bool, message: String) -> void:
+	status_label.text = message
+	if success:
+		status_label.add_theme_color_override("font_color", Color(0.6, 0.85, 0.6, 1))
+	else:
+		status_label.add_theme_color_override("font_color", Color(0.85, 0.5, 0.5, 1))
+	_refresh_recipes()


### PR DESCRIPTION
## Summary

Implements the crafting system from issue #99. Players combine monster-drop
materials at a blacksmith NPC to craft upgraded equipment and consumables.
Core loop: kill enemies -> collect materials -> open the crafting UI ->
select a recipe -> craft -> receive the item.

Crafting is fully server-authoritative. The client only displays recipes
and sends a "craft recipe X" intent; the server validates the inventory,
consumes ingredients, and adds the result.

## What's included

- **`CraftingRecipeData`** resource (`scripts/Resources/CraftingRecipeData.gd`)
  with `recipe_name`, `ingredients: Array[ItemData]`, `ingredient_counts: Array[int]`,
  `result: ItemData`, `result_count: int`.
- **ResourceManager** now auto-loads recipes from a new `resources/Crafting/`
  folder via a `_load_crafting_data()` loader.
- **Three material items** (`resources/Items/Materials/`): Wolf Fang,
  Mushroom Cap, Slime Gel — stackable `MATERIAL`-type items, added as drops
  to the Boar, Goblin, and Slime enemies so the loop is playable.
- **Four starter recipes** referencing existing items:
  - 5x Wolf Fang -> Bronze Dagger
  - 3x Mushroom Cap + 2x Slime Gel -> Health Potion
  - 4x Slime Gel + 2x Wolf Fang -> Mana Potion
  - 3x Wolf Fang + 3x Mushroom Cap -> Leather Cap
- **`CraftingStation`** server component with a `request_craft` RPC. Validates
  ingredient counts, checks result inventory space, and handles edge cases:
  ingredients spread across multiple stacks, duplicate ingredient types,
  full inventory, and slots freed by consuming materials.
- **Draggable `crafting_window`** UI listing every recipe with owned/required
  ingredient counts; the Craft button is enabled only when materials suffice.
- **Blacksmith NPC** (`crafting_npc.tscn`) placed in town next to the
  merchant — right-click to open the crafting UI. Reuses the merchant's
  clickable-overlay interaction pattern.

No crafting skill or level — recipes are gated only by having materials.

## Test plan

- [ ] Launch host + client; both load town with the blacksmith NPC visible
- [ ] Kill Boars/Goblins/Slimes and confirm Wolf Fang / Mushroom Cap / Slime Gel drop
- [ ] Right-click the blacksmith; crafting window opens and is draggable by the title bar
- [ ] Recipe rows show owned/required counts; Craft button disabled until materials suffice
- [ ] Craft a recipe: ingredients are consumed, result is added, status shows success
- [ ] Attempt crafting without enough materials -> "Missing materials"
- [ ] Attempt crafting with a full inventory -> "Inventory full"
- [ ] Verify a client (non-host) can craft and the inventory syncs correctly
- [ ] Confirm crafted items persist after a map change / relog

Closes #99