### PR TITLE
Quests as resources (.tres auto-load)

### DIFF
--- a/resources/Quests/Advancement/q_call_to_advance.tres
+++ b/resources/Quests/Advancement/q_call_to_advance.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_call_to_advance"
+quest_name = "Answer the Call"
+description = "You have mastered the fundamentals. At level 30 a warrior may choose a specialized path. Reach level 30, return to town, and type /advance to claim your advanced class."
+required_level = 25
+prerequisite_quest_id = "q_veterans_path"
+objectives = Array[Dictionary]([{
+"type": 2,
+"target": "",
+"amount": 30
+}])
+reward_coins = 1000
+reward_items = Array[String](["Grand Healing Draught", "Grand Mana Draught"])
+sort_order = 130

--- a/resources/Quests/Advancement/q_goblin_trouble.tres
+++ b/resources/Quests/Advancement/q_goblin_trouble.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_goblin_trouble"
+quest_name = "Goblin Trouble"
+description = "The goblin warbands are growing. Break their numbers before they march on the village."
+required_level = 13
+prerequisite_quest_id = "q_deep_woods"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Goblin",
+"amount": 40
+}])
+reward_exp = 1400
+reward_coins = 180
+sort_order = 110

--- a/resources/Quests/Advancement/q_veterans_path.tres
+++ b/resources/Quests/Advancement/q_veterans_path.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_veterans_path"
+quest_name = "A Veteran's Path"
+description = "Only seasoned fighters can hope to specialize. Reach level 25 to walk the veteran's path."
+required_level = 20
+prerequisite_quest_id = "q_seasoned_warrior"
+objectives = Array[Dictionary]([{
+"type": 2,
+"target": "",
+"amount": 25
+}])
+reward_coins = 600
+reward_items = Array[String](["Greater Healing Draught"])
+sort_order = 120

--- a/resources/Quests/Beginner/q_boar_patrol.tres
+++ b/resources/Quests/Beginner/q_boar_patrol.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_boar_patrol"
+quest_name = "Boar Patrol"
+description = "The boars near the village have grown bold and trample the crops. Cull a few of them."
+required_level = 3
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Boar",
+"amount": 5
+}])
+reward_exp = 100
+reward_coins = 20
+sort_order = 30

--- a/resources/Quests/Beginner/q_first_blood.tres
+++ b/resources/Quests/Beginner/q_first_blood.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_first_blood"
+quest_name = "First Blood"
+description = "Defeat your first Slime to prove your mettle."
+required_level = 1
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 3
+}])
+reward_exp = 50
+reward_coins = 10
+sort_order = 10

--- a/resources/Quests/Beginner/q_slime_slayer.tres
+++ b/resources/Quests/Beginner/q_slime_slayer.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_slayer"
+quest_name = "Slime Slayer"
+description = "The slimes are multiplying! Thin the herd."
+required_level = 2
+prerequisite_quest_id = "q_first_blood"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 10
+}])
+reward_exp = 150
+reward_coins = 30
+sort_order = 20

--- a/resources/Quests/Early/q_growing_power.tres
+++ b/resources/Quests/Early/q_growing_power.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_growing_power"
+quest_name = "Growing Power"
+description = "Continue your training and reach level 10."
+required_level = 5
+prerequisite_quest_id = "q_level_up"
+objectives = Array[Dictionary]([{
+"type": 2,
+"target": "",
+"amount": 10
+}])
+reward_coins = 150
+reward_items = Array[String](["Health Potion", "Mana Potion"])
+sort_order = 60

--- a/resources/Quests/Early/q_level_up.tres
+++ b/resources/Quests/Early/q_level_up.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_level_up"
+quest_name = "Getting Stronger"
+description = "Reach level 5 to unlock new abilities."
+required_level = 1
+objectives = Array[Dictionary]([{
+"type": 2,
+"target": "",
+"amount": 5
+}])
+reward_coins = 50
+reward_items = Array[String](["Health Potion"])
+sort_order = 50

