### PR TITLE
Save: normalise character_class / character_type key aliases at one site

### DIFF
--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -125,11 +125,17 @@ func get_characters():
 				if not FileAccess.file_exists(dev_file_path):
 					var is_advanced = class_enum >= Constants.ClassType.CRUSADER
 					var starting_level = 30 if is_advanced else 1
+					# Use the canonical "character_type" key on the wire / in
+					# save payloads — matches multiplayer_controller_v2's
+					# get_save_data and the backend's /load response. Older
+					# dev-mode files on disk may still have "character_class";
+					# MultiplayerPlayerV2.normalise_save_keys rewrites them
+					# on load.
 					var save_data = {
 							"username": dev_char_name,
 							"level": starting_level,
 							"experience": 0,
-							"character_class": class_enum,
+							"character_type": class_enum,
 							"current_health": 100,
 							"max_health": 100,
 							"current_mana": 100,
@@ -174,7 +180,14 @@ func get_characters():
 				}
 				if loaded_data is Dictionary:
 					char_data["level"] = loaded_data.get("level", 1)
-					char_data["character_class"] = loaded_data.get("character_class", 0)
+					# Prefer the canonical "character_type" key; fall back to
+					# "character_class" for legacy dev-mode files on disk.
+					# The response key stays "character_class" because that's
+					# the lobby/UI contract (CharacterSelectScreen reads it).
+					char_data["character_class"] = loaded_data.get(
+						"character_type",
+						loaded_data.get("character_class", 0)
+					)
 				characters.append(char_data)
 				#print("Local save: Found character '%s' (level %d)" % [char_name, char_data["level"]])
 				idx += 1
@@ -228,11 +241,13 @@ func create_character(char_name, class_id):
 			return
 		var is_advanced = class_id >= Constants.ClassType.CRUSADER
 		var starting_level = 30 if is_advanced else 1
+		# Use the canonical "character_type" key — see the matching comment in
+		# get_characters above.
 		var save_data = {
 			"username": char_name,
 			"level": starting_level,
 			"experience": 0,
-			"character_class": class_id,
+			"character_type": class_id,
 			"current_health": 100,
 			"max_health": 100,
 			"current_mana": 100,

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -688,12 +688,22 @@ func _on_player_spawned(player_id: int) -> void:
 	else:
 		player_data = await _load_player_data_async(username)
 
+	# Normalise legacy save-key aliases (e.g. dev-mode local saves that wrote
+	# "character_class" instead of the canonical "character_type") before any
+	# read. The same normalisation runs again at the top of _load_data so any
+	# future direct caller is covered; doing it here as well means the
+	# character_type lookup below sees the canonical key regardless of which
+	# write path produced the file.
+	player_data = MultiplayerPlayerV2.normalise_save_keys(player_data)
+
 	# Prefer character_type from player_data — `info.character_type` is set
 	# from the client's character pick at join time and is never refreshed
 	# when the class changes mid-session (job advancement). The carried
 	# state (from get_save_data("all")) and the backend load both include
 	# the current value, so trust them when present. Without this the
 	# next map change reverts an advanced player back to their base class.
+	# (The fallback to info.character_type covers first-spawn-no-save-data,
+	# not the legacy key — the normaliser above already rewrote that.)
 	var character_type: int = player_data.get("character_type", info.get("character_type", -1))
 	info["character_type"] = character_type
 

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -643,12 +643,54 @@ func _get_stats_data() -> Dictionary:
 	}
 
 
+## Save-key alias map.
+##
+## Translates legacy keys in incoming save payloads to their canonical form.
+## Add a row here when a key is renamed; every read site flows through
+## `normalise_save_keys` so callers only ever see the canonical key.
+##
+## Currently:
+##   - "character_class" -> "character_type"
+##     The dev-mode local save (network_manager.create_character /
+##     get_characters) used to write "character_class". The wire format and
+##     the runtime controller both use "character_type". Existing files in
+##     the wild may still carry the legacy key.
+const _SAVE_KEY_ALIASES: Dictionary = {
+	"character_class": "character_type",
+}
+
+
+## Returns a NEW dict with any legacy save-key aliases rewritten to their
+## canonical form. Idempotent: passing an already-normalised dict is a no-op.
+## Does not mutate the input.
+##
+## Public so other server-side loaders (e.g. PlayerManager._on_player_spawned,
+## which reads character_type out of player_data BEFORE _load_data runs) can
+## share the same alias table.
+static func normalise_save_keys(data: Dictionary) -> Dictionary:
+	var out: Dictionary = data.duplicate()
+	for legacy_key in _SAVE_KEY_ALIASES:
+		if out.has(legacy_key):
+			var canonical_key: String = _SAVE_KEY_ALIASES[legacy_key]
+			# If the canonical key isn't already present, copy the legacy value
+			# over. If both are present, the canonical value wins (the legacy
+			# one is stale by definition).
+			if not out.has(canonical_key):
+				out[canonical_key] = out[legacy_key]
+			out.erase(legacy_key)
+	return out
+
+
 func _load_data(data: Dictionary) -> void:
 	if _is_being_cleaned_up:
 		return
