### PR TITLE
Isolate maps in per-map SubViewports (server physics no longer leaks across maps)

### DIFF
--- a/scripts/Bot/bot_manager.gd
+++ b/scripts/Bot/bot_manager.gd
@@ -198,6 +198,13 @@ func _on_bot_spawned(bot_id: int) -> void:
 	if is_instance_valid(canvas_layer) and is_instance_valid(inv) and not inv.slots_data.is_empty():
 		canvas_layer.queue_free()
 
+	# A bot has no display — free its Camera2D so it can't compete with the
+	# host's camera inside the map's shared SubViewport (the host is server+
+	# client, so bot characters spawn in the same viewport as the host's body).
+	var bot_camera := player_node.get_node_or_null("Camera2D")
+	if is_instance_valid(bot_camera):
+		bot_camera.queue_free()
+
 	# The brain is parented to BotManager — not the character node — so it
 	# survives the character being freed and recreated on every map change,
 	# keeping its travel timers, patrol progress and cooldowns intact. On a map

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -83,6 +83,9 @@ func _ensure_maps_container() -> SubViewportContainer:
 	container.anchor_bottom = 1.0
 	container.stretch = true
 	container.mouse_filter = Control.MOUSE_FILTER_PASS
+	# Keep the per-viewport render texture sampled as nearest-neighbor when
+	# blitted to the window, so pixel-art doesn't go blurry through the wrap.
+	container.texture_filter = CanvasItem.TEXTURE_FILTER_NEAREST
 	get_tree().root.add_child(container)
 	return container
 
@@ -95,6 +98,10 @@ func _wrap_in_subviewport(map_instance: Node, map_id: String) -> SubViewport:
 	viewport.handle_input_locally = false
 	viewport.audio_listener_enable_2d = true
 	viewport.physics_object_picking = true
+	# SubViewport does NOT inherit the project's rendering/textures/canvas_textures/
+	# default_texture_filter setting — it defaults to LINEAR. Force nearest so the
+	# pixel-art textures rendered inside the viewport stay crisp.
+	viewport.canvas_item_default_texture_filter = Viewport.DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST
 	viewport.add_child(map_instance)
 	return viewport
 

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -62,6 +62,43 @@ func _on_server_started():
 	_build_map_connections()
 
 
+# === MAP CONTAINER + SUBVIEWPORT WRAPPING ===
+# Each map lives inside its own SubViewport with a fresh World2D, so physics,
+# navigation, canvas (lights), and audio listeners are fully isolated between
+# maps. Authors keep editing map scenes at (0,0); the wrap is added at runtime.
+# Both server and client mirror the same wrapping so absolute node paths line up
+# for MultiplayerSynchronizer replication and RPC routing.
+
+func _ensure_maps_container() -> SubViewportContainer:
+	var existing := get_tree().root.get_node_or_null("Maps")
+	if existing is SubViewportContainer:
+		return existing
+	if existing != null:
+		push_warning("MapManager: /root/Maps exists but is not a SubViewportContainer; replacing.")
+		get_tree().root.remove_child(existing)
+		existing.queue_free()
+	var container := SubViewportContainer.new()
+	container.name = "Maps"
+	container.anchor_right = 1.0
+	container.anchor_bottom = 1.0
+	container.stretch = true
+	container.mouse_filter = Control.MOUSE_FILTER_PASS
+	get_tree().root.add_child(container)
+	return container
+
+
+func _wrap_in_subviewport(map_instance: Node, map_id: String) -> SubViewport:
+	var viewport := SubViewport.new()
+	viewport.name = "Map_%s_VP" % map_id
+	viewport.world_2d = World2D.new()
+	viewport.disable_3d = true
+	viewport.handle_input_locally = false
+	viewport.audio_listener_enable_2d = true
+	viewport.physics_object_picking = true
+	viewport.add_child(map_instance)
+	return viewport
+
+
 # === SERVER LOGIC ===
 
 func request_map_change(player_id: int, target_map_id: String, target_spawn_point_name: String = ""):
@@ -143,18 +180,13 @@ func _load_map_on_server(map_id: String):
 		return
 	
 	map_instance.name = "Map_" + map_id
