### PR TITLE
Inventory: converge Bot and Player consumable-use through one verb

### DIFF
--- a/scripts/Bot/bot_brain.gd
+++ b/scripts/Bot/bot_brain.gd
@@ -1099,11 +1099,10 @@ func _try_use_consumable() -> void:
 		var is_mana_pot := consumable.effect_properties.has("regain_amount")
 
 		if (need_health and is_health_pot) or (need_mana and is_mana_pot):
-			player.inventory_component.remove_item_from_stack(consumable, 1, "used")
-			var effect_instance = consumable.effect_script.new() as BaseItemEffect
-			effect_instance.user = player
-			effect_instance.source_item = consumable
-			effect_instance.execute()
+			# Delegate to the shared server-side verb so the bot path picks up
+			# any future fixes to consumable use. The helper skips flush_save
+			# for bots automatically (no persisted save row).
+			player.inventory_component._execute_consumable(player, consumable)
 			return
 
 

--- a/scripts/Components/inventory.gd
+++ b/scripts/Components/inventory.gd
@@ -988,20 +988,43 @@ func request_use_item(slot_index: int):
 		#print("Use Item failed: Consumable '%s' has no effect script. item type=%d, script=%s" % [consumable.name, consumable.item_type, consumable.get_script()])
 		return
 
+	await _execute_consumable(player, consumable)
+
+
+## Shared server-side consumable-use verb. Both the player RPC path
+## (`request_use_item`) and the bot brain (`bot_brain._try_use_consumable`)
+## funnel through here so a single sequence — remove from stack, conditionally
+## flush save, execute effect — applies to both.
+##
+## The save-flush is the only thing the bot path skips: bots have negative peer
+## IDs and no persisted save row, and `SaveManager.flush_save` on a bot username
+## would either no-op or waste an HTTP round-trip. Future fixes to consumable
+## use now apply to bots automatically; the only intentional split is the one
+## guarded line below.
+func _execute_consumable(player_node, consumable: ConsumableData) -> void:
+	if not multiplayer.is_server():
+		return
+	if not is_instance_valid(player_node) or not consumable:
+		return
+	if not consumable.effect_script:
+		return
+
 	# Remove one from the stack and persist before executing the effect,
 	# because effects like Town Potion trigger a map change that frees this node.
-	remove_item_from_stack(item, 1, "used")
+	remove_item_from_stack(consumable, 1, "used")
 
-	# Force-save inventory now so map changes don't lose the removal
-	if player.username and SaveManager:
-		SaveManager.queue_save(player.username, "inventory", player)
-		await SaveManager.flush_save(player.username)
+	# Force-save inventory now so map changes don't lose the removal.
+	# Bots have no persisted save row, so skip the flush for them.
+	var is_bot := BotManager and BotManager.is_bot(player_node.player_id)
+	if not is_bot and player_node.username and SaveManager:
+		SaveManager.queue_save(player_node.username, "inventory", player_node)
+		await SaveManager.flush_save(player_node.username)
 
 	# Execute the effect (must happen after save completes, as effects like
 	# Town Potion trigger a map change that frees this node and reloads from save)
-	if not is_instance_valid(player):
+	if not is_instance_valid(player_node):
 		return
 	var effect_instance = consumable.effect_script.new() as BaseItemEffect
-	effect_instance.user = player
+	effect_instance.user = player_node
 	effect_instance.source_item = consumable
 	effect_instance.execute()


### PR DESCRIPTION
## Summary

`InventoryComponent.request_use_item` (the player RPC path) and `bot_brain._try_use_consumable` (the bot path) were parallel implementations of the same server-side verb: remove one from the stack, then run the consumable effect. The bot path silently diverged in one important way — it never called `SaveManager.flush_save` between the remove and the execute. Effects like Town Potion trigger a map change that frees the inventory node and reloads from save; without a flush, the stack decrement gets undone on reload. For human players this works because the player path flushes first; for bots it silently breaks any effect that re-reads persisted state.

This PR collapses the two paths onto one shared helper, `InventoryComponent._execute_consumable(player_node, consumable)`, that runs server-side and contains the full sequence: remove + conditional flush_save + execute.

- `request_use_item` keeps the thin RPC adapter shape — guard `is_server()`, resolve the sender via `PlayerManager`, validate slot index / item / `ConsumableData` / `effect_script` — then awaits `_execute_consumable`.
- `bot_brain._try_use_consumable` keeps the bot's selection policy (HP/MP threshold + matching potion lookup) and now calls `player.inventory_component._execute_consumable(player, consumable)` directly. No RPC, no duplicated remove/instantiate/execute.
- Inside `_execute_consumable` the only intentional split between bot and player is one guarded line: `if not is_bot and player_node.username and SaveManager`. Bots have negative peer IDs (`BotManager.is_bot`) and no persisted save row, so the flush is skipped for them but every other side effect (remove from stack, item_removed signal, slot resync, item_counts/item_locations bookkeeping, effect execution) now runs through the same code on both paths.

### Where the bot/peer split now lives

Before: at the verb itself — two parallel implementations, with the flush-save divergence buried inside the bot copy.
After: at the visualisation seam (already true — bots have no UI to update) and at one save-flush guard inside the shared helper. Future fixes to consumable use (e.g. a new precondition check, a re-saved-state side effect, a cooldown) apply to bots automatically because they share the verb.

### Part of an architecture review batch

This is one of a series of small convergence PRs aimed at deepening modules whose verbs were duplicated between callers (in this case, between the player RPC path and the bot brain).

## Test plan

- [ ] Player uses a Health Potion via the hotbar/inventory: stack decrements, save flushes, heal effect lands.
- [ ] Player uses a Town Potion: stack decrements, save flushes, map change runs, post-reload inventory reflects the consumption (no rollback).
- [ ] Bot whose HP drops below `HEALTH_POTION_THRESHOLD` auto-drinks: stack decrements, heal lands, no `flush_save` HTTP round-trip occurs.
- [ ] Bot with no matching potion and need_health=true: helper not called, no errors.
- [ ] Existing bot tests / `/bot` commands unaffected.