-	
+
+	# Centralise legacy-key handling here so individual component loaders
+	# don't each need their own fallback. See `normalise_save_keys`.
+	data = normalise_save_keys(data)
+
 	_is_loading_data = true
-	
+
 	#print("Loading data for ", data.get("username", "Unknown"))
 	
 	if is_instance_valid(stats_component):


### PR DESCRIPTION
## Problem

The same field is spelled two different ways across the save layer:

- **`character_class`** — dev-mode local-save writes (`network_manager.create_character`, `network_manager.get_characters`) put this in `res://saves/player_<name>.json`. Also the backend's PostgreSQL column name.
- **`character_type`** — the wire format Godot uses (in `multiplayer_controller_v2._get_stats_data`), the backend's `/load` response, and the in-memory `active_players[id]` runtime state.

Every read site coped with the divergence by adding its own fallback (e.g. `player_data.get("character_type", info.get("character_type", -1))` in `player_manager.gd:697`). The leak makes the save format implicit: a developer who reads the code can't tell which key is canonical without grepping every consumer.

## Fix

One alias map, one normaliser, applied at the loader entry point.

- **New** `MultiplayerPlayerV2.normalise_save_keys(data)` (static) — returns a new dict with legacy keys rewritten to canonical ones. Driven by a `_SAVE_KEY_ALIASES` const table. Currently maps `character_class -> character_type`. Idempotent; does not mutate the input.
- **`_load_data`** calls the normaliser at the top, before any component delegation. Any future direct caller of `_load_data` is covered for free.
- **`PlayerManager._on_player_spawned`** also runs the normaliser on `player_data` immediately after loading, because the existing code path reads `player_data["character_type"]` *before* it ever reaches `_load_data` (line 697 — for the class-change-survives-job-advancement reason explained in the existing comment).
- **`network_manager.gd`** dev-mode writers (`get_characters` and `create_character`) now write the canonical `character_type` key. The `get_characters` local-file *reader* tries `character_type` first and falls back to `character_class` for legacy files; the lobby response keeps `character_class` because that's the contract with `CharacterSelectScreen.gd`.

## No migration needed

Old dev-mode save files in `res://saves/` keep their `character_class` key — the normaliser rewrites it on load, the next `SaveManager` flush writes the canonical key, and the file is silently upgraded. The save shape is unchanged. No ADR.

## Locality win

The alias table lives in one place. The next rename is a one-line edit to `_SAVE_KEY_ALIASES` rather than a sweep across every consumer.

## Scope notes

- **Backend untouched.** Per `feedback_backend_changes_require_explicit_approval`, no changes to `backend/app.py`. The wire format and the Postgres column already use their canonical names; the disagreement is only inside the Godot side of the save layer.
- **The `info.get("character_type", -1)` fallback at `player_manager.gd:697` stays.** It is NOT redundant with the normaliser — it handles a different concern (first-spawn-with-no-save-data, where `player_data` is empty and the only available class is the one the client sent at join time). The existing comment explains this. I added a short note clarifying the two reasons.
- **Lobby contract preserved.** `CharacterSelectScreen.gd` and the `selected_character_class` meta key still use `character_class` — that's a UI-side identifier, not save data. Renaming it is out of scope.

## Follow-ups

- Extract a `_new_character_skeleton()` factory — both `create_character` and the dev-mode `get_characters` autocreate duplicate the same dict literal.
- Audit other potentially legacy save keys (e.g. `monies` location, inventory shape) — none touched here.
- Eventually align the lobby (`character_class`) with the save (`character_type`) so the whole codebase uses one word.

Part of an architecture review batch.

## Verification

- Grep for `"character_class"` / `"character_type"` — every save-data read site flows through either `_load_data` (and thus through the normaliser) or `PlayerManager._on_player_spawned` (which now also normalises). Other occurrences are in the lobby UI surface (preserved), backend column code (untouched), or comments.
- Idempotency: `normalise_save_keys` operates on a dict copy, erases the legacy key after copying its value, and prefers any pre-existing canonical value when both keys are present.

## Test plan

- [ ] Start a fresh dev-mode session, create a new character, host, walk around — character class persists through map changes.
- [ ] Place a hand-edited save file in `res://saves/` with `"character_class": 2` (no `character_type`), load that character — class is correctly recognised as Mage and survives a map change.
- [ ] Backend path (`docker-compose up -d`, create character via API, save/load) — unchanged behaviour.
- [ ] Job-advancement at level 30 still survives a map change (regression check on the `info.character_type` fallback comment).