### PR TITLE
Fix: SaveManager.flush_save hangs in local-save mode, breaking portal transitions

### DIFF
--- a/scripts/Managers/save_manager.gd
+++ b/scripts/Managers/save_manager.gd
@@ -195,7 +195,13 @@ func flush_save(username: String) -> void:
 	job.is_flush = true
 
 	_save_queue.append(job)
-	_try_dispatch()
+	# Defer dispatch so the `await job.completed` below is set up BEFORE the
+	# synchronous local-save dispatch path could fire `_release_slot` and emit
+	# the signal. Without this, in local-save mode `_send_via_slot` runs to
+	# completion synchronously inside `_try_dispatch`, the signal emits, and
+	# the await below would then hang forever waiting for a signal that has
+	# already fired (Godot await is one-shot — it cannot catch past emissions).
+	call_deferred("_try_dispatch")
 
 	# Wait for this specific job to finish. The signal is per-job, so two
 	# concurrent flush_save callers each await their own SaveJob and never


### PR DESCRIPTION
## Summary

`SaveManager.flush_save` hangs forever in **local-save mode** (`NetworkManager.use_local_save = true`), causing `change_to_map` to never reach `MapManager.request_map_change` — portals silently fail. Bots, which skip the save flush, can still hop maps in the same world, which is what made this confusing to spot.

## Root cause

Classic Godot one-shot-await bug:

```gdscript
_save_queue.append(job)
_try_dispatch()        # <-- in local-save mode, this runs SYNCHRONOUSLY all the way
                       #     through _send_via_slot → _save_to_file → _release_slot,
                       #     emitting `job.completed` before returning.
await job.completed    # <-- now awaits a signal that already fired. Hangs forever.
```

- **Backend mode** works because `_send_via_slot` does `await req.request_completed`, yielding control back to `flush_save` before the dispatch chain emits the signal.
- **Local-save mode** has no internal await — file write is synchronous — so the signal fires before the outer `await` is set up.

## Fix

Defer the dispatch so the `await` is in place before the signal can possibly emit:

```diff
 _save_queue.append(job)
-_try_dispatch()
+call_deferred("_try_dispatch")
 await job.completed
```

One-line behavior change, lots of explanatory comment.

## Discovery story

Surfaced while testing PR 1 of the [weapon-identity-overhaul](https://github.com/breckdareck/multiplayer-test/pull/154) in a parallel folder using dev login + local save. Portal label appeared, key press registered, server-side `interact()` called `change_to_map` correctly — then nothing. Added trace prints across `portal.gd`, `player_manager.gd`, `multiplayer_controller_v2.gd`, `map_manager.gd`; the print BEFORE `await SaveManager.flush_save(username)` fired, the print AFTER did not. Bots simultaneously moving between maps (visible in the same trace output) confirmed the async path was wedged on the player but not on bots — bots skip the flush entirely per the existing comment in `change_to_map`.

## Why this didn't show up before

- Local-save mode is dev-only / rare — most testing happens with the backend up.
- The bug existed since the `flush_save` refactor that introduced per-job `completed` signals (replacing a prior wait-loop), but it only bites when the dispatch chain has zero internal awaits.
- Would have hit PR 3 of the weapon-identity-overhaul as soon as it landed — weapon swap queues+flushes saves every swap, so the swap UX would have hung the same way.

## Test plan

- [ ] Toggle local-save in the LoginScreen, dev login, walk into a portal, press W/Up. Map should transition.
- [ ] Backend-mode portal still works (no regression in the async path).
- [ ] Bot portal hopping still works (uses a separate code path with no flush).
- [ ] Other `flush_save` callers (disconnect, logout, channel switch) still complete in both modes.

## Related

- Memory: [feedback_godot_await_after_sync_emit_hangs](memory/feedback_godot_await_after_sync_emit_hangs.md) — general pattern + how to spot it
- Will land cleanly under the weapon-identity-overhaul PRs since none of them touch SaveManager. PR 1 (#154) doesn't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)