--- a/resources/Quests/Early/q_pest_control.tres
+++ b/resources/Quests/Early/q_pest_control.tres
@@ -1,0 +1,23 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_pest_control"
+quest_name = "Pest Control"
+description = "Multiple monster species threaten the village. Eliminate them."
+required_level = 5
+prerequisite_quest_id = "q_slime_slayer"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 15
+}, {
+"type": 0,
+"target": "Boar",
+"amount": 10
+}])
+reward_exp = 300
+reward_coins = 50
+sort_order = 40

--- a/resources/Quests/EndlessHunt/q_endless_hunt_1.tres
+++ b/resources/Quests/EndlessHunt/q_endless_hunt_1.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_endless_hunt_1"
+quest_name = "Endless Hunt I"
+description = "The boars keep coming back to trample the crops. Cull 15 of them — that should give us some peace."
+required_level = 3
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Boar",
+"amount": 15
+}])
+reward_exp = 250
+reward_coins = 60
+npc_only = true
+sort_order = 200

--- a/resources/Quests/EndlessHunt/q_endless_hunt_2.tres
+++ b/resources/Quests/EndlessHunt/q_endless_hunt_2.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_endless_hunt_2"
+quest_name = "Endless Hunt II"
+description = "Still more boars. The herd needs serious thinning. Bring down 50 this time."
+required_level = 5
+prerequisite_quest_id = "q_endless_hunt_1"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Boar",
+"amount": 50
+}])
+reward_exp = 700
+reward_coins = 200
+npc_only = true
+sort_order = 210

--- a/resources/Quests/EndlessHunt/q_endless_hunt_3.tres
+++ b/resources/Quests/EndlessHunt/q_endless_hunt_3.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_endless_hunt_3"
+quest_name = "Endless Hunt III"
+description = "Truly endless. The boars seem infinite. Slay 99 more to prove your dedication."
+required_level = 8
+prerequisite_quest_id = "q_endless_hunt_2"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Boar",
+"amount": 99
+}])
+reward_exp = 1800
+reward_coins = 500
+npc_only = true
+sort_order = 220

--- a/resources/Quests/EndlessHunt/q_endless_hunt_4.tres
+++ b/resources/Quests/EndlessHunt/q_endless_hunt_4.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_endless_hunt_4"
+quest_name = "Endless Hunt IV: The Final Tide"
+description = "Legend speaks of a warrior who would cull 999. The village will sing of the boar-slayer for generations. Are you that warrior?"
+required_level = 12
+prerequisite_quest_id = "q_endless_hunt_3"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Boar",
+"amount": 999
+}])
+reward_exp = 10000
+reward_coins = 3000
+reward_items = Array[String](["Grand Healing Draught", "Grand Mana Draught"])
+npc_only = true
+sort_order = 230

--- a/resources/Quests/Mid/q_collector.tres
+++ b/resources/Quests/Mid/q_collector.tres
@@ -1,0 +1,17 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_collector"
+quest_name = "The Collector"
+description = "Gather coins from fallen monsters to fund the village defense."
+required_level = 5
+objectives = Array[Dictionary]([{
+"type": 1,
+"target": "Coin",
+"amount": 100
+}])
+reward_exp = 250
+sort_order = 100

--- a/resources/Quests/Mid/q_deep_woods.tres
+++ b/resources/Quests/Mid/q_deep_woods.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_deep_woods"
+quest_name = "Into the Deep Woods"
+description = "Venture past the meadow into goblin territory and prove you can handle the deep woods."
+required_level = 10
+prerequisite_quest_id = "q_pest_control"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Goblin",
+"amount": 25
+}])
+reward_exp = 600
+reward_coins = 100
+sort_order = 70

