### PR TITLE
Player-to-player trading: proximity-based dual-confirmation

### DIFF
--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -121,6 +121,10 @@ func remove_player(id: int):
 	# Notify PartyManager
 	if PartyManager:
 		PartyManager._on_player_disconnected(id)
+
+	# Tear down any trade the disconnecting player was involved in
+	if TradeManager:
+		TradeManager.handle_player_disconnect(id)
 	
 	# Remove from active players
 	if id in active_players:

--- a/scripts/Player/player_hud.gd
+++ b/scripts/Player/player_hud.gd
@@ -13,6 +13,11 @@ var chat_window_scene = preload("res://scenes/UI/ChatWindow.tscn")
 var death_popup_instance: DeathPopup
 var ping_display_script = preload("res://scripts/UI/ping_display.gd")
 
+## Player-to-player trade UI. The window is created lazily when a trade session
+## opens; the request popup is created per incoming request.
+var _trade_window: TradeWindow = null
+var _trade_request_popup: TradeRequestPopup = null
+
 @onready var health_bar: TextureProgressBar = $BottomStatsContainer/HealthBar
 @onready var hp_value_label: Label = $BottomStatsContainer/HealthBar/HPValueLabel
 
@@ -43,6 +48,10 @@ func _ready() -> void:
 	
 	# Connect to PartyManager invite signal
 	PartyManager.party_invite_received.connect(_on_party_invite_received)
+
+	# Connect to TradeManager signals for player-to-player trading
+	TradeManager.trade_request_received.connect(_on_trade_request_received)
+	TradeManager.trade_session_opened.connect(_on_trade_session_opened)
 
 	# Setup Scrolling Log
 	var scrolling_log_instance = scrolling_log_scene.instantiate()
@@ -89,6 +98,29 @@ func _on_party_invite_received(inviter_id: int, inviter_username: String, party_
 	add_child(invite_popup)
 	invite_popup.set_invite_data(inviter_id, inviter_username, party_id)
 	invite_popup.show()
+
+
+## An incoming trade request — show an accept/decline popup.
+func _on_trade_request_received(_requester_id: int, requester_name: String) -> void:
+	if is_instance_valid(_trade_request_popup):
+		_trade_request_popup.queue_free()
+	_trade_request_popup = TradeRequestPopup.create(requester_name)
+	if moveable_windows_container:
+		moveable_windows_container.add_child(_trade_request_popup)
+	else:
+		add_child(_trade_request_popup)
+	_trade_request_popup.present()
+
+
+## A trade session has been established — open the dual-offer trade window.
+func _on_trade_session_opened(partner_id: int, partner_name: String) -> void:
+	if not is_instance_valid(_trade_window):
+		_trade_window = TradeWindow.create_player_window()
+		if moveable_windows_container:
+			moveable_windows_container.add_child(_trade_window)
+		else:
+			add_child(_trade_window)
+	_trade_window.open_session(partner_id, partner_name)
 
 func _input(event: InputEvent) -> void:
 	if player.player_id != multiplayer.get_unique_id():

--- a/scripts/Trading/trade_manager.gd
+++ b/scripts/Trading/trade_manager.gd
@@ -1,27 +1,115 @@
 extends Node
 
+## Server-authoritative player-to-player trading.
+##
+## Two trade flows live here:
+##  * Player <-> Player — a proximity-gated, dual-confirmation offer/swap session.
+##    A player sends a trade request; the target accepts; both place items/gold
+##    into their offer; both press Confirm; the server atomically swaps.
+##  * Player <-> Bot — an instant give/take used by the bot trade window.
+##    Bots have no client, so there is no offer/confirm step.
+##
+## All inventory mutations happen on the server. Clients only send intent
+## (request / accept / decline / offer item / set gold / confirm / cancel).
+
 signal trade_started(trade_id: int, player_a: int, player_b: int)
 signal trade_updated(trade_id: int)
 signal trade_completed(trade_id: int)
 signal trade_cancelled(trade_id: int)
 
-var _active_trades: Dictionary = {}
-var _player_trade_map: Dictionary = {}
+## Client-side signals consumed by the trade UI.
+signal trade_request_received(requester_id: int, requester_name: String)
+signal trade_session_opened(partner_id: int, partner_name: String)
+signal trade_session_updated(data: Dictionary)
+signal trade_session_closed(message: String)
+
+var _active_trades: Dictionary = {}        # trade_id -> session Dictionary
+var _player_trade_map: Dictionary = {}     # player_id -> trade_id
+var _pending_requests: Dictionary = {}     # target_id -> requester_id
 var _next_trade_id: int = 1
 
 const MAX_TRADE_SLOTS: int = 8
+## Maximum world-space distance between two players for a trade to start/continue.
+const TRADE_RANGE: float = 120.0
+## Squared range — avoids a sqrt on the per-frame proximity check.
+const TRADE_RANGE_SQ: float = TRADE_RANGE * TRADE_RANGE
+## How often the server re-checks that both traders are still in range.
+const PROXIMITY_CHECK_INTERVAL: float = 0.5
+
+var _proximity_timer: float = 0.0
 
 
-func request_trade(initiator_id: int, target_id: int) -> int:
+func _process(delta: float) -> void:
+	if not multiplayer.is_server() or _active_trades.is_empty():
+		return
+	_proximity_timer += delta
+	if _proximity_timer < PROXIMITY_CHECK_INTERVAL:
+		return
+	_proximity_timer = 0.0
+	_enforce_proximity()
+
+
+#=============================================================================
+# PLAYER <-> PLAYER: REQUEST / ACCEPT
+#=============================================================================
+
+## [SERVER] A player asks another nearby player to trade. Returns true if the
+## request was sent. Bot targets skip the request step entirely.
+func request_trade(initiator_id: int, target_id: int) -> bool:
 	if not multiplayer.is_server():
-		return -1
+		return false
+
+	if initiator_id == target_id:
+		return false
+
+	# Bots have no client/UI — go straight to an instant give/take session.
+	if BotManager.is_bot(target_id):
+		return _start_bot_trade(initiator_id, target_id)
 
 	if _player_trade_map.has(initiator_id):
-		#print("TradeManager: Player %d is already in a trade." % initiator_id)
-		return -1
+		_notify_player(initiator_id, "You are already trading.", Color.ORANGE)
+		return false
 	if _player_trade_map.has(target_id):
-		#print("TradeManager: Target %d is already in a trade." % target_id)
-		return -1
+		_notify_player(initiator_id, "That player is already trading.", Color.ORANGE)
+		return false
+	if _pending_requests.has(target_id):
+		_notify_player(initiator_id, "That player has a pending trade request.", Color.ORANGE)
+		return false
+
+	if not _players_in_range(initiator_id, target_id):
+		_notify_player(initiator_id, "You must be closer to trade.", Color.ORANGE)
+		return false
+
+	# One outgoing request per player — drop any earlier unanswered one.
+	for pending_target in _pending_requests.keys():
+		if _pending_requests[pending_target] == initiator_id:
+			_pending_requests.erase(pending_target)
+
+	_pending_requests[target_id] = initiator_id
+	var initiator_name := _get_player_name(initiator_id)
+	_client_receive_trade_request.rpc_id(target_id, initiator_id, initiator_name)
+	_notify_player(initiator_id, "Trade request sent to %s." % _get_player_name(target_id), Color.CYAN)
+	return true
+
+
+## [SERVER] The target accepts a pending trade request, opening a session.
+func accept_trade_request(target_id: int) -> bool:
+	if not multiplayer.is_server():
+		return false
+
+	var initiator_id: int = _pending_requests.get(target_id, -1)
+	if initiator_id == -1:
+		return false
+	_pending_requests.erase(target_id)
+
+	# Re-validate: either side may have started another trade, or moved away.
+	if _player_trade_map.has(initiator_id) or _player_trade_map.has(target_id):
+		_notify_player(target_id, "Trade no longer available.", Color.ORANGE)
+		return false
+	if not _players_in_range(initiator_id, target_id):
+		_notify_player(initiator_id, "Trade partner moved out of range.", Color.ORANGE)
+		_notify_player(target_id, "Trade partner moved out of range.", Color.ORANGE)
+		return false
 
 	var trade_id := _next_trade_id
 	_next_trade_id += 1
@@ -34,22 +122,35 @@ func request_trade(initiator_id: int, target_id: int) -> int:
 		"offer_b": {"items": [], "gold": 0},
 		"confirmed_a": false,
 		"confirmed_b": false,
-		"is_bot_trade": BotManager.is_bot(target_id),
 	}
-
 	_active_trades[trade_id] = session
 	_player_trade_map[initiator_id] = trade_id
 	_player_trade_map[target_id] = trade_id
 
-	#print("TradeManager: Trade %d started between %d and %d." % [trade_id, initiator_id, target_id])
 	trade_started.emit(trade_id, initiator_id, target_id)
+	_open_session_for(initiator_id, trade_id)
+	_open_session_for(target_id, trade_id)
+	_sync_trade_to_client(initiator_id, trade_id)
+	_sync_trade_to_client(target_id, trade_id)
+	return true
 
-	if not BotManager.is_bot(initiator_id):
-		_sync_trade_to_client(initiator_id, trade_id)
 