-	
-	# Create Maps container if needed
-	var maps_container = get_tree().root.get_node_or_null("Maps")
-	if not maps_container:
-		maps_container = Node.new()
-		maps_container.name = "Maps"
-		get_tree().root.add_child(maps_container)
-		#print("MapManager: Created Maps container at /root/Maps")
-	
-	# Add to server's scene tree
-	maps_container.add_child(map_instance)
-																											
+
+	# Wrap in a SubViewport (isolated World2D) so physics/nav don't leak across
+	# maps that share the (0,0) authoring origin. See helpers above.
+	var maps_container := _ensure_maps_container()
+	var viewport := _wrap_in_subviewport(map_instance, map_id)
+	maps_container.add_child(viewport)
+
 	active_maps[map_id] = {"scene_instance": map_instance, "player_ids": []}
 	map_loaded.emit(map_id)
 	
@@ -315,12 +347,19 @@ func _remove_player_from_map(player_id: int, map_id: String):
 
 func _unload_map_on_server(map_id: String):
 	if not map_id in active_maps: return
-	
+
 	#print("MapManager: Despawning empty map '%s'" % map_id)
 	var map_instance = active_maps[map_id].scene_instance
 	if is_instance_valid(map_instance):
 		invalidate_synchronizer_cache(map_instance)
-		map_instance.queue_free()
+		# Free the SubViewport wrapper, not just the map, so the wrap doesn't
+		# leak. Falls back to freeing the map directly if a wrap is somehow
+		# missing (defensive — shouldn't happen with the current load path).
+		var viewport: Node = map_instance.get_parent()
+		if viewport is SubViewport:
+			viewport.queue_free()
+		else:
+			map_instance.queue_free()
 
 	active_maps.erase(map_id)
 	map_unloaded.emit(map_id)
@@ -474,8 +513,14 @@ func client_set_current_map(map_id: String, spawn_point_name: String = ""):
 			if is_instance_valid(my_player) and my_player.has_method("cleanup_before_removal"):
 				my_player.cleanup_before_removal()
 				#print("Client: Cleaned up own player before map transition")
-		
-		current_map_instance.queue_free()
+
+		# Free the SubViewport wrapper (created in the wrap below) so it doesn't
+		# leak. Falls back to freeing the map directly if a wrap is missing.
+		var old_viewport: Node = current_map_instance.get_parent()
+		if old_viewport is SubViewport:
+			old_viewport.queue_free()
+		else:
+			current_map_instance.queue_free()
 		current_map_instance = null
 	
 	# Load and instantiate new map
@@ -495,17 +540,13 @@ func client_set_current_map(map_id: String, spawn_point_name: String = ""):
 		return
 		
 	map_instance.name = "Map_" + map_id
-	
-	# Create Maps container if needed (same structure as server)
-	var maps_container = get_tree().root.get_node_or_null("Maps")
-	if not maps_container:
-		maps_container = Node.new()
-		maps_container.name = "Maps"
-		get_tree().root.add_child(maps_container)
-		#print("Client: Created Maps container at /root/Maps")
-	
-	# Add to client's scene tree under Maps (matching server structure)
-	maps_container.add_child(map_instance)
+
+	# Mirror the server's wrap so the absolute node path of every map-child
+	# (Players/<id>, Enemies, spawners, ...) matches between server and client.
+	# Synchronizer replication and RPC routing rely on this parity.
+	var maps_container := _ensure_maps_container()
+	var viewport := _wrap_in_subviewport(map_instance, map_id)
+	maps_container.add_child(viewport)
 	
 	# On client, map synchronizers should start hidden and rely on server visibility updates
 	# if not multiplayer.is_server():

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -102,8 +102,24 @@ func _wrap_in_subviewport(map_instance: Node, map_id: String) -> SubViewport:
 	# default_texture_filter setting — it defaults to LINEAR. Force nearest so the
 	# pixel-art textures rendered inside the viewport stay crisp.
 	viewport.canvas_item_default_texture_filter = Viewport.DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST
+	# Render transparent when the map's content is hidden (visible=false on the
+	# map root) so SubViewportContainer doesn't stack one map's render on top of
+	# another on the host's screen. See _set_local_map_visible.
+	viewport.transparent_bg = true
 	viewport.add_child(map_instance)
 	return viewport
+
+
+## Show/hide a map LOCALLY on this peer. Bot/non-local maps stay loaded for
+## physics, but their SubViewport content is hidden so the SubViewportContainer
+## renders only the local peer's current map. Affects only the local peer's
+## tree — remote clients have their own map instances and are unaffected.
+func _set_local_map_visible(map_id: String, vis: bool) -> void:
+	if not active_maps.has(map_id):
+		return
+	var map_instance = active_maps[map_id].scene_instance
+	if is_instance_valid(map_instance):
+		map_instance.visible = vis
 
 
 # === SERVER LOGIC ===