--- a/resources/Quests/Mid/q_seasoned_warrior.tres
+++ b/resources/Quests/Mid/q_seasoned_warrior.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_seasoned_warrior"
+quest_name = "Seasoned Warrior"
+description = "Prove your dedication by reaching level 20."
+required_level = 10
+prerequisite_quest_id = "q_growing_power"
+objectives = Array[Dictionary]([{
+"type": 2,
+"target": "",
+"amount": 20
+}])
+reward_coins = 400
+reward_items = Array[String](["Healing Draught"])
+sort_order = 90

--- a/resources/Quests/Mid/q_slime_exterminator.tres
+++ b/resources/Quests/Mid/q_slime_exterminator.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_exterminator"
+quest_name = "Slime Exterminator"
+description = "The slime population is out of control. A massive cull is needed."
+required_level = 8
+prerequisite_quest_id = "q_slime_slayer"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 50
+}])
+reward_exp = 800
+reward_coins = 120
+sort_order = 80

--- a/resources/Quests/SlimeThreat/q_slime_threat_1.tres
+++ b/resources/Quests/SlimeThreat/q_slime_threat_1.tres
@@ -1,0 +1,19 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_threat_1"
+quest_name = "Slime Threat: Level 1"
+description = "Slimes have been spotted in this area. The local authority asks that travelers cull 15 of them."
+required_level = 1
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 15
+}])
+reward_exp = 200
+reward_coins = 40
+npc_only = true
+sort_order = 300

--- a/resources/Quests/SlimeThreat/q_slime_threat_2.tres
+++ b/resources/Quests/SlimeThreat/q_slime_threat_2.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_threat_2"
+quest_name = "Slime Threat: Level 2"
+description = "The slime population is growing. Take down 50 more to contain the threat."
+required_level = 3
+prerequisite_quest_id = "q_slime_threat_1"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 50
+}])
+reward_exp = 600
+reward_coins = 150
+npc_only = true
+sort_order = 310

--- a/resources/Quests/SlimeThreat/q_slime_threat_3.tres
+++ b/resources/Quests/SlimeThreat/q_slime_threat_3.tres
@@ -1,0 +1,20 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_threat_3"
+quest_name = "Slime Threat: Level 3"
+description = "Slime infestation level rising. Eliminate 99 more — your reward will be substantial."
+required_level = 6
+prerequisite_quest_id = "q_slime_threat_2"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 99
+}])
+reward_exp = 1600
+reward_coins = 450
+npc_only = true
+sort_order = 320

