### PR TITLE
Networking: prune dead NetworkUtils API surface

### DIFF
--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -264,10 +264,3 @@ func _update_ui_for_client():
 		menu_container.setup_PID_label(false, multiplayer.get_unique_id())
 	if menu_container.has_node("connection_panel"):
 		menu_container.connection_panel.show()
-
-# === LEGACY COMPATIBILITY ===
-func get_public_IP_address() -> String:
-	return NetworkUtils.get_public_ip_address()
-
-func is_valid_ip(text: String) -> bool:
-	return NetworkUtils.is_valid_ip(text)

--- a/scripts/Networking/network_utils.gd
+++ b/scripts/Networking/network_utils.gd
@@ -58,57 +58,6 @@ func has_flag(flag_name: String) -> bool:
 	var args = OS.get_cmdline_args() + OS.get_cmdline_user_args()
 	return flag_name in args
 
-# === SCENE UTILITIES ===
-func get_players_spawn_node(scene_tree: SceneTree) -> Node:
-	var scene = scene_tree.current_scene.get_node_or_null("Level")
-	if scene:
-		return scene.find_child("Players", true, false)
-	return null
-
-func get_node_safe(node: Node, path: String) -> Node:
-	if not node:
-		return null
-	return node.get_node_or_null(path)
-
-# === CLEANUP UTILITIES ===
-func clear_networked_entities(scene_tree: SceneTree) -> void:
-	var scene_root = scene_tree.get_current_scene()
-	if not scene_root:
-		return
-	
-	for entity in scene_root.get_tree().get_nodes_in_group("networked_entities"):
-		if is_instance_valid(entity):
-			entity.queue_free()
-
-func safe_disconnect_signal(signal_obj: Signal, callable_obj: Callable):
-	if signal_obj.is_connected(callable_obj):
-		signal_obj.disconnect(callable_obj)
-
-# === CONNECTION TESTING ===
-func test_tcp_connection(ip: String, port: int, timeout: float = 2.0) -> bool:
-	var tcp = StreamPeerTCP.new()
-	var error = tcp.connect_to_host(ip, port)
-	
-	if error != OK:
-		return false
-	
-	var time_waited = 0.0
-	while time_waited < timeout:
-		tcp.poll()
-		var status = tcp.get_status()
-		
-		if status == StreamPeerTCP.STATUS_CONNECTED:
-			tcp.disconnect_from_host()
-			return true
-		elif status == StreamPeerTCP.STATUS_ERROR:
-			return false
-		
-		await Engine.get_main_loop().process_frame
-		time_waited += get_process_delta_time()
-	
-	tcp.disconnect_from_host()
-	return false
-
 # === LOGGING UTILITIES ===
 func log_network_event(event_type: String, details: String = ""):
 	var timestamp = Time.get_datetime_string_from_system()
@@ -129,18 +78,3 @@ func is_valid_port(port: int) -> bool:
 
 func is_port_in_range(port: int, min_port: int, max_port: int) -> bool:
 	return port >= min_port and port <= max_port
-
-# === MULTIPLAYER UTILITIES ===
-func get_multiplayer_info() -> Dictionary:
-	return {
-		"is_server": multiplayer.is_server(),
-		"unique_id": multiplayer.get_unique_id(),
-		"has_peer": multiplayer.multiplayer_peer != null,
-		"connected": multiplayer.multiplayer_peer != null and multiplayer.multiplayer_peer.get_connection_status() == MultiplayerPeer.CONNECTION_CONNECTED
-	}
-
-func format_player_id(id: int) -> String:
-	if id == 1:
-		return "Host"
-	else:
-		return "Player_%d" % id


### PR DESCRIPTION
## Summary

Part of an architecture-review batch. `NetworkUtils` had grown into a grab-bag of helpers, with **7 of its 17 public functions having zero call sites** anywhere in the repo. This PR mechanically deletes those dead functions plus two forwarding shims in `MultiplayerManager` that delegated to NetworkUtils with no remaining callers.

73 lines removed, no behavior change.

## Functions deleted (with grep evidence)

For each deleted function, grep across `**/*.gd`, `**/*.tscn`, `**/*.tres` returned **only the definition site** (and the function's own references to itself).

### `scripts/Networking/network_utils.gd`

| Function | Grep result |
|---|---|
| `get_players_spawn_node` | Only `network_utils.gd:62:func get_players_spawn_node(...)` |
| `get_node_safe` | Only `network_utils.gd:68:func get_node_safe(...)` |
| `clear_networked_entities` | Only `network_utils.gd:74:func clear_networked_entities(...)` |
| `safe_disconnect_signal` | Only `network_utils.gd:83:func safe_disconnect_signal(...)` |
| `test_tcp_connection` | Only `network_utils.gd:88:func test_tcp_connection(...)` |
| `get_multiplayer_info` | Only `network_utils.gd:134:func get_multiplayer_info(...)` |
| `format_player_id` | Only `network_utils.gd:142:func format_player_id(...)` |

### `scripts/Managers/multiplayer_manager.gd` (legacy shims)

| Function | Grep result |
|---|---|
| `get_public_IP_address` | Only `multiplayer_manager.gd:269:func get_public_IP_address(...)` (no external callers; the live call site in `server_manager.gd` already uses `NetworkUtils.get_public_ip_address()` directly) |
| `is_valid_ip` (on `MultiplayerManager`) | Only `multiplayer_manager.gd:272:func is_valid_ip(...)` (no callers; `multiplayer_manager.gd:81` itself calls `NetworkUtils.is_valid_ip(...)` directly, bypassing the shim) |

Also searched for indirect references (`"<func_name>"` as a string for `call`/`callable`/`Signal.connect`) and `.tscn` editor bindings — zero matches.

## Live NetworkUtils functions kept

These have real callers across the networking autoloads and are out of scope:

- `is_valid_ip` (called by `MultiplayerManager.join_game`)
- `get_public_ip_address` (called by `ServerManager` for the host's connection info)
- `get_port_from_args` (called by `MultiplayerManager` startup)
- `get_string_arg` (called by `ServerManager` for `--max-players`)
- `log_network_event` (called by server/client/player/channel managers)
- `log_connection_attempt` / `log_connection_result` (called by `ClientManager`)
- `is_valid_port` (called by `ChannelManager`)

## Not deleted (could be in a follow-up)

Two additional functions in `NetworkUtils` are also dead per the same grep sweep:
- `has_flag` (0 callers)
- `is_port_in_range` (0 callers)

They were not on the reported list for this PR and were left alone to keep the diff tightly scoped. A trivial follow-up could remove them.

## What this PR does NOT touch

- The `NetworkUtils` autoload itself stays registered in `project.godot` — its live functions still have real callers.
- `ChannelManager` (a separate deepening candidate from the architecture review — it has only one external caller in `MultiplayerManager.switch_channel`, a one-line `await` wrapper) is **deferred to a separate PR**. Merging it touches the autoload list in `project.godot` and reshapes the networking-manager cluster; that change is larger and less mechanical, so it stays out of this surgical pass.
- No other unrelated cleanup is bundled in.

## Test plan

- [ ] Open the project in Godot 4.5; confirm there are no parse errors in `network_utils.gd` or `multiplayer_manager.gd`.
- [ ] Host a local server; confirm host startup logs still print `[NETWORK_SERVER_START]` (proves `log_network_event` still resolves).
- [ ] Join from a second client by IP; confirm `MultiplayerManager.join_game` rejects an invalid IP (proves `NetworkUtils.is_valid_ip` is still wired).
- [ ] Switch channels via the in-game UI; confirm `is_valid_port` and channel-switch logging still run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)