@@ -142,6 +158,12 @@ func request_map_change(player_id: int, target_map_id: String, target_spawn_poin
 		return
 
 	if player_id == 1:
+		# Hide the previously-active map locally so its SubViewport stops
+		# compositing on top of the host's view; show the new one.
+		if not current_map_id.is_empty() and current_map_id != target_map_id:
+			_set_local_map_visible(current_map_id, false)
+		_set_local_map_visible(target_map_id, true)
+
 		current_map_instance = map_instance
 		current_map_id = target_map_id
 		# Play per-map BGM for the host player
@@ -193,6 +215,10 @@ func _load_map_on_server(map_id: String):
 	var maps_container := _ensure_maps_container()
 	var viewport := _wrap_in_subviewport(map_instance, map_id)
 	maps_container.add_child(viewport)
+	# Default to hidden locally — the host toggles it visible only when they
+	# travel to this map. Bots/other peers keep simulating regardless; this
+	# only suppresses local rendering on the host's screen.
+	map_instance.visible = false
 
 	active_maps[map_id] = {"scene_instance": map_instance, "player_ids": []}
 	map_loaded.emit(map_id)
@@ -554,6 +580,9 @@ func client_set_current_map(map_id: String, spawn_point_name: String = ""):
 	var maps_container := _ensure_maps_container()
 	var viewport := _wrap_in_subviewport(map_instance, map_id)
 	maps_container.add_child(viewport)
+	# Remote clients only ever have one map loaded; it's always the local
+	# peer's current map, so render it.
+	map_instance.visible = true
 	
 	# On client, map synchronizers should start hidden and rely on server visibility updates
 	# if not multiplayer.is_server():


### PR DESCRIPTION
## Summary

- Wraps each loaded map in a `SubViewport` with its own `World2D` so physics, navigation, canvas (lights), and audio listeners are fully isolated between maps that share the `(0,0)` authoring origin.
- Both server and client mirror the wrap so absolute node paths line up for `MultiplayerSynchronizer` replication and RPC routing.
- `/root/Maps` becomes a `SubViewportContainer` (Control, fullscreen, stretch). On the headless server this is inert; on the client it surfaces the active `SubViewport` to the window.

Map authors keep editing scenes at `(0,0)` — the wrap is added at runtime in `MapManager`; no map scene is modified.

## Why

Today the server holds every active map under `/root/Maps` at world `(0,0)`, all sharing one `World2D`. Raycasts, area queries, navigation, and 2D lights from Map A leak into Map B. The visibility filter system hides cross-map *replication*, but nothing isolates the *physics simulation*. This change does.

`get_world_2d()` traverses up to find the owning Viewport, so existing physics queries in `scripts/Abilities/AL_Teleport.gd`, `scripts/Bot/bot_navigator.gd`, and `scripts/Bot/bot_nav_graph.gd` automatically pick up the per-map `World2D`. No call sites needed to change.

## Files

- `scripts/Managers/map_manager.gd`
  - New helpers `_ensure_maps_container()` (SubViewportContainer) and `_wrap_in_subviewport(map_instance, map_id)`.
  - `_load_map_on_server` wraps + adds the SubViewport.
  - `_unload_map_on_server` frees the SubViewport wrapper, not just the map.
  - `client_set_current_map` mirrors the wrap; frees the wrapper on transition.

## Test plan (manual — server-authoritative networking is hard to unit-test)

- [ ] Host + 1 client; both load town; move around. No console errors.
- [ ] Walk through a portal to `game`. Camera follows; player visible; enemies spawn; map BGM plays.
- [ ] With host on `game` and bot on `town`: bot still navigates; `/bot watch <bot>` overlay shows graph on the bot's map only; no cross-map ray hits.
- [ ] Kill an enemy on `game`: damage number renders; XP awarded; drop appears and is pickable.
- [ ] Cast Teleport: raycasts find ground on the current map only.
- [ ] Open inventory window mid-game: clicks register on the inventory, not on the world behind it.
- [ ] Disconnect/reconnect: maps unload cleanly (no leaked SubViewport nodes in remote debugger).

## Out of scope (follow-ups)

- Removing the now-redundant map-filter safety belts in `update_visibility_for_player` and `bot_brain.gd`'s `Enemies` group filter. Still correct, harmless; defer.
- Switching player spawn to `MultiplayerSpawner` (currently manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)