--- a/resources/Quests/SlimeThreat/q_slime_threat_4.tres
+++ b/resources/Quests/SlimeThreat/q_slime_threat_4.tres
@@ -1,0 +1,21 @@
+[gd_resource type="Resource" script_class="QuestData" load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Resources/QuestSystem/QuestData.gd" id="1_quest_data"]
+
+[resource]
+script = ExtResource("1_quest_data")
+quest_id = "q_slime_threat_4"
+quest_name = "Slime Threat: Level 4 — Total Eradication"
+description = "EXTREME SLIME EMERGENCY. The legendary hunter who slays 999 will be honored forever."
+required_level = 10
+prerequisite_quest_id = "q_slime_threat_3"
+objectives = Array[Dictionary]([{
+"type": 0,
+"target": "Slime",
+"amount": 999
+}])
+reward_exp = 9000
+reward_coins = 2700
+reward_items = Array[String](["Grand Healing Draught", "Grand Mana Draught"])
+npc_only = true
+sort_order = 330

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -42,137 +42,67 @@ var _tracked_quests: Dictionary = {}
 var _onboarded: Dictionary = {}
 
 
+## Folder that the auto-loader recursively scans for QuestData .tres files at
+## QuestManager._ready(). Mirrors the ResourceManager pattern for abilities,
+## items, buffs, and classes. Subfolders are allowed (and used — see
+## resources/Quests/Beginner/, /Early/, /Mid/, /Advancement/, /EndlessHunt/,
+## /SlimeThreat/) — the scanner descends into them.
+const QUESTS_DIR: String = "res://resources/Quests/"
+
+
 func _ready() -> void:
-	_define_quests()
+	_load_quests_from_resources()
 	#print("QuestManager: Loaded %d quest definitions." % _quests.size())
 
 
 # ═══════════════════════════════════════════════════════════════════════════
-# QUEST DEFINITIONS
+# QUEST DEFINITIONS — loaded from .tres files in res://resources/Quests/
 # ═══════════════════════════════════════════════════════════════════════════
+#
+# Each quest lives in its own .tres file. Quest IDs are stable strings (not
+# auto-generated UUIDs) because player save data persists references to them
+# in `_active_quests`, `_completed_quests`, and `_tracked_quests`, and scene
+# files (town.tscn, game.tscn) bake quest IDs into NPC `offered_quest_ids`.
+# Renaming a quest_id is a breaking change.
+#
+# To add a quest: drop a new .tres under res://resources/Quests/<chain>/,
+# fill in the QuestData fields (use a unique quest_id, set sort_order to
+# control its position in the Q-window's Available tab), and reload the
+# editor. No code change required.
 
-func _define_quests() -> void:
-	# --- Beginner quests (level 1-5) ---
-	_add_quest("q_first_blood", "First Blood", "Defeat your first Slime to prove your mettle.", 1, "",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 3}],
-		50, 10, [])
-
-	_add_quest("q_slime_slayer", "Slime Slayer", "The slimes are multiplying! Thin the herd.", 2, "q_first_blood",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 10}],
-		150, 30, [])
-
-	_add_quest("q_boar_patrol", "Boar Patrol", "The boars near the village have grown bold and trample the crops. Cull a few of them.", 3, "",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 5}],
-		100, 20, [])
-
-	# --- Early quests (level 5-10) ---
-	_add_quest("q_pest_control", "Pest Control", "Multiple monster species threaten the village. Eliminate them.", 5, "q_slime_slayer",
-		[
-			{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 15},
-			{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 10},
-		],
-		300, 50, [])
-
-	# REACH_LEVEL quests grant no EXP — the level itself was already earned by
-	# grinding EXP, so rewarding EXP for it creates a self-feeding loop. Pay out
-	# in coins and consumables instead.
-	_add_quest("q_level_up", "Getting Stronger", "Reach level 5 to unlock new abilities.", 1, "",
-		[{"type": QuestData.ObjectiveType.REACH_LEVEL, "target": "", "amount": 5}],
-		0, 50, ["Health Potion"])
-
-	_add_quest("q_growing_power", "Growing Power", "Continue your training and reach level 10.", 5, "q_level_up",
-		[{"type": QuestData.ObjectiveType.REACH_LEVEL, "target": "", "amount": 10}],
-		0, 150, ["Health Potion", "Mana Potion"])
-
-	# --- Mid-level quests (level 10-20) ---
-	_add_quest("q_deep_woods", "Into the Deep Woods", "Venture past the meadow into goblin territory and prove you can handle the deep woods.", 10, "q_pest_control",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Goblin", "amount": 25}],
-		600, 100, [])
-
-	_add_quest("q_slime_exterminator", "Slime Exterminator", "The slime population is out of control. A massive cull is needed.", 8, "q_slime_slayer",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 50}],
-		800, 120, [])
-
-	_add_quest("q_seasoned_warrior", "Seasoned Warrior", "Prove your dedication by reaching level 20.", 10, "q_growing_power",
-		[{"type": QuestData.ObjectiveType.REACH_LEVEL, "target": "", "amount": 20}],
-		0, 400, ["Healing Draught"])
-
-	_add_quest("q_collector", "The Collector", "Gather coins from fallen monsters to fund the village defense.", 5, "",
-		[{"type": QuestData.ObjectiveType.COLLECT, "target": "Coin", "amount": 100}],
-		250, 0, [])
-
-	# --- Advancement track (level 13-30) ---
-	_add_quest("q_goblin_trouble", "Goblin Trouble", "The goblin warbands are growing. Break their numbers before they march on the village.", 13, "q_deep_woods",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Goblin", "amount": 40}],
-		1400, 180, [])
-
-	_add_quest("q_veterans_path", "A Veteran's Path", "Only seasoned fighters can hope to specialize. Reach level 25 to walk the veteran's path.", 20, "q_seasoned_warrior",
-		[{"type": QuestData.ObjectiveType.REACH_LEVEL, "target": "", "amount": 25}],
-		0, 600, ["Greater Healing Draught"])
-
-	_add_quest("q_call_to_advance", "Answer the Call", "You have mastered the fundamentals. At level 30 a warrior may choose a specialized path. Reach level 30, return to town, and type /advance to claim your advanced class.", 25, "q_veterans_path",
-		[{"type": QuestData.ObjectiveType.REACH_LEVEL, "target": "", "amount": 30}],
-		0, 1000, ["Grand Healing Draught", "Grand Mana Draught"])
-
-	# --- Endless Hunt: Village Elder's signature NPC-only chain ---
-	# Hidden from the Quest Log's Available tab; the player can only get the
-	# next link by talking to the Village Elder in Maple Town. Escalates
-	# 15 -> 50 -> 99 -> 999 in the MapleStory tradition of long-tail grind
-	# chains. The 999 tier is prestige content, gated to level 12+ so it
-	# doesn't masquerade as normal progression.
-	_add_quest("q_endless_hunt_1", "Endless Hunt I", "The boars keep coming back to trample the crops. Cull 15 of them — that should give us some peace.", 3, "",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 15}],
-		250, 60, [], true)
-
-	_add_quest("q_endless_hunt_2", "Endless Hunt II", "Still more boars. The herd needs serious thinning. Bring down 50 this time.", 5, "q_endless_hunt_1",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 50}],
-		700, 200, [], true)
-
-	_add_quest("q_endless_hunt_3", "Endless Hunt III", "Truly endless. The boars seem infinite. Slay 99 more to prove your dedication.", 8, "q_endless_hunt_2",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 99}],
-		1800, 500, [], true)
-
-	_add_quest("q_endless_hunt_4", "Endless Hunt IV: The Final Tide", "Legend speaks of a warrior who would cull 999. The village will sing of the boar-slayer for generations. Are you that warrior?", 12, "q_endless_hunt_3",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Boar", "amount": 999}],
-		10000, 3000, ["Grand Healing Draught", "Grand Mana Draught"], true)
-
-	# --- Slime Threat: Slime Meadow's NPC-only chain ---
-	# Posted on a sign in the Slime Meadow itself; same 15/50/99/999 cadence
-	# as the Village Elder's Endless Hunt, but targets slimes and starts at
-	# level 1 because slimes are the lowest-level mob in the zone.
-	_add_quest("q_slime_threat_1", "Slime Threat: Level 1", "Slimes have been spotted in this area. The local authority asks that travelers cull 15 of them.", 1, "",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 15}],
-		200, 40, [], true)
-
-	_add_quest("q_slime_threat_2", "Slime Threat: Level 2", "The slime population is growing. Take down 50 more to contain the threat.", 3, "q_slime_threat_1",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 50}],
-		600, 150, [], true)
-
-	_add_quest("q_slime_threat_3", "Slime Threat: Level 3", "Slime infestation level rising. Eliminate 99 more — your reward will be substantial.", 6, "q_slime_threat_2",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 99}],
-		1600, 450, [], true)
-
-	_add_quest("q_slime_threat_4", "Slime Threat: Level 4 — Total Eradication", "EXTREME SLIME EMERGENCY. The legendary hunter who slays 999 will be honored forever.", 10, "q_slime_threat_3",
-		[{"type": QuestData.ObjectiveType.KILL, "target": "Slime", "amount": 999}],
-		9000, 2700, ["Grand Healing Draught", "Grand Mana Draught"], true)
+func _load_quests_from_resources() -> void:
+	var loaded: Array[QuestData] = []
+	_scan_quests_recursive(QUESTS_DIR, loaded)
+	# Sort by `sort_order` so curated narrative order survives the move from
+	# `_define_quests()` (insertion order) to scanning files off disk
+	# (filesystem/alphabetical order). Dictionary preserves insertion order
+	# in GDScript, so inserting in sorted order is sufficient.
+	loaded.sort_custom(func(a: QuestData, b: QuestData) -> bool:
+		return a.sort_order < b.sort_order)
+	for q in loaded:
+		if q.quest_id.is_empty():
+			push_warning("QuestManager: skipping quest with empty quest_id (file: %s)" % q.resource_path)
+			continue
+		if _quests.has(q.quest_id):
+			push_warning("QuestManager: duplicate quest_id '%s' — '%s' overwrites '%s'" % [
+				q.quest_id, q.resource_path, _quests[q.quest_id].resource_path
+			])
+		_quests[q.quest_id] = q
 
 
-func _add_quest(id: String, qname: String, desc: String, req_level: int, prereq: String,
-		objectives: Array, exp: int, coins: int, items: Array, npc_only: bool = false) -> void:
-	var quest := QuestData.new()
-	quest.quest_id = id
-	quest.quest_name = qname
-	quest.description = desc
-	quest.required_level = req_level
-	quest.prerequisite_quest_id = prereq
-	for obj in objectives:
-		quest.objectives.append(obj)
-	quest.reward_exp = exp
-	quest.reward_coins = coins
+## Walk QUESTS_DIR (and any subfolders) for QuestData .tres files. Mirrors
+## ResourceManager._load_resources_recursively but specialized to QuestData
+## so we get the type guard for free.
+func _scan_quests_recursive(path: String, into: Array[QuestData]) -> void:
+	var items: PackedStringArray = ResourceLoader.list_directory(path)
 	for item_name in items:
-		quest.reward_items.append(item_name)
-	quest.npc_only = npc_only
-	_quests[id] = quest
+		var full_path: String = path + item_name
+		if item_name.ends_with("/"):
+			_scan_quests_recursive(full_path, into)
+		elif full_path.ends_with(".tres") or full_path.ends_with(".res"):
+			var resource: Resource = ResourceLoader.load(full_path)
+			if resource is QuestData:
+				into.append(resource)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/Resources/CLAUDE.md
+++ b/scripts/Resources/CLAUDE.md
@@ -28,24 +28,52 @@ here; the **data instances** (`.tres` files) live under `resources/`.
 Look content up with `ResourceManager.get_ability_data(id_or_name)`,
 `get_item_by_name(name)`, etc. — never `load()` content `.tres` at runtime.
 
+**`QuestData` follows the same pattern, but owned by `QuestManager`** —
+`QuestManager._load_quests_from_resources()` recursively scans
+`resources/Quests/` on `_ready()` and keys each loaded `QuestData` by its
+`quest_id` string. Look quests up with `QuestManager.get_quest_data(id)`.
+Quests live in chain-themed subfolders (`Beginner/`, `Early/`, `Mid/`,
+`Advancement/`, `EndlessHunt/`, `SlimeThreat/`) so they're discoverable by
+narrative role rather than alphabetic dump. To add a quest, drop a new
+`.tres` under the right subfolder — no code change required.
+
 **Exception — enemies are NOT auto-loaded.** `EnemyData` (`resources/Enemies/`) is
 referenced directly by an exported `enemy_data` on each enemy scene, not via
 `ResourceManager`.
 
