### PR TITLE
Free Market zone with player-run personal shops

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,7 @@ BotManager="*res://scripts/Bot/bot_manager.gd"
 TradeManager="*res://scripts/Trading/trade_manager.gd"
 JobAdvancementManager="*res://scripts/Managers/job_advancement_manager.gd"
 QuestManager="*res://scripts/Managers/quest_manager.gd"
+PersonalShopManager="*res://scripts/Managers/personal_shop_manager.gd"
 
 [display]
 
@@ -182,6 +183,11 @@ OpenPartyWindow={
 OpenQuestWindow={
 "deadzone": 0.2,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
+]
+}
+OpenPersonalShop={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":77,"key_label":0,"unicode":109,"location":0,"echo":false,"script":null)
 ]
 }
 

--- a/scenes/Levels/free_market.tscn
+++ b/scenes/Levels/free_market.tscn
@@ -1,0 +1,113 @@
+[gd_scene load_steps=12 format=3 uid="uid://cf3mkt0free01"]
+
+[ext_resource type="Script" uid="uid://dfj1ny2sygjrj" path="res://scripts/Gameplay/map_base.gd" id="1_mapbase"]
+[ext_resource type="Script" uid="uid://b1ruh77vt7mdu" path="res://scripts/VFX/damage_numbers.gd" id="2_dmgnum"]
+[ext_resource type="PackedScene" path="res://scenes/Gameplay/portal.tscn" id="3_portal"]
+[ext_resource type="PackedScene" uid="uid://bx2n3vrfxk75m" path="res://scenes/Gameplay/killzone.tscn" id="4_killzone"]
+[ext_resource type="Texture2D" uid="uid://cd28i3fo3v1m0" path="res://assets/sprites/Country-village_asset_pack/1_Tileset & props/country village tileset.png" id="5_tileset"]
+[ext_resource type="Script" uid="uid://igk1rxt26f2i" path="res://scripts/UI/global_drop_handler.gd" id="6_drophandler"]
+[ext_resource type="FontFile" uid="uid://c8e0uior67hgl" path="res://assets/fonts/PixelOperator8.ttf" id="7_font"]
+
+[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_kill"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_floor"]
+size = Vector2(640, 24)
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_wall"]
+size = Vector2(24, 200)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_ground"]
+atlas = ExtResource("5_tileset")
+region = Rect2(16, 16, 16, 16)
+
+[node name="FreeMarket" type="Node2D"]
+script = ExtResource("1_mapbase")
+bgm_path = "uid://1ib7gi5y7uov"
+
+[node name="DmgNumberSpawner" type="MultiplayerSpawner" parent="."]
+spawn_path = NodePath("..")
+script = ExtResource("2_dmgnum")
+
+[node name="Camera2D" type="Camera2D" parent="."]
+position = Vector2(0, -40)
+zoom = Vector2(4, 4)
+process_callback = 0
+limit_enabled = false
+position_smoothing_enabled = true
+
+[node name="PlayerSpawn" type="Marker2D" parent="."]
+position = Vector2(0, 0)
+
+[node name="Town_FreeMarket_Portal_Spawn" type="Marker2D" parent="."]
+position = Vector2(-260, 0)
+
+[node name="GroundSprite" type="Sprite2D" parent="."]
+position = Vector2(0, 24)
+scale = Vector2(41, 1.6)
+texture = SubResource("AtlasTexture_ground")
+
+[node name="Ground" type="StaticBody2D" parent="."]
+collision_layer = 1
+collision_mask = 0
+
+[node name="FloorShape" type="CollisionShape2D" parent="Ground"]
+position = Vector2(0, 24)
+shape = SubResource("RectangleShape2D_floor")
+
+[node name="LeftWallShape" type="CollisionShape2D" parent="Ground"]
+position = Vector2(-320, -76)
+shape = SubResource("RectangleShape2D_wall")
+
+[node name="RightWallShape" type="CollisionShape2D" parent="Ground"]
+position = Vector2(320, -76)
+shape = SubResource("RectangleShape2D_wall")
+
+[node name="PortalToTown" parent="." instance=ExtResource("3_portal")]
+position = Vector2(-280, 4)
+target_map_id = "town"
+target_spawn_point_name = "Town_FreeMarket_Portal_Spawn"
+
+[node name="MarketSign" type="Label" parent="."]
+offset_left = -90.0
+offset_top = -110.0
+offset_right = 90.0
+offset_bottom = -86.0
+scale = Vector2(0.5, 0.5)
+theme_override_fonts/font = ExtResource("7_font")
+theme_override_font_sizes/font_size = 14
+text = "FREE MARKET — Press M to open your shop"
+horizontal_alignment = 1
+vertical_alignment = 1
+
+[node name="Killzone" parent="." instance=ExtResource("4_killzone")]
+position = Vector2(0, 220)
+monitoring = false
+monitorable = false
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Killzone"]
+shape = SubResource("WorldBoundaryShape2D_kill")
+debug_color = Color(0.9764706, 0, 0, 0.75686276)
+
+[node name="Platforms" type="Node2D" parent="."]
+
+[node name="Players" type="Node2D" parent="."]
+
+[node name="Enemies" type="Node2D" parent="."]
+
+[node name="Projectiles" type="Node2D" parent="."]
+
+[node name="ItemDrops" type="Node2D" parent="."]
+
+[node name="GlobalDropHandler" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+offset_right = 1152.0
+offset_bottom = 648.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 1
+script = ExtResource("6_drophandler")
+
+[node name="AudioStreamPlayer" type="AudioStreamPlayer" parent="."]

--- a/scenes/Levels/town.tscn
+++ b/scenes/Levels/town.tscn
@@ -528,6 +528,14 @@ target_spawn_point_name = "Game_Town_Portal_Spawn"
 [node name="Town_Game_Portal_Spawn" type="Marker2D" parent="."]
 position = Vector2(-53, -606)
 
+[node name="PortalToFreeMarket" parent="." instance=ExtResource("3_knl1o")]
+position = Vector2(78, -608)
+target_map_id = "free_market"
+target_spawn_point_name = "Town_FreeMarket_Portal_Spawn"
+
+[node name="Town_FreeMarket_Portal_Spawn" type="Marker2D" parent="."]
+position = Vector2(53, -606)
+
 [node name="Camera2D" type="Camera2D" parent="."]
 position = Vector2(0, -608)
 zoom = Vector2(4, 4)

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -12,6 +12,7 @@ const MAP_SCENES = {
 	"game2": "res://scenes/Levels/game2.tscn",
 	"game3": "res://scenes/Levels/game3.tscn",
 	"town": "res://scenes/Levels/town.tscn",
+	"free_market": "res://scenes/Levels/free_market.tscn",
 }
 
 const DEFAULT_MAP = "town"
@@ -258,7 +259,12 @@ func _spawn_player_on_server_map(player_id: int, map_id: String, spawn_point_nam
 
 func _remove_player_from_map(player_id: int, map_id: String):
 	if not map_id in active_maps: return
-	
+
+	# Close any personal shop this player had open — leaving the Free Market (or
+	# disconnecting) must not leave an orphaned shop with their items held.
+	if PersonalShopManager:
+		PersonalShopManager.handle_player_left(player_id)
+
 	var map_instance = active_maps[map_id].scene_instance
 	if not is_instance_valid(map_instance): return
 	

--- a/scripts/Managers/personal_shop_manager.gd
+++ b/scripts/Managers/personal_shop_manager.gd
@@ -1,0 +1,464 @@
+# personal_shop_manager.gd - AutoLoad singleton
+# Server-authoritative personal shops for the Free Market zone.
+#
+# A player opens a personal shop by listing items from their inventory with a
+# coin price. Other players nearby can browse a read-only view and buy items.
+# All coin/item transfers happen on the server; clients only send intents.
+extends Node
+
+## Emitted on every peer when the set of open shops changes (a shop opens or
+## closes). The UI uses this to refresh "Browse Shop" availability.
+signal shops_changed()
+
+## Maximum number of distinct listings a single shop can hold.
+const MAX_LISTINGS: int = 12
+
+## Map id where personal shops are allowed to operate.
+const FREE_MARKET_MAP: String = "free_market"
+
+# === SERVER STATE ===
+# { seller_id: { "shop_name": String, "listings": Array[Dictionary] } }
+# Each listing: { "listing_id": int, "item": ItemData, "price": int }
+var _shops: Dictionary = {}
+var _next_listing_id: int = 1
+
+# === CLIENT STATE ===
+# Lightweight mirror so clients know which sellers have an open shop without
+# leaking listing contents. { seller_id: shop_name }
+var _open_shop_names: Dictionary = {}
+# Seller id this client explicitly asked to browse; lets the next browse-data
+# RPC open the window even though the same RPC is also used for push refreshes.
+var _pending_browse: int = 0
+
+
+# === HELPERS ===
+
+func is_shop_open(seller_id: int) -> bool:
+	if multiplayer.is_server():
+		return _shops.has(seller_id)
+	return _open_shop_names.has(seller_id)
+
+
+func get_shop_name(seller_id: int) -> String:
+	if multiplayer.is_server():
+		return _shops.get(seller_id, {}).get("shop_name", "")
+	return _open_shop_names.get(seller_id, "")
+
+
+func _get_player(peer_id: int) -> Node:
+	return PlayerManager.get_player_node(peer_id)
+
+
+## Builds the slim, network-safe view of a shop's listings.
+func _serialize_listings(seller_id: int) -> Array:
+	var out: Array = []
+	if not _shops.has(seller_id):
+		return out
+	for listing in _shops[seller_id].listings:
+		var item: ItemData = listing.item
+		out.append({
+			"listing_id": listing.listing_id,
+			"item": item.to_dictionary(),
+			"price": listing.price,
+		})
+	return out
+
+
+# === SERVER: SHOP LIFECYCLE ===
+
+## [Client -> Server] Open (or rename) the caller's personal shop.
+@rpc("any_peer", "call_local", "reliable")
+func request_open_shop(shop_name: String) -> void:
+	if not multiplayer.is_server():
+		return
+	var seller_id := multiplayer.get_remote_sender_id()
+	if seller_id == 0:
+		seller_id = multiplayer.get_unique_id()
+
+	# Personal shops are a Free Market feature only.
+	if MapManager.get_player_map(seller_id) != FREE_MARKET_MAP:
+		_notify(seller_id, "You can only open a shop in the Free Market.", Color.ORANGE)
+		return
+
+	var clean_name := shop_name.strip_edges()
+	if clean_name.is_empty():
+		var p := _get_player(seller_id)
+		clean_name = "%s's Shop" % (p.username if is_instance_valid(p) and not p.username.is_empty() else "Player")
+	clean_name = clean_name.substr(0, 40)
+
+	if not _shops.has(seller_id):
+		_shops[seller_id] = {"shop_name": clean_name, "listings": []}
+	else:
+		_shops[seller_id].shop_name = clean_name
+
+	_broadcast_shop_open_state(seller_id, true, clean_name)
+	_sync_owner_shop(seller_id)
+
+
+## [Client -> Server] Close the caller's personal shop. Unlisted items stay in
+## the seller's inventory (they were never removed).
+@rpc("any_peer", "call_local", "reliable")
+func request_close_shop() -> void:
+	if not multiplayer.is_server():
+		return
+	var seller_id := multiplayer.get_remote_sender_id()
+	if seller_id == 0:
+		seller_id = multiplayer.get_unique_id()
+	_close_shop(seller_id)
+
+
+func _close_shop(seller_id: int) -> void:
+	if not multiplayer.is_server() or not _shops.has(seller_id):
+		return
+
+	# Return every held listing item to the seller so closing the shop never
+	# destroys items. If the seller's node is gone (disconnect), the items are
+	# still recorded in their inventory before the disconnect save flushes.
+	var seller := _get_player(seller_id)
+	if is_instance_valid(seller) and is_instance_valid(seller.inventory_component):
+		for listing in _shops[seller_id].listings:
+			seller.inventory_component.server_add_item_instance(listing.item.to_dictionary())
+
+	_shops.erase(seller_id)
+	_broadcast_shop_open_state(seller_id, false, "")
+	if not BotManager.is_bot(seller_id):
+		_client_shop_closed.rpc_id(seller_id)
+
+
+## Called by PlayerManager / MapManager when a player disconnects or leaves the
+## Free Market — their shop must not linger.
+func handle_player_left(seller_id: int) -> void:
+	if multiplayer.is_server():
+		_close_shop(seller_id)
+
+
+# === SERVER: LISTINGS ===
+
+## [Client -> Server] List one unit of an inventory item for sale at `price`.
+@rpc("any_peer", "call_local", "reliable")
+func request_list_item(slot_index: int, price: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var seller_id := multiplayer.get_remote_sender_id()
+	if seller_id == 0:
+		seller_id = multiplayer.get_unique_id()
+
+	if not _shops.has(seller_id):
+		return
+	if _shops[seller_id].listings.size() >= MAX_LISTINGS:
+		_notify(seller_id, "Your shop is full.", Color.ORANGE)
+		return
+	if price < 1:
+		_notify(seller_id, "Price must be at least 1 coin.", Color.ORANGE)
+		return
+
+	var seller := _get_player(seller_id)
+	if not is_instance_valid(seller) or not is_instance_valid(seller.inventory_component):
+		return
+
+	var slots: Array = seller.inventory_component.get_slots()
+	if slot_index < 0 or slot_index >= slots.size():
+		return
+	var slot: SlotData = slots[slot_index]
+	if not slot.item:
+		return
+
+	# Remove one unit from the seller's inventory and hold it in the listing.
+	# Holding the item server-side guarantees it can't be sold/dropped twice.
+	var item: ItemData = slot.item
+	var listed_item: ItemData
+	if item.can_stack and item.current_stack_amount > 1:
+		listed_item = item.duplicate_with_path(true)
+		listed_item.current_stack_amount = 1
+		seller.inventory_component.remove_item_from_stack(item, 1, "listed")
+	else:
+		listed_item = item
+		seller.inventory_component.remove_item(item, "listed")
+
+	var listing := {
+		"listing_id": _next_listing_id,
+		"item": listed_item,
+		"price": clampi(price, 1, 999999999),
+	}
+	_next_listing_id += 1
+	_shops[seller_id].listings.append(listing)
+
+	_sync_owner_shop(seller_id)
+	_sync_browsers(seller_id)
+
+
+## [Client -> Server] Remove a listing and return the held item to the seller.
+@rpc("any_peer", "call_local", "reliable")
+func request_unlist_item(listing_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var seller_id := multiplayer.get_remote_sender_id()
+	if seller_id == 0:
+		seller_id = multiplayer.get_unique_id()
+
+	if not _shops.has(seller_id):
+		return
+
+	var listings: Array = _shops[seller_id].listings
+	for i in listings.size():
+		if listings[i].listing_id == listing_id:
+			var held_item: ItemData = listings[i].item
+			var seller := _get_player(seller_id)
+			if is_instance_valid(seller) and is_instance_valid(seller.inventory_component):
+				if seller.inventory_component.get_empty_slots().is_empty() \
+						and not seller.inventory_component.item_locations.has(held_item.item_id):
+					_notify(seller_id, "Your inventory is full.", Color.ORANGE)
+					return
+				seller.inventory_component.server_add_item_instance(held_item.to_dictionary())
+			listings.remove_at(i)
+			_sync_owner_shop(seller_id)
+			_sync_browsers(seller_id)
+			return
+
+
+# === SERVER: BROWSING & BUYING ===
+
+## [Client -> Server] Ask for a read-only snapshot of `seller_id`'s shop.
+@rpc("any_peer", "call_local", "reliable")
+func request_browse_shop(seller_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var browser_id := multiplayer.get_remote_sender_id()
+	if browser_id == 0:
+		browser_id = multiplayer.get_unique_id()
+
+	if not _shops.has(seller_id):
+		_client_browse_failed.rpc_id(browser_id, "That shop is no longer open.")
+		return
+	if browser_id == seller_id:
+		return  # use the owner panel instead
+	if not _is_within_range(browser_id, seller_id):
+		_client_browse_failed.rpc_id(browser_id, "You are too far from the shop.")
+		return
+
+	_client_receive_browse_data.rpc_id(browser_id, seller_id,
+		_shops[seller_id].shop_name, _serialize_listings(seller_id))
+
+
+## [Client -> Server] Buy a listing. Atomic: validates coins, range, and that
+## the listing still exists, then transfers coins and the item server-side.
+@rpc("any_peer", "call_local", "reliable")
+func request_buy_listing(seller_id: int, listing_id: int) -> void:
+	if not multiplayer.is_server():
+		return
+	var buyer_id := multiplayer.get_remote_sender_id()
+	if buyer_id == 0:
+		buyer_id = multiplayer.get_unique_id()
+
+	if buyer_id == seller_id:
+		return
+	if not _shops.has(seller_id):
+		_client_browse_failed.rpc_id(buyer_id, "That shop is no longer open.")
+		return
+
+	# Locate the listing.
+	var listings: Array = _shops[seller_id].listings
+	var listing_index := -1
+	for i in listings.size():
+		if listings[i].listing_id == listing_id:
+			listing_index = i
+			break
+	if listing_index == -1:
+		_notify(buyer_id, "That item was already sold.", Color.ORANGE)
+		_sync_browser(buyer_id, seller_id)
+		return
+
+	if not _is_within_range(buyer_id, seller_id):
+		_notify(buyer_id, "You are too far from the shop.", Color.ORANGE)
+		return
+
+	var buyer := _get_player(buyer_id)
+	var seller := _get_player(seller_id)
+	if not is_instance_valid(buyer) or not is_instance_valid(buyer.inventory_component) \
+			or not is_instance_valid(buyer.player_inventory):
+		return
+	if not is_instance_valid(seller) or not is_instance_valid(seller.player_inventory):
+		_notify(buyer_id, "The seller is no longer available.", Color.ORANGE)
+		return
+
+	var listing: Dictionary = listings[listing_index]
+	var price: int = listing.price
+	var item: ItemData = listing.item
+
+	# --- Atomic validation block ---
+	if buyer.player_inventory.monies_amount < price:
+		_notify(buyer_id, "You don't have enough coins.", Color.ORANGE)
+		return
+	if buyer.inventory_component.get_empty_slots().is_empty() \
+			and not buyer.inventory_component.item_locations.has(item.item_id):
+		_notify(buyer_id, "Your inventory is full.", Color.ORANGE)
+		return
+
+	# --- Commit: remove listing first so it can't be double-bought. ---
+	listings.remove_at(listing_index)
+	buyer.player_inventory.monies_amount -= price
+	seller.player_inventory.monies_amount += price
+	buyer.inventory_component.server_add_item_instance(item.to_dictionary())
+
+	var item_name: String = item.name
+	_notify(buyer_id, "Bought %s for %d coins." % [item_name, price], Color(0.5, 0.9, 0.5))
+	_notify(seller_id, "Sold %s for %d coins." % [item_name, price], Color(0.5, 0.9, 0.5))
+
+	_sync_owner_shop(seller_id)
+	_sync_browsers(seller_id)
+
+
+## Distance gate — a browsing player must be physically near the seller.
+func _is_within_range(a_id: int, b_id: int) -> bool:
+	const MAX_RANGE_SQ: float = 160.0 * 160.0
+	var a := _get_player(a_id)
+	var b := _get_player(b_id)
+	if not is_instance_valid(a) or not is_instance_valid(b):
+		return false
+	if MapManager.get_player_map(a_id) != MapManager.get_player_map(b_id):
+		return false
+	return a.global_position.distance_squared_to(b.global_position) <= MAX_RANGE_SQ
+
+
+# === SERVER -> CLIENT SYNC HELPERS ===
+
+func _broadcast_shop_open_state(seller_id: int, is_open: bool, shop_name: String) -> void:
+	# Tell every real client (host included) so their "browse" prompts update.
+	_client_shop_state.rpc(seller_id, is_open, shop_name)
+
+
+func _sync_owner_shop(seller_id: int) -> void:
+	if BotManager.is_bot(seller_id) or not _shops.has(seller_id):
+		return
+	_client_receive_owner_data.rpc_id(seller_id,
+		_shops[seller_id].shop_name, _serialize_listings(seller_id))
+
+
+## Pushes a fresh snapshot to every player currently browsing this shop.
+func _sync_browsers(seller_id: int) -> void:
+	if not _shops.has(seller_id):
+		return
+	for browser_id in _browsers_of(seller_id):
+		_sync_browser(browser_id, seller_id)
+
+
+func _sync_browser(browser_id: int, seller_id: int) -> void:
+	if BotManager.is_bot(browser_id):
+		return
+	if not _shops.has(seller_id):
+		_client_browse_failed.rpc_id(browser_id, "That shop is no longer open.")
+		return
+	_client_receive_browse_data.rpc_id(browser_id, seller_id,
+		_shops[seller_id].shop_name, _serialize_listings(seller_id))
+
+
+## Real players on the same map as the seller (potential browsers). The client
+## window itself filters to whoever actually has the browse panel open.
+func _browsers_of(seller_id: int) -> Array:
+	var map_id := MapManager.get_player_map(seller_id)
+	if map_id.is_empty():
+		return []
+	var out: Array = []
+	for pid in MapManager.get_real_players_on_map(map_id):
+		if pid != seller_id:
+			out.append(pid)
+	return out
+
+
+func _notify(player_id: int, message: String, color: Color) -> void:
+	if player_id == multiplayer.get_unique_id():
+		ChatManager.add_system_message(message, color)
+	elif not BotManager.is_bot(player_id):
+		ChatManager.add_system_message.rpc_id(player_id, message, color)
+
+
+# === CLIENT RPCs ===
+
+@rpc("authority", "call_local", "reliable")
+func _client_shop_state(seller_id: int, is_open: bool, shop_name: String) -> void:
+	if is_open:
+		_open_shop_names[seller_id] = shop_name
+	else:
+		_open_shop_names.erase(seller_id)
+	shops_changed.emit()
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_receive_owner_data(shop_name: String, listings: Array) -> void:
+	# Only refresh if the owner panel is actually open — a background sale should
+	# update the panel in place, not pop a closed window back open.
+	if is_instance_valid(_shop_window) and not _shop_window.visible:
+		return
+	var window := _get_or_create_window()
+	window.show_owner_view(shop_name, listings)
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_receive_browse_data(seller_id: int, shop_name: String, listings: Array) -> void:
+	# A push refresh (seller sold/unlisted) reaches every player on the map. Only
+	# act on it when this client actually has that shop's browse window open, so
+	# we don't pop a window open for non-browsers. An explicit browse request,
+	# though, must always open the window — distinguished by _pending_browse.
+	if seller_id != _pending_browse and is_instance_valid(_shop_window):
+		if not _shop_window.visible or not _shop_window.is_browsing() \
+				or _shop_window.get_browse_seller_id() != seller_id:
+			return
+	_pending_browse = 0
+	var window := _get_or_create_window()
+	window.show_browse_view(seller_id, shop_name, listings)
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_shop_closed() -> void:
+	if is_instance_valid(_shop_window):
+		_shop_window.on_shop_closed()
+
+
+@rpc("authority", "call_local", "reliable")
+func _client_browse_failed(reason: String) -> void:
+	ChatManager.add_system_message(reason, Color.ORANGE)
+	if is_instance_valid(_shop_window) and _shop_window.is_browsing():
+		_shop_window.visible = false
+
+
+# === CLIENT WINDOW MANAGEMENT ===
+
+var _shop_window: PersonalShopWindow = null
+
+
+func _get_or_create_window() -> PersonalShopWindow:
+	if is_instance_valid(_shop_window):
+		return _shop_window
+	_shop_window = PersonalShopWindow.create()
+	var local_player := PlayerManager.get_player_node(multiplayer.get_unique_id())
+	if is_instance_valid(local_player):
+		var container = local_player.get_node_or_null("CanvasLayer/MoveableWindows")
+		if container:
+			container.add_child(_shop_window)
+			return _shop_window
+	get_tree().current_scene.add_child(_shop_window)
+	return _shop_window
+
+
+## Opens the owner-side shop management panel for the local player. The panel
+## starts in a "not yet open" state; the player names the shop and clicks
+## "Open Shop", which sends request_open_shop to the server.
+func open_my_shop_panel() -> void:
+	if MapManager.current_map_id != FREE_MARKET_MAP:
+		ChatManager.add_system_message("You can only open a shop in the Free Market.", Color.ORANGE)
+		return
+	var window := _get_or_create_window()
+	var already_open := is_shop_open(multiplayer.get_unique_id())
+	window.show_owner_view(get_shop_name(multiplayer.get_unique_id()), [], already_open)
+	# If the shop is already open, pull a fresh authoritative snapshot.
+	if already_open:
+		request_open_shop.rpc_id(1, get_shop_name(multiplayer.get_unique_id()))
+
+
+## Opens the read-only browse panel for another player's shop.
+func browse_player_shop(seller_id: int) -> void:
+	if not is_shop_open(seller_id):
+		ChatManager.add_system_message("That player does not have a shop open.", Color.ORANGE)
+		return
+	_pending_browse = seller_id
+	request_browse_shop.rpc_id(1, seller_id)

--- a/scripts/Managers/personal_shop_manager.gd.uid
+++ b/scripts/Managers/personal_shop_manager.gd.uid
@@ -1,0 +1,1 @@
+uid://cdb0k1dvbfdsi

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -91,6 +91,12 @@ func remove_player(id: int):
 	#print("Player %d left - removing character" % id)
 	NetworkUtils.log_network_event("PLAYER_LEAVE", "Player ID: %d" % id)
 	
+	# Close any personal shop BEFORE the save flush so items held in listings are
+	# returned to the seller's inventory and persisted (the shop itself is not
+	# saved — its held items must land back in the inventory snapshot).
+	if multiplayer.is_server() and PersonalShopManager:
+		PersonalShopManager.handle_player_left(id)
+
 	# Full save before disconnect — delegate to SaveManager for consistency
 	if multiplayer.is_server() and id in active_players:
 		var current_map = MapManager.get_player_map(id)

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -153,6 +153,11 @@ func _unhandled_input(event: InputEvent) -> void:
 		if event is InputEventKey and event.is_echo():
 			return
 
+		# Toggle the personal shop panel (Free Market only).
+		if event.is_action_pressed("OpenPersonalShop") and not InputManager.is_locked():
+			PersonalShopManager.open_my_shop_panel()
+			return
+
 		if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_RIGHT and event.pressed:
 			if _handle_right_click(event):
 				return
@@ -470,6 +475,10 @@ func change_to_map(new_map_id: String, spawn_point_name: String = ""):
 		var data_string: String = JSON.stringify(get_save_data())
 		request_map_change_rpc.rpc_id(1, new_map_id, spawn_point_name, data_string)
 	else:
+		# Close any personal shop first so held listing items return to the
+		# inventory BEFORE the save flush captures it (the shop is not persisted).
+		if PersonalShopManager:
+			PersonalShopManager.handle_player_left(player_id)
 		# Flush save before map change — the player node is freed during the transition,
 		# so a debounced save would fire on an already-freed node and be silently skipped.
 		if not username.is_empty() and SaveManager:
@@ -888,6 +897,11 @@ func request_map_change_rpc(new_map_id: String, spawn_point_name: String = "", c
 
 	var requester_id = multiplayer.get_remote_sender_id()
 	#print("Player %d requesting map change to '%s' at spawn '%s'" % [requester_id, new_map_id, spawn_point_name])
+
+	# Close any personal shop first so held listing items return to the
+	# inventory BEFORE the save flush captures it (the shop is not persisted).
+	if PersonalShopManager:
+		PersonalShopManager.handle_player_left(requester_id)
 
 	# Flush save before map change — the player node is freed during the transition,
 	# so a debounced save would fire on an already-freed node and be silently skipped.

--- a/scripts/UI/personal_shop_window.gd
+++ b/scripts/UI/personal_shop_window.gd
@@ -1,0 +1,454 @@
+class_name PersonalShopWindow
+extends Panel
+
+## Draggable UI panel for Free Market personal shops.
+##
+## Two modes:
+##  - OWNER: manage your own shop — name it, list/unlist inventory items.
+##  - BROWSE: read-only view of another player's shop — buy listed items.
+##
+## All coin/item mutations are server-authoritative. This window only sends
+## intents (list / unlist / open / close / buy) and renders server snapshots.
+
+enum Mode { OWNER, BROWSE }
+
+const WINDOW_WIDTH: float = 460.0
+const WINDOW_HEIGHT: float = 480.0
+const TITLE_HEIGHT: float = 28.0
+const PADDING: float = 8.0
+const ROW_POOL_SIZE: int = 64
+
+var _mode: int = Mode.OWNER
+var _browse_seller_id: int = 0
+var _shop_open: bool = false
+var _built := false
+
+var is_dragging := false
+var drag_offset := Vector2()
+
+var _title_label: Label
+var _name_input: LineEdit
+var _open_close_btn: Button
+var _owner_row: HBoxContainer
+var _status_label: Label
+var _list_container: VBoxContainer
+var _list_rows: Array[Button] = []
+var _list_caption: Label
+
+var _hover_bg: StyleBoxFlat
+var _normal_bg: StyleBoxEmpty
+
+
+static func create() -> PersonalShopWindow:
+	var window := PersonalShopWindow.new()
+	window.custom_minimum_size = Vector2(WINDOW_WIDTH, WINDOW_HEIGHT)
+	window.size = Vector2(WINDOW_WIDTH, WINDOW_HEIGHT)
+	window.visible = false
+	window.clip_contents = true
+	window.mouse_filter = Control.MOUSE_FILTER_STOP
+	window.add_to_group("ui_window")
+
+	var bg := StyleBoxFlat.new()
+	bg.bg_color = Color(0.12, 0.12, 0.15, 0.97)
+	bg.border_color = Color(0.3, 0.3, 0.4, 1.0)
+	bg.set_border_width_all(2)
+	bg.set_corner_radius_all(4)
+	window.add_theme_stylebox_override("panel", bg)
+
+	window._hover_bg = StyleBoxFlat.new()
+	window._hover_bg.bg_color = Color(0.25, 0.25, 0.35, 1.0)
+	window._hover_bg.set_corner_radius_all(2)
+	window._normal_bg = StyleBoxEmpty.new()
+
+	window._build_ui()
+	return window
+
+
+func _build_ui() -> void:
+	var root := VBoxContainer.new()
+	root.set_anchors_and_offsets_preset(PRESET_FULL_RECT)
+	root.add_theme_constant_override("separation", 0)
+	add_child(root)
+
+	# --- Title bar ---
+	var title_bar := Panel.new()
+	title_bar.custom_minimum_size = Vector2(0, TITLE_HEIGHT)
+	title_bar.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+	title_bar.mouse_filter = Control.MOUSE_FILTER_PASS
+	var title_bg := StyleBoxFlat.new()
+	title_bg.bg_color = Color(0.18, 0.18, 0.22, 1.0)
+	title_bg.set_corner_radius_all(4)
+	title_bg.corner_radius_bottom_left = 0
+	title_bg.corner_radius_bottom_right = 0
+	title_bar.add_theme_stylebox_override("panel", title_bg)
+	root.add_child(title_bar)
+
+	_title_label = Label.new()
+	_title_label.text = "Personal Shop"
+	_title_label.add_theme_font_size_override("font_size", 13)
+	_title_label.add_theme_color_override("font_color", Color(0.9, 0.85, 0.6))
+	_title_label.position = Vector2(PADDING, 4)
+	_title_label.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	title_bar.add_child(_title_label)
+
+	var close_btn := Button.new()
+	close_btn.text = "X"
+	close_btn.flat = true
+	close_btn.add_theme_font_size_override("font_size", 12)
+	close_btn.add_theme_color_override("font_color", Color.WHITE)
+	close_btn.add_theme_color_override("font_hover_color", Color.RED)
+	close_btn.set_anchors_preset(PRESET_TOP_RIGHT)
+	close_btn.offset_left = -28
+	close_btn.offset_top = 2
+	close_btn.offset_right = -4
+	close_btn.offset_bottom = 26
+	close_btn.pressed.connect(func(): visible = false)
+	title_bar.add_child(close_btn)
+
+	# --- Content margin ---
+	var margin := MarginContainer.new()
+	margin.add_theme_constant_override("margin_left", int(PADDING))
+	margin.add_theme_constant_override("margin_right", int(PADDING))
+	margin.add_theme_constant_override("margin_top", int(PADDING))
+	margin.add_theme_constant_override("margin_bottom", int(PADDING))
+	margin.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	margin.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	root.add_child(margin)
+
+	var col := VBoxContainer.new()
+	col.add_theme_constant_override("separation", 6)
+	col.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	col.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	margin.add_child(col)
+
+	# --- Owner controls row (name input + open/close) ---
+	_owner_row = HBoxContainer.new()
+	_owner_row.add_theme_constant_override("separation", 6)
+	col.add_child(_owner_row)
+
+	_name_input = LineEdit.new()
+	_name_input.placeholder_text = "Shop name..."
+	_name_input.max_length = 40
+	_name_input.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	_name_input.add_theme_font_size_override("font_size", 11)
+	_owner_row.add_child(_name_input)
+
+	_open_close_btn = Button.new()
+	_open_close_btn.text = "Open Shop"
+	_open_close_btn.custom_minimum_size = Vector2(90, 24)
+	_open_close_btn.add_theme_font_size_override("font_size", 11)
+	_open_close_btn.pressed.connect(_on_open_close_pressed)
+	_owner_row.add_child(_open_close_btn)
+
+	# --- Status / helper line ---
+	_status_label = Label.new()
+	_status_label.add_theme_font_size_override("font_size", 10)
+	_status_label.add_theme_color_override("font_color", Color(0.7, 0.7, 0.8))
+	_status_label.autowrap_mode = TextServer.AUTOWRAP_WORD_SMART
+	col.add_child(_status_label)
+
+	# --- List caption ---
+	_list_caption = Label.new()
+	_list_caption.text = "Listings"
+	_list_caption.add_theme_font_size_override("font_size", 12)
+	_list_caption.add_theme_color_override("font_color", Color(0.5, 0.8, 1.0))
+	col.add_child(_list_caption)
+
+	var sep := HSeparator.new()
+	col.add_child(sep)
+
+	# --- Scrollable list ---
+	var scroll := ScrollContainer.new()
+	scroll.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	scroll.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	col.add_child(scroll)
+
+	_list_container = VBoxContainer.new()
+	_list_container.add_theme_constant_override("separation", 2)
+	_list_container.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	scroll.add_child(_list_container)
+
+	for i in ROW_POOL_SIZE:
+		var btn := Button.new()
+		btn.flat = true
+		btn.alignment = HORIZONTAL_ALIGNMENT_LEFT
+		btn.custom_minimum_size = Vector2(0, 26)
+		btn.add_theme_font_size_override("font_size", 10)
+		btn.add_theme_color_override("font_hover_color", Color(1.0, 0.95, 0.7))
+		btn.add_theme_stylebox_override("hover", _hover_bg)
+		btn.add_theme_stylebox_override("normal", _normal_bg)
+		btn.add_theme_stylebox_override("pressed", _hover_bg)
+		btn.add_theme_stylebox_override("focus", _normal_bg)
+		btn.mouse_filter = Control.MOUSE_FILTER_STOP
+		btn.visible = false
+		_list_container.add_child(btn)
+		_list_rows.append(btn)
+
+	_built = true
+
+
+# === PUBLIC API (called by PersonalShopManager) ===
+
+func is_browsing() -> bool:
+	return _mode == Mode.BROWSE
+
+
+## Seller id of the shop currently shown in browse mode (0 if not browsing).
+func get_browse_seller_id() -> int:
+	return _browse_seller_id if _mode == Mode.BROWSE else 0
+
+
+## Opens the owner-side management view. `server_open` is true when this is a
+## refresh driven by a server snapshot of an already-open shop.
+func show_owner_view(shop_name: String, listings: Array, server_open: bool = true) -> void:
+	_mode = Mode.OWNER
+	_browse_seller_id = 0
+	_shop_open = server_open
+
+	# Keep whatever the player typed; only overwrite from the server name.
+	if not shop_name.is_empty():
+		_name_input.text = shop_name
+
+	_title_label.text = "My Shop"
+	_owner_row.visible = true
+	_open_close_btn.text = "Close Shop" if _shop_open else "Open Shop"
+	_name_input.editable = not _shop_open
+	_list_caption.text = "Your Listings (%d/%d)" % [listings.size(), PersonalShopManager.MAX_LISTINGS]
+	_status_label.text = "Open your shop, then click an inventory item below to list it. Click a listing to unlist it."
+
+	_render_rows(listings, true)
+	_show()
+
+
+## Renders the read-only browse view of another player's shop.
+func show_browse_view(seller_id: int, shop_name: String, listings: Array) -> void:
+	_mode = Mode.BROWSE
+	_browse_seller_id = seller_id
+	_title_label.text = shop_name if not shop_name.is_empty() else "Shop"
+	_owner_row.visible = false
+	_list_caption.text = "Items For Sale"
+	_status_label.text = "Click an item to buy it. You must stay near the seller."
+	_render_rows(listings, false)
+	_show()
+
+
+## Server told us our own shop closed (e.g. we left the Free Market).
+func on_shop_closed() -> void:
+	if _mode == Mode.OWNER:
+		_shop_open = false
+		_open_close_btn.text = "Open Shop"
+		_name_input.editable = true
+		_clear_rows()
+
+
+# === INTERNAL ===
+
+func _on_open_close_pressed() -> void:
+	if _mode != Mode.OWNER:
+		return
+	if _open_close_btn.text == "Open Shop":
+		_shop_open = true
+		_name_input.editable = false
+		_open_close_btn.text = "Close Shop"
+		PersonalShopManager.request_open_shop.rpc_id(1, _name_input.text)
+	else:
+		_shop_open = false
+		_name_input.editable = true
+		_open_close_btn.text = "Open Shop"
+		PersonalShopManager.request_close_shop.rpc_id(1)
+		_clear_rows()
+
+
+## Renders either the seller's listings or, in OWNER mode, also the inventory
+## items available to list.
+func _render_rows(listings: Array, is_owner: bool) -> void:
+	_clear_rows()
+	var row_idx := 0
+
+	# 1. Active listings.
+	for listing in listings:
+		if row_idx >= _list_rows.size():
+			break
+		var item: ItemData = ItemData.from_dictionary(listing.get("item", {}))
+		if not item:
+			continue
+		var price: int = int(listing.get("price", 0))
+		var listing_id: int = int(listing.get("listing_id", -1))
+		var btn := _list_rows[row_idx]
+		btn.text = "%s   -   %d coins%s" % [item.name, price,
+			"  (click to unlist)" if is_owner else "  (click to buy)"]
+		btn.tooltip_text = _item_tooltip(item)
+		btn.add_theme_color_override("font_color", _rarity_color(item))
+		btn.visible = true
+		_disconnect_all(btn)
+		if is_owner:
+			var lid := listing_id
+			btn.pressed.connect(func(): _unlist(lid))
+		else:
+			var seller := _browse_seller_id
+			var lid2 := listing_id
+			btn.pressed.connect(func(): _buy(seller, lid2))
+		row_idx += 1
+
+	# 2. Owner mode: list inventory items that can be put up for sale.
+	if is_owner:
+		if row_idx < _list_rows.size():
+			var header := _list_rows[row_idx]
+			header.text = "--- Your Inventory (click to list) ---"
+			header.tooltip_text = ""
+			header.add_theme_color_override("font_color", Color(0.6, 0.6, 0.7))
+			header.visible = true
+			header.disabled = true
+			_disconnect_all(header)
+			row_idx += 1
+
+		var local := PlayerManager.get_player_node(multiplayer.get_unique_id())
+		if is_instance_valid(local) and is_instance_valid(local.inventory_component):
+			var slots: Array = local.inventory_component.get_slots()
+			for i in slots.size():
+				if row_idx >= _list_rows.size():
+					break
+				var slot: SlotData = slots[i]
+				if not slot.item:
+					continue
+				var inv_item: ItemData = slot.item
+				var btn2 := _list_rows[row_idx]
+				var stack_txt := ""
+				if inv_item.can_stack and inv_item.current_stack_amount > 1:
+					stack_txt = " x%d" % inv_item.current_stack_amount
+				btn2.text = "%s%s" % [inv_item.name, stack_txt]
+				btn2.tooltip_text = _item_tooltip(inv_item)
+				btn2.add_theme_color_override("font_color", _rarity_color(inv_item))
+				btn2.disabled = false
+				btn2.visible = true
+				_disconnect_all(btn2)
+				var slot_idx := i
+				var suggested := maxi(1, inv_item.base_value)
+				btn2.pressed.connect(func(): _prompt_list(slot_idx, inv_item.name, suggested))
+				row_idx += 1
+
+
+func _clear_rows() -> void:
+	for btn in _list_rows:
+		btn.visible = false
+		btn.disabled = false
+		btn.text = ""
+		btn.tooltip_text = ""
+		_disconnect_all(btn)
+
+
+func _disconnect_all(btn: Button) -> void:
+	for connection in btn.pressed.get_connections():
+		btn.pressed.disconnect(connection.callable)
+
+
+# --- Listing price prompt ---
+
+var _price_dialog: AcceptDialog = null
+var _price_spin: SpinBox = null
+var _pending_slot: int = -1
+
+
+func _prompt_list(slot_index: int, item_name: String, suggested_price: int) -> void:
+	_pending_slot = slot_index
+	if not is_instance_valid(_price_dialog):
+		_price_dialog = AcceptDialog.new()
+		_price_dialog.title = "Set Price"
+		_price_dialog.ok_button_text = "List Item"
+		var vb := VBoxContainer.new()
+		var lbl := Label.new()
+		lbl.name = "PromptLabel"
+		vb.add_child(lbl)
+		_price_spin = SpinBox.new()
+		_price_spin.min_value = 1
+		_price_spin.max_value = 999999999
+		_price_spin.step = 1
+		vb.add_child(_price_spin)
+		_price_dialog.add_child(vb)
+		_price_dialog.confirmed.connect(_on_price_confirmed)
+		add_child(_price_dialog)
+	var prompt_lbl := _price_dialog.find_child("PromptLabel", true, false)
+	if prompt_lbl is Label:
+		prompt_lbl.text = "Price (coins) for: %s" % item_name
+	_price_spin.value = suggested_price
+	_price_dialog.popup_centered(Vector2i(260, 110))
+
+
+func _on_price_confirmed() -> void:
+	if _pending_slot < 0:
+		return
+	PersonalShopManager.request_list_item.rpc_id(1, _pending_slot, int(_price_spin.value))
+	_pending_slot = -1
+
+
+func _unlist(listing_id: int) -> void:
+	PersonalShopManager.request_unlist_item.rpc_id(1, listing_id)
+
+
+func _buy(seller_id: int, listing_id: int) -> void:
+	if seller_id == 0:
+		return
+	PersonalShopManager.request_buy_listing.rpc_id(1, seller_id, listing_id)
+
+
+# --- Display helpers ---
+
+func _item_tooltip(item: ItemData) -> String:
+	var tip := item.name
+	if item is EquipmentData:
+		var eq := item as EquipmentData
+		tip += "\nLevel %d" % eq.item_level
+		var rarity_name: String = Constants.ItemRarity.find_key(eq.rarity)
+		if rarity_name:
+			tip += " | %s" % rarity_name
+		for stat_type in eq.bonus_stats:
+			var stat_data: StatData = eq.bonus_stats[stat_type]
+			if stat_data.flat_bonus_value > 0:
+				tip += "\n%s: +%d" % [Constants.StatType.find_key(stat_type), stat_data.flat_bonus_value]
+	elif item is ConsumableData:
+		if not item.description.is_empty():
+			tip += "\n%s" % item.description
+	return tip
+
+
+func _rarity_color(item: ItemData) -> Color:
+	if item is EquipmentData:
+		match item.rarity:
+			Constants.ItemRarity.COMMON: return Color(0.7, 0.7, 0.7)
+			Constants.ItemRarity.UNCOMMON: return Color(1.0, 1.0, 1.0)
+			Constants.ItemRarity.RARE: return Color(1.0, 0.6, 0.2)
+			Constants.ItemRarity.EPIC: return Color(0.7, 0.3, 0.9)
+			Constants.ItemRarity.LEGENDARY: return Color(1.0, 0.85, 0.0)
+	return Color(0.8, 0.8, 0.8)
+
+
+func _show() -> void:
+	if not visible:
+		var vp_size := get_viewport_rect().size
+		global_position = (vp_size - size) * 0.5
+		visible = true
+	move_to_front()
+
+
+# --- Draggable ---
+
+func _gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
+		if event.pressed:
+			var title_rect := Rect2(global_position, Vector2(size.x, TITLE_HEIGHT))
+			if title_rect.has_point(get_global_mouse_position()):
+				is_dragging = true
+				drag_offset = get_global_mouse_position() - global_position
+				move_to_front()
+		else:
+			is_dragging = false
+
+
+func _process(_delta: float) -> void:
+	if is_dragging:
+		var new_pos := get_global_mouse_position() - drag_offset
+		var vp_size := get_viewport_rect().size
+		new_pos.x = clampf(new_pos.x, 0, vp_size.x - size.x)
+		new_pos.y = clampf(new_pos.y, 0, vp_size.y - size.y)
+		global_position = new_pos

--- a/scripts/UI/personal_shop_window.gd.uid
+++ b/scripts/UI/personal_shop_window.gd.uid
@@ -1,0 +1,1 @@
+uid://bnkfdtaosor0e

--- a/scripts/UI/player_context_menu.gd
+++ b/scripts/UI/player_context_menu.gd
@@ -47,6 +47,10 @@ func show_for_target(target_id: int, screen_pos: Vector2) -> void:
 	_add_button("Trade with %s" % target_name, _do_trade)
 	_add_button("Invite to Party", _do_party_invite)
 
+	# Show "Browse Shop" only when the target currently has a personal shop open.
+	if PersonalShopManager.is_shop_open(_target_id):
+		_add_button("Browse Shop", _do_browse_shop)
+
 	if _target_is_bot and multiplayer.is_server():
 		_add_separator()
 		_add_button("Force Travel", _do_travel)
@@ -141,6 +145,12 @@ func _do_inspect() -> void:
 
 func _do_trade() -> void:
 	_open_trade_window(_target_id)
+
+
+func _do_browse_shop() -> void:
+	if _target_id == 0:
+		return
+	PersonalShopManager.browse_player_shop(_target_id)
 
 
 func _open_trade_window(target_id: int) -> void:


### PR DESCRIPTION
## Summary

Implements issue #7 — a Free Market zone where players open **personal shops** to sell inventory items to each other for coins.

- **New `free_market` map** inheriting `MapBase`, reusing existing tilesets/art (no new art). Linked to `town` via portals in both directions, modeled on the recently-added town map.
- **`PersonalShopManager`** autoload — server-authoritative store of every open shop. Handles open/close, list/unlist, browse, and buy.
- **`PersonalShopWindow`** UI — a draggable panel built procedurally (same style as `TradeWindow` / `PlayerContextMenu`):
  - **Owner mode**: name your shop, click inventory items to list them with a price, click listings to unlist.
  - **Browse mode**: read-only view of another player's shop; click an item to buy.
- **Opening a shop**: press **M** in the Free Market.
- **Browsing**: right-click a nearby player who has a shop open → **"Browse Shop"** appears in the context menu.

## Server-authoritative & atomic

Clients only send intents (`list` / `unlist` / `open` / `close` / `buy`). All coin and item transfers happen on the server:

- Listed items are **removed from the seller's inventory and held in the listing** server-side, so they can't be sold or dropped twice.
- A buy validates coins, range, and that the listing still exists, then transfers coins + item in one block. The listing is removed first so it can't be double-bought.
- Browsing is **range-gated (~160px, same map)** — physical presence creates the social space.

## Edge cases handled

- Seller disconnects or leaves the Free Market → shop auto-closes and **all held listing items are returned to the seller** before the disconnect/map-change save flushes (so nothing is lost).
- Buyer inventory full, insufficient coins, item already sold, seller unlists mid-browse → all rejected server-side with a chat notification; browsing clients get a fresh snapshot.
- Push refreshes (a sale/unlist) reach all players on the map but only update a client that actually has that shop's window open.

## Design choice: sellers keep playing

The shop is pure server-side state, not tied to the seller's node behavior, so **the seller keeps moving and playing freely while shopkeeping** — no stalling needed. This is both simpler (no movement-lock state machine) and a better player experience.

## Test plan

- [ ] Walk through the new town → Free Market portal (and back).
- [ ] Press M in the Free Market, name a shop, list an item with a price.
- [ ] Second player walks up, right-clicks the seller, browses, and buys — verify coins/items transfer on both sides.
- [ ] Try buying with insufficient coins / full inventory — verify rejection.
- [ ] Unlist an item mid-browse; verify the browser's view refreshes.
- [ ] Seller leaves the Free Market or disconnects with items listed — verify items return to inventory and persist.
- [ ] Confirm pressing M outside the Free Market is rejected.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)