-	return trade_id
+## [SERVER] The target declines a pending trade request.
+func decline_trade_request(target_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var initiator_id: int = _pending_requests.get(target_id, -1)
+	if initiator_id == -1:
+		return
+	_pending_requests.erase(target_id)
+	_notify_player(initiator_id, "%s declined your trade request." % _get_player_name(target_id), Color.ORANGE)
 
 
+#=============================================================================
+# PLAYER <-> PLAYER: OFFER MANIPULATION
+#=============================================================================
+
+## [SERVER] Places the item in inventory `slot_index` into the player's offer.
 func add_item_to_trade(player_id: int, slot_index: int) -> bool:
 	if not multiplayer.is_server():
 		return false
@@ -62,34 +163,39 @@ func add_item_to_trade(player_id: int, slot_index: int) -> bool:
 	var offer: Dictionary = session[offer_key]
 
 	if offer.items.size() >= MAX_TRADE_SLOTS:
+		_notify_player(player_id, "Trade offer is full.", Color.ORANGE)
 		return false
 
 	var player_node := PlayerManager.get_player_node(player_id)
 	if not is_instance_valid(player_node) or not is_instance_valid(player_node.inventory_component):
 		return false
 
-	var slots := player_node.inventory_component.get_slots()
+	var slots: Array = player_node.inventory_component.get_slots()
 	if slot_index < 0 or slot_index >= slots.size():
 		return false
 
-	var slot = slots[slot_index]
+	var slot: SlotData = slots[slot_index]
 	if not slot.item:
 		return false
 
+	# A slot may only be offered once.
 	for existing in offer.items:
 		if existing.slot_index == slot_index:
 			return false
 
-	offer.items.append({"slot_index": slot_index, "item_id": slot.item.item_id, "item_name": slot.item.name})
+	offer.items.append({
+		"slot_index": slot_index,
+		"item_id": slot.item.item_id,
+		"item_name": slot.item.name,
+	})
 
-	session.confirmed_a = false
-	session.confirmed_b = false
-
-	_sync_trade_to_client(session.player_a, trade_id)
+	_reset_confirmations(session)
+	_sync_both(trade_id)
 	trade_updated.emit(trade_id)
 	return true
 
 
+## [SERVER] Removes the entry at `trade_slot_index` from the player's offer.
 func remove_item_from_trade(player_id: int, trade_slot_index: int) -> bool:
 	if not multiplayer.is_server():
 		return false
@@ -105,14 +211,13 @@ func remove_item_from_trade(player_id: int, trade_slot_index: int) -> bool:
 		return false
 
 	offer.items.remove_at(trade_slot_index)
-	session.confirmed_a = false
-	session.confirmed_b = false
-
-	_sync_trade_to_client(session.player_a, trade_id)
+	_reset_confirmations(session)
+	_sync_both(trade_id)
 	trade_updated.emit(trade_id)
 	return true
 
 
+## [SERVER] Sets the amount of gold the player offers, clamped to what they own.
 func set_trade_gold(player_id: int, amount: int) -> bool:
 	if not multiplayer.is_server():
 		return false
@@ -129,14 +234,14 @@ func set_trade_gold(player_id: int, amount: int) -> bool:
 
 	amount = clampi(amount, 0, player_node.player_inventory.monies_amount)
 	session[offer_key].gold = amount
-	session.confirmed_a = false
-	session.confirmed_b = false
-
-	_sync_trade_to_client(session.player_a, trade_id)
+	_reset_confirmations(session)
+	_sync_both(trade_id)
 	trade_updated.emit(trade_id)
 	return true
 
 
+## [SERVER] Marks a player as having confirmed their offer. When both sides have
+## confirmed, the trade executes. Any later offer change resets confirmations.
 func confirm_trade(player_id: int) -> bool:
 	if not multiplayer.is_server():
 		return false
@@ -150,93 +255,130 @@ func confirm_trade(player_id: int) -> bool:
 	else:
 		session.confirmed_b = true
 
-	if session.is_bot_trade:
-		session.confirmed_b = _bot_evaluate_trade(trade_id)
-		if not session.confirmed_b:
-			#print("TradeManager: Bot rejected trade %d." % trade_id)
-			_sync_trade_to_client(session.player_a, trade_id)
-			return false
-
 	if session.confirmed_a and session.confirmed_b:
 		_execute_trade(trade_id)
 		return true
 
-	_sync_trade_to_client(session.player_a, trade_id)
+	_sync_both(trade_id)
 	trade_updated.emit(trade_id)
 	return true
 
 
+## [SERVER] Clears a confirmation without touching the offer (an "unconfirm").
+func unconfirm_trade(player_id: int) -> bool:
+	if not multiplayer.is_server():
+		return false
+	var trade_id: int = _player_trade_map.get(player_id, -1)
+	if trade_id == -1:
+		return false
+	var session: Dictionary = _active_trades[trade_id]
+	_reset_confirmations(session)
+	_sync_both(trade_id)
+	trade_updated.emit(trade_id)
+	return true
+
+
+## [SERVER] Cancels a trade. Offered items were never removed, so there is
+## nothing to return — the session is simply discarded.
 func cancel_trade(player_id: int) -> void:
 	if not multiplayer.is_server():
 		return
 	var trade_id: int = _player_trade_map.get(player_id, -1)
 	if trade_id == -1:
+		# The player may have an outstanding request rather than a live session.
+		_cancel_pending_for(player_id)
 		return
 
 	var session: Dictionary = _active_trades[trade_id]
-	#print("TradeManager: Trade %d cancelled by %d." % [trade_id, player_id])
-
-	_player_trade_map.erase(session.player_a)
-	_player_trade_map.erase(session.player_b)
-	_active_trades.erase(trade_id)
-
-	if not BotManager.is_bot(session.player_a):
-		_client_trade_closed.rpc_id(session.player_a, "Trade cancelled.")
-	if not BotManager.is_bot(session.player_b):
-		_client_trade_closed.rpc_id(session.player_b, "Trade cancelled.")
-
+	_close_session(trade_id, "Trade cancelled.")
 	trade_cancelled.emit(trade_id)
 
 
+## Drops any pending request that names `player_id` as initiator or target.
+func _cancel_pending_for(player_id: int) -> void:
+	if _pending_requests.has(player_id):
+		_pending_requests.erase(player_id)
+	for target_id in _pending_requests.keys():
+		if _pending_requests[target_id] == player_id:
+			_pending_requests.erase(target_id)
+
+
+#=============================================================================
+# PLAYER <-> PLAYER: EXECUTION
+#=============================================================================
+
+## Validates both inventories still hold the offered items (and enough gold),
+## then atomically swaps items and gold between the two players.
 func _execute_trade(trade_id: int) -> void:
-	var session: Dictionary = _active_trades[trade_id]
+	var session: Dictionary = _active_trades.get(trade_id, {})
+	if session.is_empty():
+		return
+
 	var node_a := PlayerManager.get_player_node(session.player_a)
 	var node_b := PlayerManager.get_player_node(session.player_b)
-
 	if not is_instance_valid(node_a) or not is_instance_valid(node_b):
-		cancel_trade(session.player_a)
+		_close_session(trade_id, "Trade failed: partner unavailable.")
 		return
 
 	var inv_a: InventoryComponent = node_a.inventory_component
 	var inv_b: InventoryComponent = node_b.inventory_component
 	var pinv_a: PlayerInventory = node_a.player_inventory
 	var pinv_b: PlayerInventory = node_b.player_inventory
+	if not (is_instance_valid(inv_a) and is_instance_valid(inv_b) \
+			and is_instance_valid(pinv_a) and is_instance_valid(pinv_b)):
+		_close_session(trade_id, "Trade failed: inventory unavailable.")
+		return
 
-	if not is_instance_valid(inv_a) or not is_instance_valid(inv_b):
-		cancel_trade(session.player_a)
+	# Re-check proximity at the moment of execution.
+	if not _players_in_range(session.player_a, session.player_b):
+		_close_session(trade_id, "Trade failed: partner out of range.")
 		return
 
 	var offer_a: Dictionary = session.offer_a
 	var offer_b: Dictionary = session.offer_b
 
-	# Collect actual items from slots before removing
-	var items_from_a: Array = []
-	var slots_a := inv_a.get_slots()
-	for entry in offer_a.items:
-		var idx: int = entry.slot_index
-		if idx >= 0 and idx < slots_a.size() and slots_a[idx].item:
-			items_from_a.append(slots_a[idx].item)
+	# --- VALIDATE: offered items still exist in the named slots ---
+	var items_from_a := _collect_offered_items(inv_a, offer_a.items)
+	if items_from_a.is_empty() and not offer_a.items.is_empty():
+		_close_session(trade_id, "Trade failed: an offered item is missing.")
+		return
+	var items_from_b := _collect_offered_items(inv_b, offer_b.items)
+	if items_from_b.is_empty() and not offer_b.items.is_empty():
+		_close_session(trade_id, "Trade failed: an offered item is missing.")
+		return
 
-	var items_from_b: Array = []
-	var slots_b := inv_b.get_slots()
-	for entry in offer_b.items:
-		var idx: int = entry.slot_index
-		if idx >= 0 and idx < slots_b.size() and slots_b[idx].item:
-			items_from_b.append(slots_b[idx].item)
+	# --- VALIDATE: enough gold on hand ---
+	if pinv_a.monies_amount < offer_a.gold or pinv_b.monies_amount < offer_b.gold:
+		_close_session(trade_id, "Trade failed: not enough gold.")
+		return
 
-	# Remove items from sources
+	# --- VALIDATE: receiving side has type-appropriate space for the items ---
+	# Each side frees its own offered slots before receiving them, so the check
+	# simulates the swap against the post-removal slot layout.
+	if not _can_receive(inv_a, items_from_b, items_from_a) \
+			or not _can_receive(inv_b, items_from_a, items_from_b):
+		_close_session(trade_id, "Trade failed: not enough inventory space.")
+		return
+
+	# --- COMMIT: all validation passed, perform the swap atomically ---
+	# Snapshot item dictionaries before removal (removal mutates the slot data).
+	var dicts_from_a: Array = []
+	for item in items_from_a:
+		dicts_from_a.append(item.to_dictionary())
+	var dicts_from_b: Array = []
+	for item in items_from_b:
+		dicts_from_b.append(item.to_dictionary())
+
 	for item in items_from_a:
 		inv_a.remove_item(item, "traded")
 	for item in items_from_b:
 		inv_b.remove_item(item, "traded")
 
-	# Add items to recipients
-	for item in items_from_a:
-		inv_b.server_add_item_instance(item.to_dictionary())
-	for item in items_from_b:
-		inv_a.server_add_item_instance(item.to_dictionary())
+	for item_dict in dicts_from_a:
+		inv_b.server_add_item_instance(item_dict)
+	for item_dict in dicts_from_b:
+		inv_a.server_add_item_instance(item_dict)
 
-	# Transfer gold
 	if offer_a.gold > 0:
 		pinv_a.monies_amount -= offer_a.gold
 		pinv_b.monies_amount += offer_a.gold
@@ -244,163 +386,133 @@ func _execute_trade(trade_id: int) -> void:
 		pinv_b.monies_amount -= offer_b.gold
 		pinv_a.monies_amount += offer_b.gold
 
-	#print("TradeManager: Trade %d completed. %d items A→B, %d items B→A, gold A→B: %d, B→A: %d" % [trade_id, items_from_a.size(), items_from_b.size(), offer_a.gold, offer_b.gold])
-
 	_player_trade_map.erase(session.player_a)
 	_player_trade_map.erase(session.player_b)
 	_active_trades.erase(trade_id)
 
-	if not BotManager.is_bot(session.player_a):
-		_client_trade_closed.rpc_id(session.player_a, "Trade completed!")
-	if not BotManager.is_bot(session.player_b):
-		_client_trade_closed.rpc_id(session.player_b, "Trade completed!")
-
+	_client_trade_closed.rpc_id(session.player_a, "Trade completed!")
+	_client_trade_closed.rpc_id(session.player_b, "Trade completed!")
 	trade_completed.emit(trade_id)
 
 
-func _bot_evaluate_trade(trade_id: int) -> bool:
-	var session: Dictionary = _active_trades[trade_id]
-	var bot_id: int = session.player_b
-	var bot_node := PlayerManager.get_player_node(bot_id)
-	if not is_instance_valid(bot_node):
-		return false
+## Simulates whether `incoming` items can land in `inv` after `outgoing` items
+## have been removed from it. Respects per-slot item-type restrictions and
+## stacking so the check matches what server_add_item_instance will actually do.
+func _can_receive(inv: InventoryComponent, incoming: Array, outgoing: Array) -> bool:
+	if incoming.is_empty():
+		return true
 
-	var class_type: Constants.ClassType = Constants.ClassType.BEGINNER
-	if is_instance_valid(bot_node.class_component):
-		class_type = bot_node.class_component.current_class
+	# Model the inventory as a list of cells after the outgoing removals.
+	# Each cell tracks its slot type, occupied item name (or "" if empty) and
+	# remaining stack space, so stacking is simulated accurately.
+	var sim: Array = []
+	var outgoing_set := {}
+	for item in outgoing:
+		outgoing_set[item] = true
 
-	var offer_a: Dictionary = session.offer_a
-	var offer_b: Dictionary = session.offer_b
+	for sd in inv.get_slots():
+		var held: ItemData = sd.item
+		# A slot whose item is being traded away counts as empty.
+		if held != null and outgoing_set.has(held):
+			held = null
+		var cell := {
+			"type": sd.allowed_item_type,
+			"name": "" if held == null else held.name,
+			"space": 0,
+		}
+		if held != null and held.can_stack:
+			cell.space = held.max_stack_amount - held.current_stack_amount
+		sim.append(cell)
 
-	# Score incoming items (what bot receives)
-	var incoming_value: float = float(offer_a.gold)
-	var inv_a := PlayerManager.get_player_node(session.player_a).inventory_component
-	var slots_a := inv_a.get_slots()
-	for entry in offer_a.items:
-		var idx: int = entry.slot_index
-		if idx >= 0 and idx < slots_a.size() and slots_a[idx].item:
-			var score := BotEquipmentLogic.score_item(slots_a[idx].item, class_type)
-			incoming_value += maxf(score, 0.0) * 10.0
-
-	# Score outgoing items (what bot gives away)
-	var outgoing_value: float = float(offer_b.gold)
-	var inv_b := bot_node.inventory_component
-	var slots_b := inv_b.get_slots()
-	for entry in offer_b.items:
-		var idx: int = entry.slot_index
-		if idx >= 0 and idx < slots_b.size() and slots_b[idx].item:
-			var score := BotEquipmentLogic.score_item(slots_b[idx].item, class_type)
-			outgoing_value += maxf(score, 0.0) * 10.0
-
-	return incoming_value >= outgoing_value
-
-
-func _sync_trade_to_client(player_id: int, trade_id: int) -> void:
-	if BotManager.is_bot(player_id):
-		return
-
-	var session: Dictionary = _active_trades.get(trade_id, {})
-	if session.is_empty():
-		return
-
-	var data := {
-		"trade_id": trade_id,
-		"partner_id": session.player_b if session.player_a == player_id else session.player_a,
-		"my_offer": session.offer_a if session.player_a == player_id else session.offer_b,
-		"partner_offer": session.offer_b if session.player_a == player_id else session.offer_a,
-		"my_confirmed": session.confirmed_a if session.player_a == player_id else session.confirmed_b,
-		"partner_confirmed": session.confirmed_b if session.player_a == player_id else session.confirmed_a,
-		"is_bot_trade": session.is_bot_trade,
-	}
-
-	# Add partner name
-	var partner_id: int = data.partner_id
-	if BotManager.is_bot(partner_id) and partner_id in BotManager.active_bots:
-		data["partner_name"] = BotManager.active_bots[partner_id].username
-	else:
-		var pinfo = PlayerManager.get_player_info(partner_id)
-		data["partner_name"] = pinfo.get("username", str(partner_id))
-
-	_client_receive_trade_data.rpc_id(player_id, data)
-
-
-# --- RPCs ---
-
-@rpc("any_peer", "call_local", "reliable")
-func rpc_request_trade(target_name: String) -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-
-	var target_id := PlayerManager.get_player_id_from_name(target_name)
-	if target_id == -1:
-		# Check bot names
-		for bot_id in BotManager.active_bots:
-			if BotManager.active_bots[bot_id].username.to_lower() == target_name.to_lower():
-				target_id = bot_id
+	for item in incoming:
+		var remaining: int = item.current_stack_amount if item.can_stack else 1
+		# Fill existing same-named stacks first.
+		if item.can_stack:
+			for cell in sim:
+				if remaining <= 0:
+					break
+				if cell.name == item.name and cell.space > 0:
+					var used: int = mini(remaining, cell.space)
+					cell.space -= used
+					remaining -= used
+		# Then drop the rest into empty, type-compatible slots.
+		while remaining > 0:
+			var slotted := false
+			for cell in sim:
+				if cell.name != "":
+					continue
+				if cell.type != Constants.ItemType.ANY and cell.type != item.item_type:
+					continue
+				cell.name = item.name
+				cell.space = (item.max_stack_amount - mini(remaining, item.max_stack_amount)) if item.can_stack else 0
+				remaining -= (mini(remaining, item.max_stack_amount) if item.can_stack else 1)
+				slotted = true
 				break
-	if target_id == -1:
-		return
-
-	request_trade(sender_id, target_id)
-
-
-@rpc("any_peer", "call_local", "reliable")
-func rpc_add_item(slot_index: int) -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-	add_item_to_trade(sender_id, slot_index)
+			if not slotted:
+				return false
+	return true
 
 
-@rpc("any_peer", "call_local", "reliable")
-func rpc_remove_item(trade_slot_index: int) -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-	remove_item_from_trade(sender_id, trade_slot_index)
+## Resolves an offer's slot entries to the live ItemData objects. Returns an
+## empty Array if any entry no longer points at its expected item.
+func _collect_offered_items(inv: InventoryComponent, offer_items: Array) -> Array:
+	var result: Array = []
+	var slots: Array = inv.get_slots()
+	for entry in offer_items:
+		var idx: int = entry.slot_index
+		if idx < 0 or idx >= slots.size():
+			return []
+		var slot: SlotData = slots[idx]
+		# The slot must still hold the same item the player offered.
+		if not slot.item or slot.item.item_id != entry.item_id:
+			return []
+		result.append(slot.item)
+	return result
 
 
-@rpc("any_peer", "call_local", "reliable")
-func rpc_set_gold(amount: int) -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-	set_trade_gold(sender_id, amount)
+#=============================================================================
+# PROXIMITY
+#=============================================================================
+
+## True when both players exist, share a map, and are within TRADE_RANGE.
+func _players_in_range(id_a: int, id_b: int) -> bool:
+	var node_a := PlayerManager.get_player_node(id_a)
+	var node_b := PlayerManager.get_player_node(id_b)
+	if not is_instance_valid(node_a) or not is_instance_valid(node_b):
+		return false
+	if MapManager.get_player_map(id_a) != MapManager.get_player_map(id_b):
+		return false
+	return node_a.global_position.distance_squared_to(node_b.global_position) <= TRADE_RANGE_SQ
 
 
-@rpc("any_peer", "call_local", "reliable")
-func rpc_confirm_trade() -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-	confirm_trade(sender_id)
+## Cancels any active trade whose partners have drifted out of range.
+func _enforce_proximity() -> void:
+	for trade_id in _active_trades.keys():
+		var session: Dictionary = _active_trades[trade_id]
+		if not _players_in_range(session.player_a, session.player_b):
+			_close_session(trade_id, "Trade cancelled: partner out of range.")
+			trade_cancelled.emit(trade_id)
 
 
-@rpc("any_peer", "call_local", "reliable")
-func rpc_cancel_trade() -> void:
-	if not multiplayer.is_server():
-		return
-	var sender_id := multiplayer.get_remote_sender_id()
-	if sender_id == 0:
-		sender_id = multiplayer.get_unique_id()
-	cancel_trade(sender_id)
+#=============================================================================
+# BOT TRADE (instant give/take — no offer/confirm step)
+#=============================================================================
+
+## Opens the instant bot-trade window on the requesting client. Bots have no
+## offer/confirm flow; items move one at a time through _transfer_trade_item.
+func _start_bot_trade(initiator_id: int, bot_id: int) -> bool:
+	if BotManager.is_bot(initiator_id):
+		return false
+	if not _players_in_range(initiator_id, bot_id):
+		_notify_player(initiator_id, "You must be closer to trade.", Color.ORANGE)
+		return false
+	_client_open_bot_trade.rpc_id(initiator_id, bot_id)
+	return true
 
 
 ## [Client/Host -> Server] Immediately moves one item between the requesting
 ## player and a bot. The bot trade window has no offer/confirm step, so the
-## transfer must run server-side where every inventory is authoritative — a
-## client holds no real data for the bot's inventory.
+## transfer runs server-side where every inventory is authoritative.
 @rpc("any_peer", "call_local", "reliable")
 func rpc_transfer_trade_item(target_id: int, slot_index: int, giving: bool) -> void:
 	if not multiplayer.is_server():
@@ -411,17 +523,21 @@ func rpc_transfer_trade_item(target_id: int, slot_index: int, giving: bool) -> v
 	_transfer_trade_item(sender_id, target_id, slot_index, giving)
 
 
-## Moves one item between `player_id` and `target_id`. `giving` true => player
-## gives to target; false => player takes from target.
+## Moves one item between `player_id` and a bot `target_id`. `giving` true =>
+## player gives to the bot; false => player takes from the bot.
 func _transfer_trade_item(player_id: int, target_id: int, slot_index: int, giving: bool) -> void:
-	# The bot trade window only trades with bots; gating here stops this RPC
-	# from being used to move items in or out of another real player.
+	# This RPC only ever trades with bots — gating here stops it being abused
+	# to move items in or out of another real player's inventory.
 	if not BotManager.is_bot(target_id):
 		return
 
 	var player_node := PlayerManager.get_player_node(player_id)
 	var target_node := PlayerManager.get_player_node(target_id)
 	if not is_instance_valid(player_node) or not is_instance_valid(target_node):
+		return
+
+	if not _players_in_range(player_id, target_id):
+		_notify_player(player_id, "You moved too far from the trader.", Color.ORANGE)
 		return
 
 	var player_inv: InventoryComponent = player_node.inventory_component
@@ -451,44 +567,278 @@ func _transfer_trade_item(player_id: int, target_id: int, slot_index: int, givin
 	dest_inv.server_add_item_instance(item.to_dictionary())
 
 
+#=============================================================================
+# SYNC HELPERS
+#=============================================================================
+
+func _reset_confirmations(session: Dictionary) -> void:
+	session.confirmed_a = false
+	session.confirmed_b = false
+
+
+func _sync_both(trade_id: int) -> void:
+	var session: Dictionary = _active_trades.get(trade_id, {})
+	if session.is_empty():
+		return
+	_sync_trade_to_client(session.player_a, trade_id)
+	_sync_trade_to_client(session.player_b, trade_id)
+
+
+## Sends one player their view of the trade (their offer, partner's offer,
+## both confirmation flags). Includes partner-item display data because a
+## client has no authoritative copy of the partner's inventory.
+func _sync_trade_to_client(player_id: int, trade_id: int) -> void:
+	var session: Dictionary = _active_trades.get(trade_id, {})
+	if session.is_empty():
+		return
+
+	var is_a := session.player_a == player_id
+	var partner_id: int = session.player_b if is_a else session.player_a
+
+	var data := {
+		"trade_id": trade_id,
+		"partner_id": partner_id,
+		"partner_name": _get_player_name(partner_id),
+		# The player's own offer carries slot indices so the client can mark
+		# those inventory slots as already-offered without local guesswork.
+		"my_offer": _offer_display(session.player_a if is_a else session.player_b,
+				session.offer_a if is_a else session.offer_b, true),
+		"partner_offer": _offer_display(partner_id,
+				session.offer_b if is_a else session.offer_a, false),
+		"my_confirmed": session.confirmed_a if is_a else session.confirmed_b,
+		"partner_confirmed": session.confirmed_b if is_a else session.confirmed_a,
+	}
+	_client_receive_trade_data.rpc_id(player_id, data)
+
+
+## Builds a display-ready offer: each item carries its full dictionary so the
+## recipient client can render an item it does not own. When `with_slots` is
+## true, each item dictionary also carries a "trade_slot_index" field — the
+## owner's inventory slot — so the owning client knows which slots are offered.
+func _offer_display(owner_id: int, offer: Dictionary, with_slots: bool) -> Dictionary:
+	var node := PlayerManager.get_player_node(owner_id)
+	var items: Array = []
+	if is_instance_valid(node) and is_instance_valid(node.inventory_component):
+		var slots: Array = node.inventory_component.get_slots()
+		for entry in offer.items:
+			var idx: int = entry.slot_index
+			var item_dict: Dictionary
+			if idx >= 0 and idx < slots.size() and slots[idx].item:
+				item_dict = slots[idx].item.to_dictionary()
+			else:
+				# Item vanished (e.g. dropped) — show a placeholder by name.
+				item_dict = {"name": entry.item_name}
+			if with_slots:
+				item_dict["trade_slot_index"] = idx
+			items.append(item_dict)
+	return {"items": items, "gold": offer.gold}
+
+
+## Removes a trade session and tells both clients to close their window.
+func _close_session(trade_id: int, message: String) -> void:
+	var session: Dictionary = _active_trades.get(trade_id, {})
+	if session.is_empty():
+		return
+	_player_trade_map.erase(session.player_a)
+	_player_trade_map.erase(session.player_b)
+	_active_trades.erase(trade_id)
+	if not BotManager.is_bot(session.player_a):
+		_client_trade_closed.rpc_id(session.player_a, message)
+	if not BotManager.is_bot(session.player_b):
+		_client_trade_closed.rpc_id(session.player_b, message)
+
+
+func _open_session_for(player_id: int, trade_id: int) -> void:
+	if BotManager.is_bot(player_id):
+		return
+	var session: Dictionary = _active_trades[trade_id]
+	var partner_id: int = session.player_b if session.player_a == player_id else session.player_a
+	_client_open_session.rpc_id(player_id, partner_id, _get_player_name(partner_id))
+
+
+func _get_player_name(player_id: int) -> String:
+	var node := PlayerManager.get_player_node(player_id)
+	if is_instance_valid(node) and not node.username.is_empty():
+		return node.username
+	if BotManager.is_bot(player_id) and player_id in BotManager.active_bots:
+		return BotManager.active_bots[player_id].get("username", "Bot %d" % player_id)
+	var info: Dictionary = PlayerManager.get_player_info(player_id)
+	return info.get("username", str(player_id))
+
+
 ## Sends a system message to a player — directly if it is the host, else by RPC.
 func _notify_player(player_id: int, message: String, color: Color) -> void:
+	if BotManager.is_bot(player_id):
+		return
 	if player_id == multiplayer.get_unique_id():
 		ChatManager.add_system_message(message, color)
 	else:
 		ChatManager.add_system_message.rpc_id(player_id, message, color)
 
 
-var _trade_window: TradeWindow = null
+#=============================================================================
+# DISCONNECT HANDLING
+#=============================================================================
+
+## Called by PlayerManager when a peer disconnects. Tears down any trade or
+## pending request the player was involved in.
+func handle_player_disconnect(player_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	_cancel_pending_for(player_id)
+	var trade_id: int = _player_trade_map.get(player_id, -1)
+	if trade_id != -1:
+		_close_session(trade_id, "Trade cancelled: partner disconnected.")
+		trade_cancelled.emit(trade_id)
 
 
-func _get_or_create_trade_window() -> TradeWindow:
-	if is_instance_valid(_trade_window):
-		return _trade_window
-	_trade_window = TradeWindow.create()
+#=============================================================================
+# RPCs — CLIENT -> SERVER (intent only)
+#=============================================================================
+
+func _sender() -> int:
+	var sender_id := multiplayer.get_remote_sender_id()
+	return sender_id if sender_id != 0 else multiplayer.get_unique_id()
+
+
+## [CLIENT -> SERVER] Request a trade with a target by name (legacy / chat path).
+@rpc("any_peer", "call_local", "reliable")
+func rpc_request_trade(target_name: String) -> void:
+	if not multiplayer.is_server():
+		return
+	var target_id := PlayerManager.get_player_id_from_name(target_name)
+	if target_id == -1:
+		for bot_id in BotManager.active_bots:
+			if BotManager.active_bots[bot_id].username.to_lower() == target_name.to_lower():
+				target_id = bot_id
+				break
+	if target_id == -1:
+		_notify_player(_sender(), "No player named '%s' found." % target_name, Color.ORANGE)
+		return
+	request_trade(_sender(), target_id)
+
+
+## [CLIENT -> SERVER] Request a trade with a target by peer id (context menu).
+@rpc("any_peer", "call_local", "reliable")
+func rpc_request_trade_with_id(target_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	request_trade(_sender(), target_id)
+
+
+## [CLIENT -> SERVER] Accept an incoming trade request.
+@rpc("any_peer", "call_local", "reliable")
+func rpc_accept_trade_request() -> void:
+	if not multiplayer.is_server():
+		return
+	accept_trade_request(_sender())
+
+
+## [CLIENT -> SERVER] Decline an incoming trade request.
+@rpc("any_peer", "call_local", "reliable")
+func rpc_decline_trade_request() -> void:
+	if not multiplayer.is_server():
+		return
+	decline_trade_request(_sender())
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_add_item(slot_index: int) -> void:
+	if not multiplayer.is_server():
+		return
+	add_item_to_trade(_sender(), slot_index)
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_remove_item(trade_slot_index: int) -> void:
+	if not multiplayer.is_server():
+		return
+	remove_item_from_trade(_sender(), trade_slot_index)
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_set_gold(amount: int) -> void:
+	if not multiplayer.is_server():
+		return
+	set_trade_gold(_sender(), amount)
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_confirm_trade() -> void:
+	if not multiplayer.is_server():
+		return
+	confirm_trade(_sender())
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_unconfirm_trade() -> void:
+	if not multiplayer.is_server():
+		return
+	unconfirm_trade(_sender())
+
+
+@rpc("any_peer", "call_local", "reliable")
+func rpc_cancel_trade() -> void:
+	if not multiplayer.is_server():
+		return
+	cancel_trade(_sender())
+
+
+#=============================================================================
+# RPCs — SERVER -> CLIENT
+#=============================================================================
+
+## [SERVER -> CLIENT] An incoming trade request — the UI shows an accept popup.
+## call_local so a host targeted by a request also sees the popup.
+@rpc("authority", "call_local", "reliable")
+func _client_receive_trade_request(requester_id: int, requester_name: String) -> void:
+	trade_request_received.emit(requester_id, requester_name)
+
+
+## [SERVER -> CLIENT] A trade session has opened — the UI shows the trade window.
+@rpc("authority", "call_local", "reliable")
+func _client_open_session(partner_id: int, partner_name: String) -> void:
+	trade_session_opened.emit(partner_id, partner_name)
+
+
+## [SERVER -> CLIENT] Authoritative trade state — the UI refreshes both offers.
+@rpc("authority", "call_local", "reliable")
+func _client_receive_trade_data(data: Dictionary) -> void:
+	trade_session_updated.emit(data)
+
+
+## [SERVER -> CLIENT] The trade has ended (completed / cancelled / failed).
+@rpc("authority", "call_local", "reliable")
+func _client_trade_closed(message: String) -> void:
+	trade_session_closed.emit(message)
+	if not message.is_empty():
+		ChatManager.add_system_message(message, Color.CYAN)
+
+
+## [SERVER -> CLIENT] Opens the instant bot-trade window on the requester.
+@rpc("authority", "call_local", "reliable")
+func _client_open_bot_trade(bot_id: int) -> void:
+	var window := _get_or_create_bot_trade_window()
+	if is_instance_valid(window):
+		window.show_for_target(bot_id)
+
+
+#=============================================================================
+# BOT TRADE WINDOW (client-side helper)
+#=============================================================================
+
+var _bot_trade_window: TradeWindow = null
+
+
+func _get_or_create_bot_trade_window() -> TradeWindow:
+	if is_instance_valid(_bot_trade_window):
+		return _bot_trade_window
+	_bot_trade_window = TradeWindow.create_bot_window()
 	var local_player := PlayerManager.get_player_node(multiplayer.get_unique_id())
 	if is_instance_valid(local_player):
 		var container = local_player.get_node_or_null("CanvasLayer/MoveableWindows")
 		if container:
-			container.add_child(_trade_window)
-			return _trade_window
-	# Fallback: add to scene tree root
-	get_tree().current_scene.add_child(_trade_window)
-	return _trade_window
-
-
-@rpc("authority", "call_local", "reliable")
-func _client_receive_trade_data(data: Dictionary) -> void:
-	var target_id: int = data.get("partner_id", -1)
-	if target_id == -1:
-		return
-	var window := _get_or_create_trade_window()
-	window.show_for_target(target_id)
-
-
-@rpc("authority", "call_local", "reliable")
-func _client_trade_closed(message: String) -> void:
-	if is_instance_valid(_trade_window):
-		_trade_window.visible = false
-	if not message.is_empty():
-		ChatManager.add_system_message(message, Color.CYAN)
+			container.add_child(_bot_trade_window)
+			return _bot_trade_window
+	get_tree().current_scene.add_child(_bot_trade_window)
+	return _bot_trade_window

--- a/scripts/UI/player_context_menu.gd
+++ b/scripts/UI/player_context_menu.gd
@@ -140,34 +140,12 @@ func _do_inspect() -> void:
 
 
 func _do_trade() -> void:
-	_open_trade_window(_target_id)
-
-
-func _open_trade_window(target_id: int) -> void:
-	var moveable := _find_moveable_container()
-	if not moveable:
+	if _target_id == 0:
 		return
-
-	var existing: TradeWindow = null
-	for child in moveable.get_children():
-		if child is TradeWindow:
-			existing = child
-			break
-
-	if not existing:
-		existing = TradeWindow.create()
-		moveable.add_child(existing)
-
-	existing.show_for_target(target_id)
-
-
-func _find_moveable_container() -> Node:
-	var player_node := PlayerManager.get_player_node(multiplayer.get_unique_id())
-	if is_instance_valid(player_node):
-		var container = player_node.get_node_or_null("CanvasLayer/MoveableWindows")
-		if container:
-			return container
-	return null
+	# Bots: instant give/take window opens once the server confirms range.
+	# Players: a trade request is sent; the partner must accept before a
+	# session (and its window) opens. The server enforces proximity for both.
+	TradeManager.rpc_request_trade_with_id.rpc_id(1, _target_id)
 
 
 func _do_party_invite() -> void:

--- a/scripts/UI/trade_request_popup.gd
+++ b/scripts/UI/trade_request_popup.gd
@@ -1,0 +1,102 @@
+class_name TradeRequestPopup
+extends Panel
+
+## A small accept/decline popup shown when another player requests a trade.
+## Accepting tells the server to open a trade session; declining dismisses it.
+## Built programmatically to match the PlayerContextMenu / TradeWindow style.
+
+const POPUP_WIDTH: float = 240.0
+const POPUP_HEIGHT: float = 96.0
+## Auto-dismiss if the request is not answered — keeps a stale popup from
+## lingering after the requester has cancelled or moved on.
+const TIMEOUT: float = 20.0
+
+var _answered: bool = false
+var _life_timer: float = 0.0
+
+
+static func create(requester_name: String) -> TradeRequestPopup:
+	var popup := TradeRequestPopup.new()
+	popup.custom_minimum_size = Vector2(POPUP_WIDTH, POPUP_HEIGHT)
+	popup.size = Vector2(POPUP_WIDTH, POPUP_HEIGHT)
+	popup.visible = false
+	popup.mouse_filter = Control.MOUSE_FILTER_STOP
+	popup.add_to_group("ui_window")
+
+	var bg := StyleBoxFlat.new()
+	bg.bg_color = Color(0.12, 0.12, 0.15, 0.97)
+	bg.border_color = Color(0.4, 0.4, 0.5, 1.0)
+	bg.set_border_width_all(2)
+	bg.set_corner_radius_all(4)
+	popup.add_theme_stylebox_override("panel", bg)
+
+	var root := VBoxContainer.new()
+	root.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+	root.add_theme_constant_override("separation", 6)
+	root.offset_left = 8
+	root.offset_top = 8
+	root.offset_right = -8
+	root.offset_bottom = -8
+	popup.add_child(root)
+
+	var label := Label.new()
+	label.text = "%s wants to trade with you." % requester_name
+	label.add_theme_font_size_override("font_size", 11)
+	label.add_theme_color_override("font_color", Color(0.9, 0.85, 0.6))
+	label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	label.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	root.add_child(label)
+
+	var buttons := HBoxContainer.new()
+	buttons.add_theme_constant_override("separation", 8)
+	buttons.alignment = BoxContainer.ALIGNMENT_CENTER
+	root.add_child(buttons)
+
+	var accept := Button.new()
+	accept.text = "Accept"
+	accept.custom_minimum_size = Vector2(100, 26)
+	accept.add_theme_font_size_override("font_size", 11)
+	accept.pressed.connect(popup._on_accept)
+	buttons.add_child(accept)
+
+	var decline := Button.new()
+	decline.text = "Decline"
+	decline.custom_minimum_size = Vector2(100, 26)
+	decline.add_theme_font_size_override("font_size", 11)
+	decline.pressed.connect(popup._on_decline)
+	buttons.add_child(decline)
+
+	return popup
+
+
+func present() -> void:
+	var vp_size := get_viewport_rect().size
+	# Anchor near the top-centre, below where party invites appear.
+	global_position = Vector2((vp_size.x - size.x) * 0.5, 120.0)
+	visible = true
+	move_to_front()
+
+
+func _process(delta: float) -> void:
+	if _answered:
+		return
+	_life_timer += delta
+	if _life_timer >= TIMEOUT:
+		# Treat a timed-out request as a decline so the server clears it.
+		_on_decline()
+
+
+func _on_accept() -> void:
+	if _answered:
+		return
+	_answered = true
+	TradeManager.rpc_accept_trade_request.rpc_id(1)
+	queue_free()
+
+
+func _on_decline() -> void:
+	if _answered:
+		return
+	_answered = true
+	TradeManager.rpc_decline_trade_request.rpc_id(1)
+	queue_free()

--- a/scripts/UI/trade_window.gd
+++ b/scripts/UI/trade_window.gd
@@ -1,20 +1,40 @@
 class_name TradeWindow
 extends Panel
 
+## Trade window with two modes:
+##  * BOT mode — instant give/take button lists (the player's inventory and the
+##    bot's inventory). Used for trading with bots, which have no client/UI.
+##  * PLAYER mode — a face-to-face dual-offer window: the player's inventory,
+##    their own offer, the partner's offer, gold fields and Confirm buttons.
+##    Items move into the offer only via server-validated RPCs.
+
+enum Mode { BOT, PLAYER }
+
+var _mode: int = Mode.BOT
 var is_dragging := false
 var drag_offset := Vector2()
 var _built := false
 var _target_id: int = 0
 var _refresh_timer: float = 0.0
-## Latest data snapshot for the trade target (their inventory is server-only).
+
+## BOT mode: latest snapshot of the bot (its inventory is server-only).
 var _bot_snapshot: Dictionary = {}
 
-const WINDOW_WIDTH: float = 500.0
-const WINDOW_HEIGHT: float = 520.0
+## PLAYER mode: latest authoritative trade state from the server.
+var _trade_data: Dictionary = {}
+var _my_confirmed: bool = false
+var _partner_confirmed: bool = false
+## PLAYER mode: inventory slot indices currently placed in this player's offer.
+## Rebuilt from authoritative server data on every trade update.
+var _offered_local_slots: Array[int] = []
+
+const WINDOW_WIDTH: float = 520.0
+const WINDOW_HEIGHT: float = 560.0
 const TITLE_HEIGHT: float = 28.0
 const PADDING: float = 8.0
 const REFRESH_INTERVAL: float = 0.5
 const BUTTON_POOL_SIZE: int = 170
+const OFFER_POOL_SIZE: int = 8
 
 var _title_label: Label
 var _my_gold_label: Label
@@ -23,15 +43,49 @@ var _my_inv_container: VBoxContainer
 var _bot_inv_container: VBoxContainer
 var _my_buttons: Array[Button] = []
 var _bot_buttons: Array[Button] = []
-# Track which slot index each button maps to
 var _my_button_slot: Array[int] = []
 var _bot_button_slot: Array[int] = []
+
+# PLAYER mode extra widgets
+var _my_offer_container: VBoxContainer
+var _partner_offer_container: VBoxContainer
+var _my_offer_buttons: Array[Button] = []
+var _partner_offer_labels: Array[Label] = []
+var _my_gold_field: LineEdit
+var _partner_gold_label: Label
+var _confirm_button: Button
+var _my_status_label: Label
+var _partner_status_label: Label
 
 var _hover_bg: StyleBoxFlat
 var _normal_bg: StyleBoxEmpty
 
 
+## Creates a bot-trade window (instant give/take).
+static func create_bot_window() -> TradeWindow:
+	var window := _new_window()
+	window._mode = Mode.BOT
+	window._build_bot_ui()
+	BotManager.bot_snapshot_received.connect(window._on_bot_snapshot)
+	return window
+
+
+## Creates a player-to-player trade window (dual offer/confirm).
+static func create_player_window() -> TradeWindow:
+	var window := _new_window()
+	window._mode = Mode.PLAYER
+	window._build_player_ui()
+	TradeManager.trade_session_updated.connect(window._on_trade_session_updated)
+	TradeManager.trade_session_closed.connect(window._on_trade_session_closed)
+	return window
+
+
+## Backwards-compatible alias — older callers used create() for the bot window.
 static func create() -> TradeWindow:
+	return create_bot_window()
+
+
+static func _new_window() -> TradeWindow:
 	var window := TradeWindow.new()
 	window.custom_minimum_size = Vector2(WINDOW_WIDTH, WINDOW_HEIGHT)
 	window.size = Vector2(WINDOW_WIDTH, WINDOW_HEIGHT)
@@ -51,19 +105,14 @@ static func create() -> TradeWindow:
 	window._hover_bg.bg_color = Color(0.25, 0.25, 0.35, 1.0)
 	window._hover_bg.set_corner_radius_all(2)
 	window._normal_bg = StyleBoxEmpty.new()
-
-	window._build_ui()
-	BotManager.bot_snapshot_received.connect(window._on_bot_snapshot)
 	return window
 
 
-func _build_ui() -> void:
-	var root := VBoxContainer.new()
-	root.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
-	root.add_theme_constant_override("separation", 0)
-	add_child(root)
+#=============================================================================
+# SHARED UI PIECES
+#=============================================================================
 
-	# Title bar
+func _build_title_bar(root: VBoxContainer) -> void:
 	var title_bar := Panel.new()
 	title_bar.custom_minimum_size = Vector2(0, TITLE_HEIGHT)
 	title_bar.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
@@ -95,10 +144,11 @@ func _build_ui() -> void:
 	close_btn.offset_top = 2
 	close_btn.offset_right = -4
 	close_btn.offset_bottom = 26
-	close_btn.pressed.connect(func(): visible = false)
+	close_btn.pressed.connect(_on_close_pressed)
 	title_bar.add_child(close_btn)
 
-	# Content margin
+
+func _build_content_margin(root: VBoxContainer) -> MarginContainer:
 	var margin := MarginContainer.new()
 	margin.add_theme_constant_override("margin_left", int(PADDING))
 	margin.add_theme_constant_override("margin_right", int(PADDING))
@@ -107,34 +157,77 @@ func _build_ui() -> void:
 	margin.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	root.add_child(margin)
+	return margin
 
-	# Two columns side by side
+
+func _make_separator() -> HSeparator:
+	var sep := HSeparator.new()
+	sep.add_theme_constant_override("separation", 4)
+	var sep_style := StyleBoxFlat.new()
+	sep_style.bg_color = Color(0.3, 0.3, 0.4, 0.5)
+	sep_style.content_margin_top = 1
+	sep_style.content_margin_bottom = 1
+	sep.add_theme_stylebox_override("separator", sep_style)
+	return sep
+
+
+func _create_button_pool(container: VBoxContainer, count: int) -> Array[Button]:
+	var pool: Array[Button] = []
+	for i in count:
+		var btn := Button.new()
+		btn.flat = true
+		btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		btn.custom_minimum_size = Vector2(0, 22)
+		btn.add_theme_font_size_override("font_size", 10)
+		btn.add_theme_color_override("font_hover_color", Color(1.0, 0.95, 0.7))
+		btn.add_theme_stylebox_override("hover", _hover_bg)
+		btn.add_theme_stylebox_override("normal", _normal_bg)
+		btn.add_theme_stylebox_override("pressed", _hover_bg)
+		btn.add_theme_stylebox_override("focus", _normal_bg)
+		btn.mouse_filter = Control.MOUSE_FILTER_STOP
+		btn.visible = false
+		container.add_child(btn)
+		pool.append(btn)
+	return pool
+
+
+#=============================================================================
+# BOT MODE UI
+#=============================================================================
+
+func _build_bot_ui() -> void:
+	var root := VBoxContainer.new()
+	root.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+	root.add_theme_constant_override("separation", 0)
+	add_child(root)
+
+	_build_title_bar(root)
+	var margin := _build_content_margin(root)
+
 	var columns := HBoxContainer.new()
 	columns.add_theme_constant_override("separation", 8)
 	columns.size_flags_vertical = Control.SIZE_EXPAND_FILL
 	columns.size_flags_horizontal = Control.SIZE_EXPAND_FILL
 	margin.add_child(columns)
 
-	# Left column: Your inventory
-	var left := _build_column(columns, "Your Items", Color(0.5, 0.8, 1.0))
+	var left := _build_inv_column(columns, "Your Items", Color(0.5, 0.8, 1.0))
 	_my_gold_label = left.gold_label
 	_my_inv_container = left.container
-	_my_buttons = _create_button_pool(_my_inv_container)
+	_my_buttons = _create_button_pool(_my_inv_container, BUTTON_POOL_SIZE)
 	_my_button_slot.resize(BUTTON_POOL_SIZE)
 	_my_button_slot.fill(-1)
 
-	# Right column: Bot inventory
-	var right := _build_column(columns, "Their Items", Color(1.0, 0.8, 0.5))
+	var right := _build_inv_column(columns, "Their Items", Color(1.0, 0.8, 0.5))
 	_bot_gold_label = right.gold_label
 	_bot_inv_container = right.container
-	_bot_buttons = _create_button_pool(_bot_inv_container)
+	_bot_buttons = _create_button_pool(_bot_inv_container, BUTTON_POOL_SIZE)
 	_bot_button_slot.resize(BUTTON_POOL_SIZE)
 	_bot_button_slot.fill(-1)
 
 	_built = true
 
 
-func _build_column(parent: HBoxContainer, header_text: String, header_color: Color) -> Dictionary:
+func _build_inv_column(parent: HBoxContainer, header_text: String, header_color: Color) -> Dictionary:
 	var col := VBoxContainer.new()
 	col.add_theme_constant_override("separation", 4)
 	col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
@@ -153,14 +246,7 @@ func _build_column(parent: HBoxContainer, header_text: String, header_color: Col
 	gold.add_theme_color_override("font_color", Color(0.9, 0.8, 0.3))
 	col.add_child(gold)
 
-	var sep := HSeparator.new()
-	sep.add_theme_constant_override("separation", 4)
-	var sep_style := StyleBoxFlat.new()
-	sep_style.bg_color = Color(0.3, 0.3, 0.4, 0.5)
-	sep_style.content_margin_top = 1
-	sep_style.content_margin_bottom = 1
-	sep.add_theme_stylebox_override("separator", sep_style)
-	col.add_child(sep)
+	col.add_child(_make_separator())
 
 	var scroll := ScrollContainer.new()
 	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
@@ -176,36 +262,205 @@ func _build_column(parent: HBoxContainer, header_text: String, header_color: Col
 	return {"gold_label": gold, "container": container}
 
 
-func _create_button_pool(container: VBoxContainer) -> Array[Button]:
-	var pool: Array[Button] = []
-	for i in BUTTON_POOL_SIZE:
-		var btn := Button.new()
-		btn.flat = true
-		btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
-		btn.custom_minimum_size = Vector2(0, 22)
-		btn.add_theme_font_size_override("font_size", 10)
-		btn.add_theme_color_override("font_hover_color", Color(1.0, 0.95, 0.7))
-		btn.add_theme_stylebox_override("hover", _hover_bg)
-		btn.add_theme_stylebox_override("normal", _normal_bg)
-		btn.add_theme_stylebox_override("pressed", _hover_bg)
-		btn.add_theme_stylebox_override("focus", _normal_bg)
-		btn.mouse_filter = Control.MOUSE_FILTER_STOP
-		btn.visible = false
-		container.add_child(btn)
-		pool.append(btn)
-	return pool
+#=============================================================================
+# PLAYER MODE UI
+#=============================================================================
+
+func _build_player_ui() -> void:
+	var root := VBoxContainer.new()
+	root.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+	root.add_theme_constant_override("separation", 0)
+	add_child(root)
+
+	_build_title_bar(root)
+	var margin := _build_content_margin(root)
+
+	var body := VBoxContainer.new()
+	body.add_theme_constant_override("separation", 6)
+	body.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	body.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	margin.add_child(body)
+
+	# --- Top: two offer panels side by side ---
+	var offers := HBoxContainer.new()
+	offers.add_theme_constant_override("separation", 8)
+	offers.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	offers.custom_minimum_size = Vector2(0, 200)
+	body.add_child(offers)
+
+	var my_col := _build_offer_column(offers, "Your Offer", Color(0.5, 0.8, 1.0), true)
+	_my_offer_container = my_col.container
+	_my_status_label = my_col.status
+	_my_offer_buttons = _create_button_pool(_my_offer_container, OFFER_POOL_SIZE)
+
+	var their_col := _build_offer_column(offers, "Their Offer", Color(1.0, 0.8, 0.5), false)
+	_partner_offer_container = their_col.container
+	_partner_status_label = their_col.status
+	_partner_gold_label = their_col.gold_label
+	for i in OFFER_POOL_SIZE:
+		var lbl := Label.new()
+		lbl.add_theme_font_size_override("font_size", 10)
+		lbl.custom_minimum_size = Vector2(0, 22)
+		lbl.visible = false
+		_partner_offer_container.add_child(lbl)
+		_partner_offer_labels.append(lbl)
+
+	# --- Gold offer row ---
+	var gold_row := HBoxContainer.new()
+	gold_row.add_theme_constant_override("separation", 6)
+	body.add_child(gold_row)
+	var gold_caption := Label.new()
+	gold_caption.text = "Your Gold:"
+	gold_caption.add_theme_font_size_override("font_size", 11)
+	gold_caption.add_theme_color_override("font_color", Color(0.9, 0.8, 0.3))
+	gold_row.add_child(gold_caption)
+	_my_gold_field = LineEdit.new()
+	_my_gold_field.text = "0"
+	_my_gold_field.custom_minimum_size = Vector2(110, 24)
+	_my_gold_field.add_theme_font_size_override("font_size", 11)
+	_my_gold_field.text_submitted.connect(_on_gold_submitted)
+	_my_gold_field.focus_exited.connect(func(): _on_gold_submitted(_my_gold_field.text))
+	gold_row.add_child(_my_gold_field)
+
+	body.add_child(_make_separator())
+
+	# --- Bottom: the player's own inventory list ---
+	var inv_header := Label.new()
+	inv_header.text = "Your Inventory  (click to add)"
+	inv_header.add_theme_font_size_override("font_size", 11)
+	inv_header.add_theme_color_override("font_color", Color(0.8, 0.8, 0.85))
+	body.add_child(inv_header)
+
+	_my_gold_label = Label.new()
+	_my_gold_label.text = "Gold: 0"
+	_my_gold_label.add_theme_font_size_override("font_size", 10)
+	_my_gold_label.add_theme_color_override("font_color", Color(0.9, 0.8, 0.3))
+	body.add_child(_my_gold_label)
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	body.add_child(scroll)
+
+	_my_inv_container = VBoxContainer.new()
+	_my_inv_container.add_theme_constant_override("separation", 1)
+	_my_inv_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_my_inv_container)
+	_my_buttons = _create_button_pool(_my_inv_container, BUTTON_POOL_SIZE)
+	_my_button_slot.resize(BUTTON_POOL_SIZE)
+	_my_button_slot.fill(-1)
+
+	# --- Action buttons ---
+	var actions := HBoxContainer.new()
+	actions.add_theme_constant_override("separation", 8)
+	actions.alignment = BoxContainer.ALIGNMENT_CENTER
+	body.add_child(actions)
+
+	_confirm_button = Button.new()
+	_confirm_button.text = "Confirm"
+	_confirm_button.custom_minimum_size = Vector2(140, 30)
+	_confirm_button.add_theme_font_size_override("font_size", 12)
+	_confirm_button.pressed.connect(_on_confirm_pressed)
+	actions.add_child(_confirm_button)
+
+	var cancel_button := Button.new()
+	cancel_button.text = "Cancel"
+	cancel_button.custom_minimum_size = Vector2(140, 30)
+	cancel_button.add_theme_font_size_override("font_size", 12)
+	cancel_button.pressed.connect(_on_cancel_pressed)
+	actions.add_child(cancel_button)
+
+	_built = true
 
 
+func _build_offer_column(parent: HBoxContainer, header_text: String, header_color: Color, is_mine: bool) -> Dictionary:
+	var col := VBoxContainer.new()
+	col.add_theme_constant_override("separation", 3)
+	col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	col.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	var panel_bg := StyleBoxFlat.new()
+	panel_bg.bg_color = Color(0.08, 0.08, 0.11, 1.0)
+	panel_bg.set_corner_radius_all(3)
+	panel_bg.set_content_margin_all(5)
+	var wrapper := PanelContainer.new()
+	wrapper.add_theme_stylebox_override("panel", panel_bg)
+	wrapper.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	wrapper.add_child(col)
+	parent.add_child(wrapper)
+
+	var header := Label.new()
+	header.text = header_text
+	header.add_theme_font_size_override("font_size", 12)
+	header.add_theme_color_override("font_color", header_color)
+	col.add_child(header)
+
+	var hint := Label.new()
+	hint.text = "(click an item below to remove)" if is_mine else ""
+	hint.add_theme_font_size_override("font_size", 8)
+	hint.add_theme_color_override("font_color", Color(0.55, 0.55, 0.6))
+	col.add_child(hint)
+
+	var gold := Label.new()
+	gold.text = "Gold: 0"
+	gold.add_theme_font_size_override("font_size", 10)
+	gold.add_theme_color_override("font_color", Color(0.9, 0.8, 0.3))
+	col.add_child(gold)
+
+	col.add_child(_make_separator())
+
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	col.add_child(scroll)
+
+	var container := VBoxContainer.new()
+	container.add_theme_constant_override("separation", 1)
+	container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(container)
+
+	var status := Label.new()
+	status.text = "Not confirmed"
+	status.add_theme_font_size_override("font_size", 10)
+	status.add_theme_color_override("font_color", Color(0.8, 0.5, 0.5))
+	col.add_child(status)
+
+	return {"container": container, "gold_label": gold, "status": status}
+
+
+#=============================================================================
+# SHOW / TARGETING
+#=============================================================================
+
+## BOT mode: open the window for a bot target.
 func show_for_target(target_id: int) -> void:
 	_target_id = target_id
 	_refresh_timer = 0.0
 	_bot_snapshot = {}
-	_request_target_snapshot()
-	_refresh_lists()
-
+	if _mode == Mode.BOT:
+		_request_target_snapshot()
+		_refresh_bot_lists()
 	var target_name := _get_target_name()
 	_title_label.text = "Trade: %s" % target_name
+	_present()
 
+
+## PLAYER mode: open the window for a confirmed trade session.
+func open_session(partner_id: int, partner_name: String) -> void:
+	_target_id = partner_id
+	_refresh_timer = 0.0
+	_trade_data = {}
+	_my_confirmed = false
+	_partner_confirmed = false
+	_my_button_slot.fill(-1)
+	_title_label.text = "Trade: %s" % partner_name
+	_refresh_player_inventory_list()
+	_refresh_offers()
+	_present()
+
+
+func _present() -> void:
 	if not visible:
 		var vp_size := get_viewport_rect().size
 		global_position = (vp_size - size) * 0.5
@@ -213,21 +468,29 @@ func show_for_target(target_id: int) -> void:
 	move_to_front()
 
 
-## Asks the server for a fresh snapshot of the trade target (their inventory
-## is server-authoritative — not present on this client).
+func _on_close_pressed() -> void:
+	if _mode == Mode.PLAYER and _target_id != 0:
+		TradeManager.rpc_cancel_trade.rpc_id(1)
+	visible = false
+
+
+#=============================================================================
+# BOT MODE: LIST REFRESH + TRANSFER
+#=============================================================================
+
 func _request_target_snapshot() -> void:
 	if _target_id != 0:
 		BotManager.request_bot_snapshot.rpc_id(1, _target_id)
 
 
 func _on_bot_snapshot(bot_id: int, snapshot: Dictionary) -> void:
-	if bot_id != _target_id or not visible:
+	if _mode != Mode.BOT or bot_id != _target_id or not visible:
 		return
 	_bot_snapshot = snapshot
-	_refresh_lists()
+	_refresh_bot_lists()
 
 
-func _refresh_lists() -> void:
+func _refresh_bot_lists() -> void:
 	if not _built:
 		return
 
@@ -240,77 +503,25 @@ func _refresh_lists() -> void:
 		_my_gold_label.text = "Gold: %d" % local_player.player_inventory.monies_amount
 	_bot_gold_label.text = "Gold: %d" % int(_bot_snapshot.get("gold", 0))
 
-	# My items — read live from my own inventory.
 	var my_items: Array = []
 	if is_instance_valid(local_player.inventory_component):
 		var slots: Array = local_player.inventory_component.get_slots()
 		for i in slots.size():
 			if slots[i].item:
 				my_items.append({"index": i, "item": slots[i].item})
-	_update_button_list(_my_buttons, _my_button_slot, my_items, true)
+	_update_button_list(_my_buttons, _my_button_slot, my_items, _give_item)
 
-	# Their items — from the snapshot (the target's inventory is server-only).
 	var their_items: Array = []
 	for entry in _bot_snapshot.get("inventory", []):
 		var item: ItemData = ItemData.from_dictionary(entry.get("item", {}))
 		if item:
 			their_items.append({"index": int(entry.get("slot_index", -1)), "item": item})
-	_update_button_list(_bot_buttons, _bot_button_slot, their_items, false)
-
-
-## `items` is an Array of { "index": int, "item": ItemData }.
-func _update_button_list(buttons: Array[Button], slot_map: Array[int], items: Array, is_mine: bool) -> void:
-	var btn_idx := 0
-
-	for entry in items:
-		if btn_idx >= buttons.size():
-			break
-		var item: ItemData = entry["item"]
-		var slot_idx: int = entry["index"]
-
-		var btn := buttons[btn_idx]
-		var item_text := item.name
-		if item.can_stack and item.current_stack_amount > 1:
-			item_text += " x%d" % item.current_stack_amount
-		if item is EquipmentData:
-			item_text += " (Lv.%d)" % item.item_level
-
-		btn.text = item_text
-		btn.tooltip_text = _build_item_tooltip(item)
-		btn.add_theme_color_override("font_color", _get_rarity_color(item))
-		btn.visible = true
-
-		# Only reconnect if the slot index changed
-		if slot_map[btn_idx] != slot_idx:
-			_disconnect_all(btn)
-			var captured_idx := slot_idx
-			if is_mine:
-				btn.pressed.connect(func(): _give_item(captured_idx))
-			else:
-				btn.pressed.connect(func(): _take_item(captured_idx))
-			slot_map[btn_idx] = slot_idx
-
-		btn_idx += 1
-
-	# Hide remaining buttons
-	for j in range(btn_idx, buttons.size()):
-		if buttons[j].visible:
-			buttons[j].visible = false
-			buttons[j].text = ""
-			buttons[j].tooltip_text = ""
-			slot_map[j] = -1
-
-
-func _disconnect_all(btn: Button) -> void:
-	for connection in btn.pressed.get_connections():
-		btn.pressed.disconnect(connection.callable)
+	_update_button_list(_bot_buttons, _bot_button_slot, their_items, _take_item)
 
 
 func _give_item(slot_index: int) -> void:
 	if _target_id == 0:
 		return
-	# The transfer runs on the server — a client holds no authoritative copy of
-	# the bot's inventory, so it cannot move items locally.
 	TradeManager.rpc_transfer_trade_item.rpc_id(1, _target_id, slot_index, true)
 	_request_post_transfer_refresh()
 
@@ -322,16 +533,230 @@ func _take_item(slot_index: int) -> void:
 	_request_post_transfer_refresh()
 
 
-## After a transfer RPC, reset slot maps and pull a fresh target snapshot. The
-## server applies the move; the own-inventory sync and the snapshot reply arrive
-## ordered after it, and the snapshot reply drives a full list refresh.
 func _request_post_transfer_refresh() -> void:
 	_my_button_slot.fill(-1)
 	_bot_button_slot.fill(-1)
 	_request_target_snapshot()
 
 
+#=============================================================================
+# PLAYER MODE: SERVER STATE + LIST REFRESH
+#=============================================================================
+
+func _on_trade_session_updated(data: Dictionary) -> void:
+	if _mode != Mode.PLAYER:
+		return
+	_trade_data = data
+	_target_id = data.get("partner_id", _target_id)
+	_my_confirmed = data.get("my_confirmed", false)
+	_partner_confirmed = data.get("partner_confirmed", false)
+	var partner_name: String = data.get("partner_name", "")
+	if not partner_name.is_empty():
+		_title_label.text = "Trade: %s" % partner_name
+	# Derive the offered-slot set straight from the authoritative server data —
+	# avoids any client/server drift if an add/remove RPC is rejected.
+	_offered_local_slots.clear()
+	for item_dict in data.get("my_offer", {}).get("items", []):
+		var idx: int = int(item_dict.get("trade_slot_index", -1))
+		if idx >= 0:
+			_offered_local_slots.append(idx)
+	_refresh_player_inventory_list()
+	_refresh_offers()
+
+
+func _on_trade_session_closed(_message: String) -> void:
+	if _mode != Mode.PLAYER:
+		return
+	_target_id = 0
+	_trade_data = {}
+	visible = false
+
+
+## Lists the player's own inventory. Items already placed in the offer are
+## hidden so a slot cannot be offered twice.
+func _refresh_player_inventory_list() -> void:
+	if not _built:
+		return
+	var local_player := _get_local_player()
+	if not is_instance_valid(local_player):
+		visible = false
+		return
+
+	if is_instance_valid(local_player.player_inventory):
+		_my_gold_label.text = "Gold: %d" % local_player.player_inventory.monies_amount
+
+	# Hide slots already placed in the offer so a slot cannot be offered twice.
+	var offered_indices := _offered_slot_indices()
+
+	var my_items: Array = []
+	if is_instance_valid(local_player.inventory_component):
+		var slots: Array = local_player.inventory_component.get_slots()
+		for i in slots.size():
+			if slots[i].item and not offered_indices.has(i):
+				my_items.append({"index": i, "item": slots[i].item})
+	_update_button_list(_my_buttons, _my_button_slot, my_items, _offer_item)
+
+
+func _offered_slot_indices() -> Dictionary:
+	var d := {}
+	for idx in _offered_local_slots:
+		d[idx] = true
+	return d
+
+
+func _refresh_offers() -> void:
+	if not _built:
+		return
+
+	var my_offer: Dictionary = _trade_data.get("my_offer", {})
+	var partner_offer: Dictionary = _trade_data.get("partner_offer", {})
+
+	# My offer — each entry is removable on click.
+	var my_items: Array = my_offer.get("items", [])
+	for i in _my_offer_buttons.size():
+		var btn := _my_offer_buttons[i]
+		if i < my_items.size():
+			var item := ItemData.from_dictionary(my_items[i])
+			btn.text = _item_label(item) if item else str(my_items[i].get("name", "?"))
+			btn.tooltip_text = _build_item_tooltip(item) if item else ""
+			if item:
+				btn.add_theme_color_override("font_color", _get_rarity_color(item))
+			btn.visible = true
+			_disconnect_all(btn)
+			var captured := i
+			btn.pressed.connect(func(): _remove_offer_item(captured))
+		else:
+			btn.visible = false
+			btn.text = ""
+			_disconnect_all(btn)
+
+	# Partner offer — read-only.
+	var their_items: Array = partner_offer.get("items", [])
+	for i in _partner_offer_labels.size():
+		var lbl := _partner_offer_labels[i]
+		if i < their_items.size():
+			var item := ItemData.from_dictionary(their_items[i])
+			lbl.text = _item_label(item) if item else str(their_items[i].get("name", "?"))
+			if item:
+				lbl.add_theme_color_override("font_color", _get_rarity_color(item))
+			lbl.visible = true
+		else:
+			lbl.visible = false
+			lbl.text = ""
+
+	_my_status_label.text = "CONFIRMED" if _my_confirmed else "Not confirmed"
+	_my_status_label.add_theme_color_override("font_color",
+			Color(0.4, 0.9, 0.4) if _my_confirmed else Color(0.8, 0.5, 0.5))
+	_partner_status_label.text = "CONFIRMED" if _partner_confirmed else "Not confirmed"
+	_partner_status_label.add_theme_color_override("font_color",
+			Color(0.4, 0.9, 0.4) if _partner_confirmed else Color(0.8, 0.5, 0.5))
+	_partner_gold_label.text = "Gold: %d" % int(partner_offer.get("gold", 0))
+
+	if _confirm_button:
+		_confirm_button.text = "Unconfirm" if _my_confirmed else "Confirm"
+
+	# Keep the gold field in sync with the server's clamped value while the
+	# player is not actively editing it.
+	if not _my_gold_field.has_focus():
+		_my_gold_field.text = str(int(my_offer.get("gold", 0)))
+
+
+func _offer_item(slot_index: int) -> void:
+	if _target_id == 0:
+		return
+	if not _offered_local_slots.has(slot_index):
+		_offered_local_slots.append(slot_index)
+	TradeManager.rpc_add_item.rpc_id(1, slot_index)
+	_refresh_player_inventory_list()
+
+
+func _remove_offer_item(trade_slot_index: int) -> void:
+	if _target_id == 0:
+		return
+	# The offer list and the local slot list stay index-aligned.
+	if trade_slot_index >= 0 and trade_slot_index < _offered_local_slots.size():
+		_offered_local_slots.remove_at(trade_slot_index)
+	TradeManager.rpc_remove_item.rpc_id(1, trade_slot_index)
+	_refresh_player_inventory_list()
+
+
+func _on_gold_submitted(text: String) -> void:
+	if _target_id == 0 or _mode != Mode.PLAYER:
+		return
+	var amount := maxi(0, int(text))
+	TradeManager.rpc_set_gold.rpc_id(1, amount)
+
+
+func _on_confirm_pressed() -> void:
+	if _target_id == 0:
+		return
+	if _my_confirmed:
+		TradeManager.rpc_unconfirm_trade.rpc_id(1)
+	else:
+		TradeManager.rpc_confirm_trade.rpc_id(1)
+
+
+func _on_cancel_pressed() -> void:
+	if _target_id != 0:
+		TradeManager.rpc_cancel_trade.rpc_id(1)
+	visible = false
+
+
+#=============================================================================
+# SHARED LIST HELPERS
+#=============================================================================
+
+## `items` is an Array of { "index": int, "item": ItemData }. `on_click` is
+## called with the slot index when a button is pressed.
+func _update_button_list(buttons: Array[Button], slot_map: Array[int], items: Array, on_click: Callable) -> void:
+	var btn_idx := 0
+	for entry in items:
+		if btn_idx >= buttons.size():
+			break
+		var item: ItemData = entry["item"]
+		var slot_idx: int = entry["index"]
+
+		var btn := buttons[btn_idx]
+		btn.text = _item_label(item)
+		btn.tooltip_text = _build_item_tooltip(item)
+		btn.add_theme_color_override("font_color", _get_rarity_color(item))
+		btn.visible = true
+
+		if slot_map[btn_idx] != slot_idx:
+			_disconnect_all(btn)
+			var captured_idx := slot_idx
+			btn.pressed.connect(func(): on_click.call(captured_idx))
+			slot_map[btn_idx] = slot_idx
+
+		btn_idx += 1
+
+	for j in range(btn_idx, buttons.size()):
+		if buttons[j].visible:
+			buttons[j].visible = false
+			buttons[j].text = ""
+			buttons[j].tooltip_text = ""
+			slot_map[j] = -1
+
+
+func _item_label(item: ItemData) -> String:
+	if not item:
+		return "?"
+	var text := item.name
+	if item.can_stack and item.current_stack_amount > 1:
+		text += " x%d" % item.current_stack_amount
+	if item is EquipmentData:
+		text += " (Lv.%d)" % item.item_level
+	return text
+
+
+func _disconnect_all(btn: Button) -> void:
+	for connection in btn.pressed.get_connections():
+		btn.pressed.disconnect(connection.callable)
+
+
 func _build_item_tooltip(item: ItemData) -> String:
+	if not item:
+		return ""
 	var tip := item.name
 	if item is EquipmentData:
 		var eq := item as EquipmentData
@@ -350,7 +775,6 @@ func _build_item_tooltip(item: ItemData) -> String:
 
 
 func _get_target_name() -> String:
-	# Prefer the snapshot, then the node's username (set on every peer at spawn).
 	var snap_name: String = _bot_snapshot.get("name", "")
 	if not snap_name.is_empty():
 		return snap_name
@@ -364,8 +788,7 @@ func _get_target_name() -> String:
 
 
 func _get_local_player() -> MultiplayerPlayerV2:
-	var pid := multiplayer.get_unique_id()
-	return PlayerManager.get_player_node(pid)
+	return PlayerManager.get_player_node(multiplayer.get_unique_id())
 
 
 func _get_rarity_color(item: ItemData) -> Color:
@@ -379,7 +802,9 @@ func _get_rarity_color(item: ItemData) -> Color:
 	return Color(0.8, 0.8, 0.8)
 
 
-# --- Draggable ---
+#=============================================================================
+# DRAGGABLE WINDOW
+#=============================================================================
 
 func _gui_input(event: InputEvent) -> void:
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
@@ -401,9 +826,17 @@ func _process(delta: float) -> void:
 		new_pos.y = clampf(new_pos.y, 0, vp_size.y - size.y)
 		global_position = new_pos
 
-	if visible and _target_id != 0:
-		_refresh_timer += delta
-		if _refresh_timer >= REFRESH_INTERVAL:
-			_refresh_timer = 0.0
-			_request_target_snapshot()
-			_refresh_lists()
+	if not visible or _target_id == 0:
+		return
+
+	_refresh_timer += delta
+	if _refresh_timer < REFRESH_INTERVAL:
+		return
+	_refresh_timer = 0.0
+
+	if _mode == Mode.BOT:
+		_request_target_snapshot()
+		_refresh_bot_lists()
+	else:
+		# Keep the inventory list fresh (items may be picked up / used elsewhere).
+		_refresh_player_inventory_list()


### PR DESCRIPTION
## Summary

Implements proximity-based, face-to-face player-to-player trading with dual confirmation and server-authoritative atomic swaps. Builds on the existing `TradeManager` autoload (previously used only for instant bot give/take) and reuses inventory display patterns.

- **Trade request flow** — the right-click context menu sends a trade request; the target gets an accept/decline popup. The server enforces a world-space proximity check on request, on accept, and at execution, plus a periodic re-check that cancels a trade if the partners walk apart.
- **Dual-offer window** — both players see their own offer, the partner's offer, gold fields and Confirm/Unconfirm buttons. Items move into an offer only via server-validated RPCs. Any change to an offer resets both confirmations.
- **Atomic swap** — on mutual confirmation the server re-validates that the offered items are still in their slots, that both sides hold enough gold, and that each receiver has type-appropriate inventory space (stacking-aware) before performing the swap. Clients never mutate inventories directly.
- **Edge cases** — disconnect mid-trade, walking out of range, full receiving inventory, moved/missing offered items, and stacked items are all handled by cancelling or failing the trade safely (no item duplication or loss).
- The existing instant **bot trade** path (`TradeWindow` give/take, `rpc_transfer_trade_item`) is preserved as a separate mode.

## Key files

- `scripts/Trading/trade_manager.gd` — request/accept/offer/confirm/cancel logic, proximity, atomic swap.
- `scripts/UI/trade_window.gd` — dual-mode trade window (bot give/take + player offer/confirm).
- `scripts/UI/trade_request_popup.gd` — incoming-request accept/decline popup (new).
- `scripts/Player/player_hud.gd` — wires up the trade UI signals.
- `scripts/UI/player_context_menu.gd` / `scripts/Networking/player_manager.gd` — route requests and disconnect cleanup.

## Test plan

- [x] Two clients near each other: request -> accept -> place items/gold -> both Confirm -> items and gold swap atomically.
- [x] Changing an offer after one side confirmed resets both confirmations.
- [x] Either side Cancel / close returns to no-trade with no item loss.
- [x] Request rejected when target is out of range.
- [x] Walking out of range during a trade cancels it.
- [ ] Receiving side with a full (type-appropriate) inventory fails the trade cleanly.
- [x] Player disconnect mid-trade cancels the partner's trade.
- [x] Bot trade window still works (instant give/take).

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)