-**Exception — quests are NOT data-driven.** `QuestData` carries `@export` fields
-for future `.tres` authoring, but the live quest list is registered in code by
-`_define_quests()` on `QuestManager`. There is no `resources/Quests/` folder.
-`KILL` objectives match exactly on `EnemyData.monster_name`, so the target
-string must be the same one set on the enemy `.tres` — past bugs shipped
-quests targeting non-existent enemy names that silently never completed.
+### QuestData author notes
 
-`QuestData.npc_only` (bool, default false): set true to hide a quest from the
-Q-window's Available tab so it can ONLY be obtained through a `QuestGiverNPC`
-whose `offered_quest_ids` includes it. Use for NPC-locked chains (e.g. the
-Village Elder's Endless Hunt 15/50/99/999) where the journal shouldn't
-spoil quests that are meant to be discovered through dialogue. After accept,
-the quest behaves normally — it appears in the Active / Completed tabs and
-in the Quest Tracker HUD like any other.
+- **`quest_id` is a hand-authored stable string, not a UUID.** Player save data
+  persists references to it (`_active_quests`, `_completed_quests`,
+  `_tracked_quests`) and scene files bake it into NPC `offered_quest_ids` arrays
+  in `town.tscn` / `game.tscn`. Renaming a `quest_id` is a breaking change —
+  existing characters lose progress on the renamed quest.
+- **`KILL` objective `target` strings match exactly on `EnemyData.monster_name`** —
+  past bugs shipped quests targeting non-existent enemy names that silently
+  never completed.
+- **`reward_items` are item NAMES** (e.g. `"Health Potion"`), resolved by
+  `ResourceManager.get_item_by_name` at completion time. Mismatches `push_warning`
+  but silently skip the reward.
+- **`sort_order: int`** controls display order in the Q-window's Available tab
+  and `QuestGiverDialog` rows. Lower values appear first; use ~10-unit spacing
+  (10, 20, 30, ...) so new quests can slot in between existing ones without
+  renumbering. Without it, `ResourceLoader.list_directory` returns filesystem
+  (alphabetical) order, which scrambles narrative flow.
+- **`npc_only: bool`** (default false): hide a quest from the Q-window's
+  Available tab so it can ONLY be obtained through a `QuestGiverNPC` whose
+  `offered_quest_ids` includes it. Use for NPC-locked chains (e.g. the
+  Village Elder's Endless Hunt 15/50/99/999) where the journal shouldn't
+  spoil quests meant to be discovered through dialogue. Once accepted the
+  quest behaves normally — it appears in the Active / Completed tabs and in
+  the Quest Tracker HUD like any other.
+- **`objectives: Array[Dictionary]`** is the per-objective list. Each dict is
+  `{"type": int, "target": String, "amount": int}` where `type` is the int
+  value of `QuestData.ObjectiveType` (`KILL = 0`, `COLLECT = 1`,
+  `REACH_LEVEL = 2`). The generic inspector renders this as expandable
+  dictionaries — workable but clunky; you author the keys by hand. A future
+  improvement is wrapping each objective in a typed `QuestObjective` Resource
+  subclass for dropdowns/validation, but it would require updating every
+  `obj.get("type", ...)` read site in `quest_manager.gd`.
 
 ## Conventions
 

--- a/scripts/Resources/QuestSystem/QuestData.gd
+++ b/scripts/Resources/QuestSystem/QuestData.gd
@@ -30,3 +30,11 @@ enum ObjectiveType {
 ## an NPC. Once accepted, the quest behaves normally — it shows up in the
 ## Active tab, persists, and grants rewards the same way.
 @export var npc_only: bool = false
+
+## Display order in the Q-window's Available tab and the QuestGiverDialog row
+## list. Lower values appear first. The QuestManager auto-loader sorts loaded
+## quests by this field before inserting into the registry, so curated
+## narrative order survives the move from `_define_quests()` to scanning
+## files alphabetically off disk. Use ~10-unit spacing (10, 20, 30, ...) so
+## new quests can slot in between existing ones without renumbering the rest.
+@export var sort_order: int = 100


### PR DESCRIPTION
## Summary

Refactors `QuestManager._define_quests()` (hand-rolled `_add_quest` calls in code) into a folder scan over `res://resources/Quests/`, mirroring the `ResourceManager` auto-load pattern that abilities, items, buffs, and classes already use.

**Why now:** the project is at 21 quests and growing (4 new this week). Hardcoded `_define_quests` was the bootstrap shortcut; with this many quests, `.tres` editing + hot-reload + visible diffs are the right tools.

## What changes

- **`QuestManager._load_quests_from_resources()`** recursively walks `res://resources/Quests/`, type-guards on `QuestData`, sorts by `sort_order`, and registers each by `quest_id`. Warns on empty `quest_id` and on duplicate keys (existing `ResourceManager` pattern silently overwrites — quests get the guard).
- **`QuestData.sort_order: int = 100`** (new): display order in the Q-window's Available tab and the `QuestGiverDialog` rows. The auto-loader sorts before inserting, so curated narrative order survives the move from `_define_quests()` insertion order to filesystem (alphabetical) scan order. Use ~10-unit spacing so new quests can slot in between.
- **All 21 existing quests** converted to `.tres` under chain-themed subfolders:
  - `Beginner/` (3): q_first_blood, q_slime_slayer, q_boar_patrol
  - `Early/` (3): q_pest_control, q_level_up, q_growing_power
  - `Mid/` (4): q_deep_woods, q_slime_exterminator, q_seasoned_warrior, q_collector
  - `Advancement/` (3): q_goblin_trouble, q_veterans_path, q_call_to_advance
  - `EndlessHunt/` (4, npc_only): q_endless_hunt_1..4
  - `SlimeThreat/` (4, npc_only): q_slime_threat_1..4
- **Reward values + prereq chains preserved exactly.** Most importantly, `quest_id` strings preserved byte-for-byte — save data (`_active_quests`, `_completed_quests`, `_tracked_quests`) and NPC `offered_quest_ids` arrays in `town.tscn` / `game.tscn` keep resolving.
- **`_define_quests()` and `_add_quest()` deleted.**

## Docs

- `scripts/Resources/CLAUDE.md`: removed the "quests are NOT data-driven" exception. Replaced with the auto-load description and a consolidated QuestData author-notes block (quest_id stability, KILL target = monster_name, reward_items = item names, sort_order, npc_only, objectives shape).
- `memory/quest-system-shape.md`: updated to reflect the new data-driven shape.

## Test plan

- [ ] Open `town.tscn` in the editor → Village Elder right-click → confirm Endless Hunt I + Level Up etc. show in the expected order (sort_order 50, 30, 100, 60, 200, 210, 220, 230)
- [ ] Open `game.tscn` (Slime Meadow) → right-click the Slime Threat Sign → confirm Slime Threat: Level 1 appears as Available
- [ ] Brand-new character: spawn into town → confirm `q_first_blood` is auto-accepted via the onboarding flow (tests that `ONBOARDING_QUEST_ID = "q_first_blood"` still resolves against the loaded dict)
- [ ] Kill 3 slimes → q_first_blood completes → quest reward popup fires → q_slime_slayer becomes available
- [ ] Log out / log back in with an in-progress character (one that has `q_first_blood` in `_active_quests` from before this PR) → confirm save data still resolves the quest (its `quest_id` is still `"q_first_blood"` in the new .tres)
- [ ] Open one of the .tres files in the resource editor / generic inspector → confirm all fields are editable, including the `objectives` Array[Dictionary] entries
- [ ] Edit a quest's `sort_order` in the .tres, restart → confirm display order changes accordingly

## Out of scope

- **Typed `QuestObjective` Resource subclass** would replace `Array[Dictionary]` for proper dropdown editing of `ObjectiveType`, but it requires updating every `obj.get("type", ...)` read site in `quest_manager.gd`. Worth doing later as a usability follow-up.
- **`add-quest` skill** mirroring `add-ability` / `add-item` / `add-buff` would be a natural next step now that quests have a recipe shape — but not in this PR.
- **`resource_editor` addon entry for Quest System** would add the custom dock browser UX for quests; without it you author in Godot's FileSystem dock + generic inspector, which is functional but less integrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)