### PR TITLE
Combat: drop redundant server-only guards on private lifecycle helpers

### DIFF
--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -195,41 +195,38 @@ func process_ability_hit(ability: AbilityData, level_stats: AbilityLevelData, du
 
 
 func turn_on_hitbox() -> void:
-	if not multiplayer.is_server():
-		return
-		
+	# Server-only by construction: reachable only from perform_attack /
+	# process_ability_hit, both of which guard at the entry point.
 	attack_hitbox.position.x = abs(attack_hitbox.position.x) * owner_node.facing_direction
-	
+
 	hit_list.clear()
 	_unique_targets_for_attack.clear()
 	_pending_bodies.clear()
-		
+
 	hitbox_area.monitoring = true
 
 
 func end_attack() -> void:
-	if not multiplayer.is_server():
-		return
-		
+	# Server-only by construction: reached via force_end_current_attack (guarded)
+	# or _on_attack_hitbox_timer_timeout (timer is only started in guarded
+	# entry points, so its timeout only fires on the server).
 	_process_collected_bodies()
-	
+
 	hitbox_area.monitoring = false
 	_current_attack_mode = AttackMode.NONE
 	current_attack_data = ""
 
 
 func end_ability_attack() -> void:
-	if not multiplayer.is_server():
-		return
-		
+	# Server-only by construction: same call paths as end_attack.
 	_process_collected_bodies()
-		
+
 	hitbox_area.monitoring = false
 	_current_attack_mode = AttackMode.NONE
 	current_ability_data = null
 	current_active_data = null
 	current_level_stats = null
-	
+
 	hit_list.clear()
 	_unique_targets_for_attack.clear()
 
@@ -254,8 +251,9 @@ func _is_on_same_map(target: Node) -> bool:
 
 
 func _on_hitbox_area_entered(area: Area2D) -> void:
-	if not multiplayer.is_server():
-		return
+	# Server-only by construction: hitbox_area.monitoring is only toggled true
+	# inside turn_on_hitbox(), whose callers are all guarded. Clients never
+	# arm the hitbox, so this signal never fires off-server.
 	if not "health_component" in (area.owner as EnemyBase):
 		return
 	if not _is_on_same_map(area.owner):


### PR DESCRIPTION
## Summary

Part of an architecture review batch (PR 03).

`combat.gd` had **9 functions** each starting with `if not multiplayer.is_server(): return`. Only **5 of those are real entry points** — the rest are internal lifecycle steps reached exclusively from already-guarded callers. Their guards are dead code.

This PR drops the 4 redundant guards. The remaining 5 entry-point guards stay in place.

## Guards removed (and the grep evidence each is server-only by construction)

### 1. `turn_on_hitbox()` (was line 198)
Callers:
- `combat.gd:98` — inside `perform_attack` (guarded at line 85)
- `combat.gd:188` — inside `process_ability_hit` (guarded at line 174)

Zero external call sites. Both reachable paths are server-only.

### 2. `end_attack()` (was line 211)
Callers:
- `combat.gd:160` — inside `force_end_current_attack` (guarded at line 156)
- `combat.gd:167` — inside `_on_attack_hitbox_timer_timeout` (signal callback)

The timer is only `start()`ed from `perform_attack:100` and `process_ability_hit:194` — both guarded — so `attack_hitbox_timer.timeout` never fires on a client. Additionally, the body conditions (`current_attack_data != ""`, `current_ability_data != null`) only become truthy via server-only writes.

### 3. `end_ability_attack()` (was line 222)
Callers:
- `combat.gd:162` — inside `force_end_current_attack` (guarded)
- `combat.gd:169` — inside `_on_attack_hitbox_timer_timeout` (same reasoning as `end_attack`)

### 4. `_on_hitbox_area_entered(area)` (was line 257)
Connected via `Hitbox.area_entered` signal (`player.tscn:1120` + reconnect in `_ready`).

`hitbox_area.monitoring` is only toggled `true` inside `turn_on_hitbox()`, whose callers are all guarded. The scene starts the Hitbox with `monitoring = false`, the `_ready` re-asserts it, and `monitoring` is not present in any `SceneReplicationConfig`. Clients never arm the hitbox, so the signal never fires off-server.

## Guards kept (the entry points that callers cross from a client path)

| Function | Why kept |
|---|---|
| `perform_attack` | Called from `attack.gd:82` (state machine) |
| `perform_ranged_attack` | Public entry point |
| `process_ability_hit` | Called from `attack.gd:119/121` (state machine) |
| `process_projectile_hit` | Called from `projectile.gd:89` |
| `force_end_current_attack` | Public-looking "force" helper; conservative keep — no external callers today, but the name signals it's an intentional escape hatch |

## Architectural rationale

Locality: the server-authority invariant lives at the entry points where callers cross the trust seam, not duplicated at every internal step. The previous shape made the seam fuzzy — every helper *looked* like it might be exposed.

Deletion test: removing each of the 4 guards does not reintroduce a way for the function to be called on a client. If it did, we'd put the guard back.

## Test plan

- [ ] Single-player: basic attack, ability attack, ranged attack still deal damage
- [ ] Host + 1 client: client attacking still damages enemies (entry-point guard on `perform_attack` does its job)
- [ ] Bot attacks still resolve (bots have negative peer IDs but run on the server side)
- [ ] `force_end_current_attack` flow exercised by performing a second attack mid-attack (both `perform_attack` and `process_ability_hit` self-cancel)
- [ ] GDScript parse cleanly in editor

Co-authored architecture review batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)