### PR TITLE
Combat: consolidate damage formula — kill BL_ShadowPartner's duplicate

### DIFF
--- a/scripts/Buffs/BL_ShadowPartner.gd
+++ b/scripts/Buffs/BL_ShadowPartner.gd
@@ -103,52 +103,14 @@ func _on_owner_dealt_damage(target: Node, damage_values: Array, crit_values: Arr
 		return
 	if not target is EnemyBase:
 		return
-	var health_comp = target.get("health_component")
-	if not health_comp:
+	if not is_instance_valid(_combat_component):
 		return
 
-	var stats_comp: StatsComponent = _owner_ref.get_node_or_null("Components/Stats")
-	if not stats_comp:
-		return
-
-	var hit_count: int = damage_values.size()
-	var attacker_level: int = _owner_ref.level_component.level
-	var target_level: int = target.monster_level
-	var level_diff: int = attacker_level - target_level
-	var hit_chance: float = clampf(95.0 + (level_diff * 2.0), 5.0, 100.0)
-
-	var shadow_damages: Array = []
-	var shadow_crits: Array = []
-
-	for i in range(hit_count):
-		if randf() * 100.0 > hit_chance:
-			shadow_damages.append(-1)
-			shadow_crits.append(false)
-			continue
-
-		var base_damage := float(_combat_component.calculate_attack_damage()) * (damage_percent / 100.0)
-
-		if target.has_node("Stats"):
-			var target_stats = target.get_node("Stats")
-			var target_defense: int = target_stats.stats.get(Constants.StatType.DEFENSE).total_value
-			var level_modifier: float = clampf(1.0 + (level_diff * 0.05), 0.5, 1.5)
-			var defense_multiplier: float = 1.0 - (float(target_defense) / (target_defense + 500.0))
-			base_damage *= level_modifier * defense_multiplier
-
-		var crit_chance: float = stats_comp.stats.get(Constants.StatType.CRITCHANCE).total_value
-		var is_crit: bool = (randf() * 100.0) < crit_chance
-
-		if is_crit:
-			var crit_damage_bonus: float = stats_comp.stats.get(Constants.StatType.CRITDAMAGE).total_value
-			var crit_multiplier: float = randf_range(1.2, 1.5) + (crit_damage_bonus / 100.0)
-			base_damage *= crit_multiplier
-		else:
-			base_damage *= randf_range(0.8, 1.2)
-
-		var final_damage := maxi(1, roundi(base_damage))
-		shadow_damages.append(final_damage)
-		shadow_crits.append(is_crit)
-		health_comp.take_damage(final_damage, _combat_component, true, is_crit, false)
+	# Delegate the formula entirely to CombatComponent so the shadow uses the
+	# same crit / defense / level-diff pipeline as the player's own hits.
+	var rolled: Dictionary = _combat_component.execute_shadow_hit(target, damage_values.size(), damage_percent)
+	var shadow_damages: Array = rolled.damages
+	var shadow_crits: Array = rolled.crits
 
 	# Interleave: insert each shadow hit after its corresponding player hit
 	for i in range(shadow_damages.size()):

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -362,23 +362,22 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 	if not health_comp or health_comp.is_dead:
 		return
 
-	var attacker_level = owner_node.level_component.level
-	var target_level = target_enemy.monster_level
+	var attacker_level: int = owner_node.level_component.level
+	var target_level: int = target_enemy.monster_level
 
 	# --- Hit Chance Calculation ---
-	var level_diff = attacker_level - target_level
-	# Base 95% chance to hit. Lose 2% chance for each level the monster is above you.
-	var hit_chance = clamp(95.0 + (level_diff * 2.0), 5.0, 100.0)
-	
-	var max_hits = 1
+	var level_diff: int = attacker_level - target_level
+	var hit_chance: float = _compute_hit_chance(level_diff)
+
+	var max_hits: int = 1
 	if ability and level_stats:
 		max_hits = level_stats.max_hits
-	
+
 	var damage_values: Array = []
 	var crit_values: Array = []
-	
+
 	for i in range(max_hits):
-		var roll = randf() * 100
+		var roll: float = randf() * 100.0
 		if roll > hit_chance:
 			damage_values.append(-1) # -1 signifies a MISS
 			crit_values.append(false)
@@ -386,36 +385,19 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 			continue # Skip to the next hit
 
 		# --- Damage Calculation ---
-		var base_damage = 0
+		var base_damage: int = 0
 		if attack_name != "":
 			base_damage = calculate_attack_damage()
 		elif ability and level_stats:
 			base_damage = calculate_ability_damage(ability, level_stats)
 
-		var modified_damage = float(base_damage)
+		var rolled: Dictionary = _compute_damage_to(target_enemy, float(base_damage), level_diff)
+		var damage_to_deal: int = rolled.damage
+		var is_crit: bool = rolled.is_crit
 
-		if target_enemy.has_node("Stats"):
-			var target_stats = target_enemy.get_node("Stats")
-			var target_defense = target_stats.stats.get(Constants.StatType.DEFENSE).total_value
-
-			var level_modifier = clamp(1.0 + (level_diff * 0.05), 0.5, 1.5)
-			var defense_multiplier = 1.0 - (float(target_defense) / (target_defense + 500.0))
-
-			modified_damage *= level_modifier * defense_multiplier
-		
-		var crit_chance = _stats_component.stats.get(Constants.StatType.CRITCHANCE).total_value
-		var is_crit = (randf() * 100) < crit_chance
-		
-		if is_crit:
-			var crit_damage_bonus = _stats_component.stats.get(Constants.StatType.CRITDAMAGE).total_value
-			var crit_multiplier = randf_range(1.2, 1.5) + (crit_damage_bonus / 100.0)
-			modified_damage *= crit_multiplier
-
-		var damage_to_deal = roundi(modified_damage)
-		
 		damage_values.append(damage_to_deal)
 		crit_values.append(is_crit)
-		
+
 		health_comp.take_damage(damage_to_deal, self, true, is_crit, false)
 
 		if damage_to_deal > 0:
@@ -468,6 +450,81 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 
 		if dmg_spawner:
 			dmg_spawner.display_number_combo(damage_values, crit_values, spawn_pos)
+
+
+func execute_shadow_hit(target: Node, hit_count: int, damage_percent: float) -> Dictionary:
+	"""Runs `hit_count` "shadow" hits on `target` at `damage_percent` of the
+	owner's basic-attack damage. Each shadow hit rolls hit-chance, defense,
+	level diff, and crit through the same pipeline `_execute_hit` uses, then
+	deals damage. Server-only.
+
+	Returns {damages: Array, crits: Array} matching `hit_count` in length so a
+	caller (e.g. BL_ShadowPartner) can splice the results into a combo display.
+	Misses are represented as -1 in `damages`, matching `_execute_hit`'s
+	convention."""
+	var result: Dictionary = {"damages": [], "crits": []}
+
+	if not multiplayer.is_server():
+		return result
+
+	var health_comp = target.get("health_component")
+	if not health_comp or health_comp.is_dead:
+		return result
+
+	var attacker_level: int = owner_node.level_component.level
+	var target_level: int = target.monster_level if "monster_level" in target else attacker_level
+	var level_diff: int = attacker_level - target_level
+	var hit_chance: float = _compute_hit_chance(level_diff)
+
+	for i in range(hit_count):
+		var roll: float = randf() * 100.0
+		if roll > hit_chance:
+			result.damages.append(-1)
+			result.crits.append(false)
+			continue
+
+		var base_damage: float = float(calculate_attack_damage()) * (damage_percent / 100.0)
+		var rolled: Dictionary = _compute_damage_to(target, base_damage, level_diff)
+		var damage_to_deal: int = rolled.damage
+		var is_crit: bool = rolled.is_crit
+
+		result.damages.append(damage_to_deal)
+		result.crits.append(is_crit)
+
+		health_comp.take_damage(damage_to_deal, self, true, is_crit, false)
+
+	return result
+
+
+func _compute_hit_chance(level_diff: int) -> float:
+	# Base 95% chance to hit. Lose 2% chance for each level the monster is above you.
+	return clampf(95.0 + (level_diff * 2.0), 5.0, 100.0)
+
+
+func _compute_damage_to(target_enemy: Node, base_damage: float, level_diff: int) -> Dictionary:
+	"""Applies the per-target damage pipeline: defense reduction, level-diff
+	modifier, then crit roll. Mirrors the inner block of `_execute_hit` so any
+	balance change to defense/crit/level-diff propagates to every call site."""
+	var modified_damage: float = base_damage
+
+	if target_enemy.has_node("Stats"):
+		var target_stats = target_enemy.get_node("Stats")
+		var target_defense: int = target_stats.stats.get(Constants.StatType.DEFENSE).total_value
+
+		var level_modifier: float = clampf(1.0 + (level_diff * 0.05), 0.5, 1.5)
+		var defense_multiplier: float = 1.0 - (float(target_defense) / (target_defense + 500.0))
+
+		modified_damage *= level_modifier * defense_multiplier
+
+	var crit_chance: float = _stats_component.stats.get(Constants.StatType.CRITCHANCE).total_value
+	var is_crit: bool = (randf() * 100.0) < crit_chance
+
+	if is_crit:
+		var crit_damage_bonus: float = _stats_component.stats.get(Constants.StatType.CRITDAMAGE).total_value
+		var crit_multiplier: float = randf_range(1.2, 1.5) + (crit_damage_bonus / 100.0)
+		modified_damage *= crit_multiplier
+
+	return {"damage": roundi(modified_damage), "is_crit": is_crit}
 
 
 func calculate_ability_damage(_ability: AbilityData, level_stats: AbilityLevelData) -> int:


### PR DESCRIPTION
Part of an architecture review batch (PR 01 of N).

## Problem

`BL_ShadowPartner._on_owner_dealt_damage` re-implemented the entire crit + defense + level-diff damage pipeline from `CombatComponent._execute_hit`. Two call sites, one formula — and they had already drifted.

The shadow's copy had two leftover divergences from the canonical formula:
- An extra `randf_range(0.8, 1.2)` variance multiplier on non-crit hits. The canonical formula dropped this in commit `8206890` ("Removed redundant non-crit variance from _execute_hit since the mastery range now handles it") — but the buff was missed during that cleanup.
- A `maxi(1, ...)` clamp on final damage. The canonical formula allows 0-damage rolls.

This is exactly the class of bug architecture consolidation prevents: balance changes touch the canonical formula, but the buff keeps the old math.

## Fix

Extracted two helpers on `CombatComponent`:

- `_compute_hit_chance(level_diff) -> float` — the `clampf(95 + level_diff * 2, 5, 100)` formula, shared by both call sites.
- `_compute_damage_to(target, base_damage, level_diff) -> Dictionary` — the per-target inner pipeline (defense reduction → level modifier → crit roll). Returns `{damage, is_crit}`.

Refactored `_execute_hit` to call `_compute_damage_to` in its inner loop. Behaviour identical (verified by reading the diff: same formula, just lifted into a helper).

Added a new server-only public entry point:

```gdscript
func execute_shadow_hit(target: Node, hit_count: int, damage_percent: float) -> Dictionary
```

Runs `hit_count` shadow rolls on `target` at `damage_percent` of the owner's basic-attack damage. Each roll uses the same hit-chance + `_compute_damage_to` pipeline as `_execute_hit`. Applies damage via `health_comp.take_damage`. Returns `{damages, crits}` arrays so the buff can splice the results into the combo display without re-touching the formula.

`BL_ShadowPartner._on_owner_dealt_damage` collapsed from ~50 lines of duplicated formula to a 3-line call + the existing interleave loop.

## Behaviour changes

Because the buff was using the *pre-mastery-rework* formula:

- Non-crit shadow hits no longer get a bonus `randf_range(0.8, 1.2)` multiplier. Variance now comes from the mastery range inside `calculate_attack_damage` like every other hit.
- A shadow can now roll 0 damage on a non-crit, same as the player can. (Will be very rare given `level_modifier * defense_multiplier` is almost never zero, but the asymmetry is gone.)

Net effect: small drop in shadow damage averages, exactly what the canonical formula intended in `8206890`.

## Invariants preserved

- Server-authoritative: `execute_shadow_hit` is gated by `multiplayer.is_server()`. Both helpers are only called from the server-authoritative path in `_execute_hit`. No client-side damage.
- Buff lifecycle untouched (no changes to `on_apply`/`on_remove`/`on_tick`/visual cleanup) — the `load_buffs`-replaces-logic-instance contract still holds.
- Stale-shadow cleanup in `_create_shadow_visual` preserved.
- Server-only `dealt_damage` signal still emits before the splice so the buff gets the original arrays.

## Follow-up (separate PRs)

- **`enemy_base.damage_on_overlap`** has its own parallel A/B-coefficient damage formula (`_get_a_coefficient`, `_get_b_coefficient`). Different math (level diff scales monster-→-player damage, not player-→-monster), but the same locality gap. Worth a separate PR.
- **`addons/balance_simulator/simulator_dock.gd`** mirrors `_calculate_max_range` and `_execute_hit` for in-editor previews — read-only, no gameplay impact, but a candidate to consolidate later if the balance team finds the simulator drifting from gameplay.

No other `BL_*` scripts hand-roll this formula (grepped for `target_defense + 500.0`, `level_diff * 0.05`, `randf_range(1.2, 1.5)`, and `CRITCHANCE` — only `BL_ShadowPartner` duplicated it; `BL_Focus` and `AL_Focus` use CRITCHANCE as a buffed stat, not in damage math).

## Diff

```
scripts/Buffs/BL_ShadowPartner.gd |  50 ++--------------
scripts/Components/combat.gd      | 121 ++++++++++++++++++++++++++++----------
2 files changed, 95 insertions(+), 76 deletions(-)
```

## Test plan

- [ ] Equip a Rogue with Shadow Partner buff active. Basic-attack a same-level enemy with `Stats/Defense` populated. Confirm: each player hit is interleaved with a shadow hit (or shadow miss `-1`), shadow damage roughly half of the player's, crits indicated separately for player vs shadow.
- [ ] Fight an enemy that's 5+ levels above you. Shadow hit-chance should drop in lockstep with the player's hit-chance (was already the case — verifying the consolidation didn't regress it).
- [ ] Fight an enemy with high defense. Shadow damage should be reduced by the same `defense / (defense + 500)` factor as the player's damage. (Was already the case — verifying.)
- [ ] Hot-reload the buff via `load_buffs` (e.g. relog / map change). Confirm shadow visual cleanly respawns and the new logic instance still connects to `dealt_damage`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)