### PR TITLE
Silence pickup sound from hidden maps (host bot-map leak)

### DIFF
--- a/scripts/Resources/ItemSystem/DroppedItem.gd
+++ b/scripts/Resources/ItemSystem/DroppedItem.gd
@@ -257,6 +257,15 @@ func pickup_item_client() -> void:
 	if synchronizer:
 		synchronizer.set_process_mode(Node.PROCESS_MODE_DISABLED)
 
+	# Skip the pickup animation + sound if this item lives inside a map that
+	# isn't visible on this peer (e.g. a bot's map on the host). map_root.visible
+	# gates rendering but not audio, so without this guard pickups in hidden
+	# maps still play through the host's speakers. Still queue_free so the node
+	# doesn't linger.
+	if not is_visible_in_tree():
+		queue_free()
+		return
+
 	# Visual effects for pickup
 	pickup_sound.stream = pickup_sfx
 	pickup_sound.play()


### PR DESCRIPTION
## Summary

Followup to #144. With per-map SubViewports, `map_root.visible=false` hides bot/non-current maps from the host's screen so the SubViewportContainer doesn't composite them — but `visible` only gates rendering, not audio. `AudioStreamPlayer2D` keeps playing through the master bus regardless, so pickups happening inside a bot's hidden map were audible on the host's speakers.

Fix: in `DroppedItem.pickup_item_client`, skip the pickup animation + sound when `is_visible_in_tree()` returns false on this peer. Still `queue_free` so the node doesn't linger.

## Why this works on every peer

- **Host, bot's hidden map**: `is_visible_in_tree() == false` (map_root hidden) → skip sound. ✓
- **Host, on the picker's map**: `is_visible_in_tree() == true` → sound plays. ✓
- **Remote client on the pickup's map**: their map_root is visible → sound plays. ✓
- **Remote client on a different map**: the item synchronizer never replicated to them (map visibility filter), so the RPC doesn't route. No change. ✓

## Notes

- Only patches `DroppedItem`. If other AudioStreamPlayer2D nodes leak across maps on the host (combat hits, ability casts, etc.), they can be patched with the same `is_visible_in_tree()` guard, or solved more centrally with a per-map audio bus.

## Test plan

- [ ] Host on town, bot on game. Bot picks up a coin/item on game — host hears nothing.
- [ ] Host on game, bot on game. Bot picks up an item — host hears it (same map).
- [ ] Host picks up an item — host hears it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)