### PR TITLE
[BIG] PR 3/10: Weapon swap UX — 2-weapon loadout, mid-combat swap, per-weapon hotbar bindings

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -186,6 +186,11 @@ OpenQuestWindow={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":81,"key_label":0,"unicode":113,"location":0,"echo":false,"script":null)
 ]
 }
+"Weapon Swap Loadout"={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194306,"key_label":0,"unicode":0,"location":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -485,13 +485,14 @@ inventory_grids = [NodePath("../../../CanvasLayer/MoveableWindows/InventoryWindo
 equipment_component = NodePath("../../Equipment")
 stats_component = NodePath("../../Stats")
 
-[node name="Equipment" type="Node" parent="Components" node_paths=PackedStringArray("head_slot", "chest_slot", "legs_slot", "feet_slot", "weapon_slot")]
+[node name="Equipment" type="Node" parent="Components" node_paths=PackedStringArray("head_slot", "chest_slot", "legs_slot", "feet_slot", "weapon_slot", "secondary_weapon_slot")]
 script = ExtResource("13_ihqbe")
 head_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/HeadSlot")
 chest_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/ChestSlot")
 legs_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/LegsSlot")
 feet_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/FeetSlot")
 weapon_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/WeaponSlot")
+secondary_weapon_slot = NodePath("../../CanvasLayer/MoveableWindows/EquipmentWindow/PanelContainer/GridContainer/SecondaryWeaponSlot")
 
 [node name="Leveling" type="Node" parent="Components"]
 script = ExtResource("3_18ciy")

--- a/scenes/UI/equipment_window.tscn
+++ b/scenes/UI/equipment_window.tscn
@@ -346,6 +346,50 @@ text = "WEAPON"
 scroll_active = false
 autowrap_mode = 2
 
+[node name="SecondaryWeaponSlot" type="PanelContainer" parent="PanelContainer/GridContainer"]
+custom_minimum_size = Vector2(55, 55)
+layout_mode = 2
+mouse_filter = 1
+theme_override_styles/panel = SubResource("StyleBoxFlat_tuhj4")
+script = ExtResource("4_84hex")
+allowed_equipment_type = 1
+allowed_item_type = 1
+
+[node name="Panel" type="Panel" parent="PanelContainer/GridContainer/SecondaryWeaponSlot"]
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxTexture_3xeyi")
+
+[node name="TextureRect" type="TextureRect" parent="PanelContainer/GridContainer/SecondaryWeaponSlot"]
+layout_mode = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="Label" type="Label" parent="PanelContainer/GridContainer/SecondaryWeaponSlot"]
+layout_mode = 2
+size_flags_vertical = 1
+theme_override_constants/outline_size = 8
+theme_override_fonts/font = ExtResource("3_h143n")
+theme_override_font_sizes/font_size = 24
+label_settings = SubResource("LabelSettings_tuhj4")
+vertical_alignment = 2
+
+[node name="MarginContainer" type="MarginContainer" parent="PanelContainer/GridContainer/SecondaryWeaponSlot"]
+layout_mode = 2
+theme_override_constants/margin_left = 2
+theme_override_constants/margin_top = 2
+theme_override_constants/margin_right = 2
+theme_override_constants/margin_bottom = 2
+
+[node name="SlotTextLabel" type="RichTextLabel" parent="PanelContainer/GridContainer/SecondaryWeaponSlot/MarginContainer"]
+layout_mode = 2
+mouse_filter = 1
+theme_override_colors/default_color = Color(0.97227865, 0.9722778, 0.97227794, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.28627452)
+theme_override_font_sizes/normal_font_size = 10
+text = "2ND WEAPON"
+scroll_active = false
+autowrap_mode = 2
+
 [node name="PetTabContent" type="PanelContainer" parent="."]
 visible = false
 layout_mode = 1

--- a/scenes/UI/hotbar.tscn
+++ b/scenes/UI/hotbar.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=3 format=3 uid="uid://op5a1mqidavt"]
+[gd_scene load_steps=5 format=3 uid="uid://op5a1mqidavt"]
 
 [ext_resource type="Script" uid="uid://c0rkvuk20x8br" path="res://scripts/UI/hotbar.gd" id="1_hotbar"]
+[ext_resource type="PackedScene" path="res://scenes/UI/hotbar_weapon_slot.tscn" id="2_wslot"]
 
 [sub_resource type="StyleBoxFlat" id="StyleBoxFlat_hotbar"]
 content_margin_left = 5.0
@@ -18,6 +19,11 @@ corner_radius_top_right = 6
 corner_radius_bottom_right = 6
 corner_radius_bottom_left = 6
 
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_separator"]
+content_margin_left = 4.0
+content_margin_right = 4.0
+bg_color = Color(0, 0, 0, 0)
+
 [node name="Hotbar" type="Control"]
 layout_mode = 3
 anchors_preset = 7
@@ -25,9 +31,9 @@ anchor_left = 0.5
 anchor_top = 1.0
 anchor_right = 0.5
 anchor_bottom = 1.0
-offset_left = -260.0
+offset_left = -325.0
 offset_top = -80.0
-offset_right = 260.0
+offset_right = 325.0
 offset_bottom = -10.0
 grow_horizontal = 2
 grow_vertical = 0
@@ -42,7 +48,29 @@ grow_horizontal = 2
 grow_vertical = 2
 theme_override_styles/panel = SubResource("StyleBoxFlat_hotbar")
 
-[node name="SlotsContainer" type="HBoxContainer" parent="Background"]
+[node name="RootHBox" type="HBoxContainer" parent="Background"]
+layout_mode = 2
+theme_override_constants/separation = 8
+
+[node name="WeaponSwapSection" type="HBoxContainer" parent="Background/RootHBox"]
+unique_name_in_owner = true
+layout_mode = 2
+theme_override_constants/separation = 4
+
+[node name="PrimaryWeaponSlot" parent="Background/RootHBox/WeaponSwapSection" instance=ExtResource("2_wslot")]
+layout_mode = 2
+slot_kind = "primary"
+
+[node name="SecondaryWeaponSlot" parent="Background/RootHBox/WeaponSwapSection" instance=ExtResource("2_wslot")]
+layout_mode = 2
+slot_kind = "secondary"
+
+[node name="Separator" type="Panel" parent="Background/RootHBox"]
+custom_minimum_size = Vector2(2, 50)
+layout_mode = 2
+theme_override_styles/panel = SubResource("StyleBoxFlat_separator")
+
+[node name="SlotsContainer" type="HBoxContainer" parent="Background/RootHBox"]
 unique_name_in_owner = true
 layout_mode = 2
 theme_override_constants/separation = 4

--- a/scenes/UI/hotbar_weapon_slot.tscn
+++ b/scenes/UI/hotbar_weapon_slot.tscn
@@ -1,0 +1,59 @@
+[gd_scene load_steps=3 format=3 uid="uid://b0pr3whpnswap"]
+
+[ext_resource type="Script" path="res://scripts/UI/hotbar_weapon_slot.gd" id="1_wslot"]
+
+[sub_resource type="StyleBoxFlat" id="StyleBoxFlat_wslot"]
+content_margin_left = 3.0
+content_margin_top = 3.0
+content_margin_right = 3.0
+content_margin_bottom = 3.0
+bg_color = Color(0.13, 0.10, 0.07, 1)
+border_width_left = 2
+border_width_top = 2
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color(0.3, 0.3, 0.35, 1)
+corner_radius_top_left = 2
+corner_radius_top_right = 2
+corner_radius_bottom_right = 2
+corner_radius_bottom_left = 2
+
+[node name="HotbarWeaponSlot" type="PanelContainer"]
+custom_minimum_size = Vector2(58, 58)
+offset_right = 58.0
+offset_bottom = 58.0
+theme_override_styles/panel = SubResource("StyleBoxFlat_wslot")
+script = ExtResource("1_wslot")
+
+[node name="MarginContainer" type="MarginContainer" parent="."]
+layout_mode = 2
+theme_override_constants/margin_left = 2
+theme_override_constants/margin_top = 2
+theme_override_constants/margin_right = 2
+theme_override_constants/margin_bottom = 2
+
+[node name="IconRect" type="TextureRect" parent="MarginContainer"]
+visible = false
+texture_filter = 1
+layout_mode = 2
+expand_mode = 1
+stretch_mode = 5
+
+[node name="CooldownOverlay" type="ColorRect" parent="MarginContainer"]
+visible = false
+layout_mode = 2
+mouse_filter = 2
+color = Color(0, 0, 0, 0.55)
+
+[node name="SlotLabel" type="Label" parent="MarginContainer"]
+layout_mode = 2
+size_flags_horizontal = 8
+size_flags_vertical = 8
+theme_override_colors/font_color = Color(0.95, 0.85, 0.2, 1)
+theme_override_colors/font_shadow_color = Color(0, 0, 0, 0.8)
+theme_override_constants/shadow_offset_x = 1
+theme_override_constants/shadow_offset_y = 1
+theme_override_font_sizes/font_size = 11
+text = "1"
+horizontal_alignment = 2
+vertical_alignment = 2

--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -57,6 +57,16 @@ var _ability_levels: Dictionary = {} # { ability_id: current_level }
 var _available_ability_points: int = 0
 var _loading_mode: bool = false
 
+# PR 3: per-weapon hotbar bindings (Option A — ESO model).
+# Each weapon carries its own independent hotbar layout. Bind Slash Blast to
+# slot 1 for the sword, Strafe to slot 1 for the bow — they don't collide.
+# On swap, the live `hotbar.save_hotbar_config()` is captured into the
+# leaving binding, then the becoming-active binding is pushed into
+# `hotbar.load_hotbar_config()`. The hotbar UI re-renders in lockstep with
+# the active weapon flip.
+var _primary_hotbar_bindings: Dictionary = {}
+var _secondary_hotbar_bindings: Dictionary = {}
+
 # Track proc cooldowns per passive ability
 var _passive_proc_cooldowns: Dictionary = {} # { "ability_id_event_type": last_proc_time }
 
@@ -93,6 +103,12 @@ func _ready() -> void:
 	# Connect to ClassComponent to handle class changes
 	if _class_component:
 		_class_component.class_changed.connect(_on_class_changed)
+
+	# PR 3: react to active-weapon flips by swapping the live hotbar to the
+	# becoming-active weapon's bindings. Runs on both server and client so the
+	# host (server + client in one tree) and remote clients both refresh.
+	if _equipment_component:
+		_equipment_component.active_weapon_changed.connect(_on_active_weapon_changed)
 
 	# Find or create the projectiles container inside the current visible map.
 	var map_node = MapManager.get_current_visible_map()
@@ -337,20 +353,21 @@ func _can_afford_ability(ability_id: String, level_stats: AbilityLevelData) -> b
 	return true
 
 
-## Returns the `Constants.ClassType` discipline of the currently-equipped
-## weapon, or -1 if there's no tier-1 weapon equipped. Used by the
-## mastery-XP-on-cast grant. Falls back to the character's current_class
-## when no weapon is in the slot (a Beginner casting their starter ability
-## with no weapon still credits the chosen discipline if it's tier-1).
+## Returns the `Constants.ClassType` discipline of the ACTIVE weapon (PR 3),
+## or -1 if there's no tier-1 weapon equipped in the active slot. Used by the
+## mastery-XP-on-cast grant. Falls back to the character's current_class when
+## the active slot is empty (a Beginner casting their starter ability with no
+## weapon still credits the chosen discipline if it's tier-1).
 ## Mirrors CombatComponent._active_weapon_discipline — kept duplicated
 ## (~10 lines) rather than centralised so each component can be read in
 ## isolation; both go through WeaponMasteryComponent.weapon_type_to_discipline
-## for the actual mapping.
+## for the actual mapping. Routes through `active_weapon_data` so the
+## primary/secondary swap correctly attributes XP.
 func _active_weapon_discipline() -> int:
-	if _equipment_component and _equipment_component.weapon_slot_data and _equipment_component.weapon_slot_data.item:
-		var item = _equipment_component.weapon_slot_data.item
-		if item is WeaponData:
-			var discipline := WeaponMasteryComponent.weapon_type_to_discipline(item.weapon_type)
+	if _equipment_component:
+		var weapon: WeaponData = _equipment_component.active_weapon_data
+		if weapon != null:
+			var discipline := WeaponMasteryComponent.weapon_type_to_discipline(weapon.weapon_type)
 			if discipline != -1:
 				return discipline
 
@@ -673,12 +690,32 @@ func sync_all_abilities_to_client(peer_id: int) -> void:
 	if not multiplayer.is_server(): return
 
 	#print("Syncing all ability data to peer %d" % peer_id)
-	var hotbar_config: Dictionary = hotbar.save_hotbar_config() if is_instance_valid(hotbar) else {}
-	sync_all_abilities_batch.rpc_id(peer_id, _ability_levels.duplicate(), _available_ability_points, hotbar_config, _cooldowns.duplicate())
+	# PR 3: snapshot the live hotbar back to whichever binding side is active
+	# before sending so the dirty in-memory state lines up with the persisted
+	# pair. The client receives both arrays + the active flag (via the
+	# equipment sync RPC), so it can re-hydrate and swap freely.
+	var live_config: Dictionary = hotbar.save_hotbar_config() if is_instance_valid(hotbar) else {}
+	_capture_active_bindings(live_config)
+	sync_all_abilities_batch.rpc_id(
+		peer_id,
+		_ability_levels.duplicate(),
+		_available_ability_points,
+		live_config,
+		_cooldowns.duplicate(),
+		_primary_hotbar_bindings.duplicate(),
+		_secondary_hotbar_bindings.duplicate()
+	)
 
 
 @rpc("authority", "call_local", "reliable")
-func sync_all_abilities_batch(abilities: Dictionary, ability_points: int, hotbar_config: Dictionary = {}, cooldowns: Dictionary = {}) -> void:
+func sync_all_abilities_batch(
+		abilities: Dictionary,
+		ability_points: int,
+		hotbar_config: Dictionary = {},
+		cooldowns: Dictionary = {},
+		primary_bindings: Dictionary = {},
+		secondary_bindings: Dictionary = {}
+		) -> void:
 	if multiplayer.is_server(): return
 
 	for ability_id in abilities:
@@ -686,6 +723,11 @@ func sync_all_abilities_batch(abilities: Dictionary, ability_points: int, hotbar
 		ability_learned.emit(ability_id)
 	_available_ability_points = ability_points
 	ability_points_changed.emit(_available_ability_points)
+
+	# PR 3: restore both binding arrays so the inactive weapon's bindings
+	# survive client-side swaps until the next save round-trip.
+	_primary_hotbar_bindings = primary_bindings.duplicate()
+	_secondary_hotbar_bindings = secondary_bindings.duplicate()
 
 	if is_instance_valid(hotbar):
 		hotbar.load_hotbar_config(hotbar_config)
@@ -831,13 +873,23 @@ func _on_class_changed(_new_class_name: String) -> void:
 
 
 #region #################### Save & Load System ####################
-## Returns a dictionary of all ability data for saving.
+## Returns a dictionary of all ability data for saving. PR 3 saves both
+## binding arrays — the live hotbar reflects whichever weapon is currently
+## active, so before serializing we snapshot it into the matching slot.
 func save_abilities() -> Dictionary:
 	# `hotbar` is a UI node; a bot frees its UI subtree, so guard the access.
+	var live_config: Dictionary = hotbar.save_hotbar_config() if is_instance_valid(hotbar) else {}
+	# Sync the live binding back into the per-weapon dict so the save reflects
+	# any edits the player made since the last swap.
+	_capture_active_bindings(live_config)
 	return {
 		"ability_levels": _ability_levels.duplicate(),
 		"available_points": _available_ability_points,
-		"hotbar_config": hotbar.save_hotbar_config() if is_instance_valid(hotbar) else {},
+		# Legacy compatibility: keep `hotbar_config` writing the active set so
+		# older clients / tools that read it still see a coherent layout.
+		"hotbar_config": live_config,
+		"primary_hotbar_bindings": _primary_hotbar_bindings.duplicate(),
+		"secondary_hotbar_bindings": _secondary_hotbar_bindings.duplicate(),
 		"cooldowns": _cooldowns.duplicate()
 	}
 
@@ -845,21 +897,34 @@ func save_abilities() -> Dictionary:
 ## Loads and applies ability data from a dictionary.
 func load_abilities(data: Dictionary) -> void:
 	if data.is_empty(): return
-	
+
 	# First, ensure all current class abilities are initialized
 	for ability_data in _class_component.get_class_abilities():
 		if ability_data != null and not _ability_levels.has(ability_data.ability_id):
 			_ability_levels[ability_data.ability_id] = 0
 			#print("Added new ability from class: %s at level 0" % ability_data.ability_id)
-			
+
 	# Load saved data by merging (not replacing) to preserve new abilities
 	var saved_levels = data.get("ability_levels", {})
 	for ability_id in saved_levels:
 		_ability_levels[ability_id] = saved_levels[ability_id]
-	
+
 	_available_ability_points = data.get("available_points", 0)
+
+	# PR 3: restore both binding arrays. Legacy saves that only have
+	# `hotbar_config` populate the primary binding so a returning character
+	# keeps their layout (the secondary starts empty until they bind it).
+	var legacy_config: Dictionary = data.get("hotbar_config", {})
+	_primary_hotbar_bindings = data.get("primary_hotbar_bindings", legacy_config).duplicate()
+	_secondary_hotbar_bindings = data.get("secondary_hotbar_bindings", {}).duplicate()
+
+	# Push the ACTIVE binding into the live hotbar. The equipment component's
+	# load step (run separately by the player root) will tell us which one
+	# that is — until then we assume primary, which matches a fresh-character
+	# default and a legacy save's only binding.
+	var active_bindings: Dictionary = _active_bindings_for_load()
 	if is_instance_valid(hotbar):
-		hotbar.load_hotbar_config(data.get("hotbar_config", {}))
+		hotbar.load_hotbar_config(active_bindings)
 
 	var saved_cooldowns: Dictionary = data.get("cooldowns", {})
 	for ability_id in saved_cooldowns:
@@ -867,7 +932,7 @@ func load_abilities(data: Dictionary) -> void:
 		if remaining > 0.0:
 			_cooldowns[ability_id] = remaining
 			cooldown_started.emit(ability_id, remaining)
-	
+
 	# Re-apply passives and update UI with loaded data
 	_apply_passive_effects()
 	if not _loading_mode:
@@ -881,6 +946,59 @@ func load_abilities(data: Dictionary) -> void:
 	#else:
 		#for ability_id in _ability_levels:
 			#print("Loaded ability: %s at level %d" % [ability_id, _ability_levels[ability_id]])
+
+
+## PR 3 helper. Picks the currently-active weapon's binding dict for a load.
+## Used by load_abilities and by _on_active_weapon_changed to know which set
+## to push into the live hotbar.
+func _active_bindings_for_load() -> Dictionary:
+	if _equipment_component and _equipment_component.active_weapon == EquipmentComponent.ACTIVE_SECONDARY:
+		return _secondary_hotbar_bindings
+	return _primary_hotbar_bindings
+
+
+## PR 3 helper. Captures the live hotbar config back into whichever binding
+## array is currently active. Called before saving (so any edits made since
+## the last swap land in the save) and on a swap (snapshot the leaving
+## weapon's layout).
+func _capture_active_bindings(live_config: Dictionary) -> void:
+	if not _equipment_component:
+		_primary_hotbar_bindings = live_config.duplicate()
+		return
+	if _equipment_component.active_weapon == EquipmentComponent.ACTIVE_SECONDARY:
+		_secondary_hotbar_bindings = live_config.duplicate()
+	else:
+		_primary_hotbar_bindings = live_config.duplicate()
+
+
+## PR 3 signal handler. Snapshot the leaving weapon's bindings, then push the
+## new weapon's bindings into the live hotbar. The hotbar UI re-renders.
+## Runs on both server and client (signal connection in `_ready`), so the host
+## and remote clients both refresh in lockstep with the authoritative swap.
+func _on_active_weapon_changed(_active_weapon: String, _active_item: ItemData) -> void:
+	# Capture the *outgoing* binding (whatever the live hotbar shows right now,
+	# which still reflects the *previous* active weapon at the moment this
+	# signal fires — EquipmentComponent emits AFTER it flipped active_weapon,
+	# so we have to look at the OPPOSITE side from the current active flag).
+	if not is_instance_valid(hotbar):
+		return
+
+	var live_config: Dictionary = hotbar.save_hotbar_config()
+	# `_equipment_component.active_weapon` has already flipped to the NEW
+	# active value, so capture the live config into the OTHER slot.
+	if _equipment_component and _equipment_component.active_weapon == EquipmentComponent.ACTIVE_SECONDARY:
+		# Just flipped to secondary — the live config still shows primary.
+		_primary_hotbar_bindings = live_config.duplicate()
+	else:
+		# Just flipped to primary — the live config still shows secondary.
+		_secondary_hotbar_bindings = live_config.duplicate()
+
+	# Push the new active set into the live hotbar.
+	hotbar.load_hotbar_config(_active_bindings_for_load())
+
+	# Visual ping: flash the hotbar to draw the eye to the changed bindings.
+	if hotbar.has_method("flash_swap_indicator"):
+		hotbar.flash_swap_indicator()
 			
 ## Disconnects from leveling component signals to prevent side effects during loading.
 func disconnect_level_signals() -> void:

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -26,15 +26,15 @@ var hit_list: Array = []
 var _unique_targets_for_attack: Dictionary = {}
 var _pending_bodies: Array = []
 
-## Damage range shown in the stats window. Uses the class's attack stat
-## (`_get_class_attack_stat()`) — for Mages and other INT-primary classes
-## that's MAGICATTACK, reflecting the channel their abilities scale on (which
-## is what they actually fight with). Basic-attack *actual* damage is a
+## Damage range shown in the stats window. Uses the active weapon's attack
+## stat (`_get_weapon_attack_stat()`) — for a Staff or Wand that's
+## MAGICATTACK, reflecting the channel their abilities scale on (which is
+## what they actually fight with). Basic-attack *actual* damage is a
 ## separate concern: `calculate_attack_damage` always uses WEAPONATTACK
-## regardless of class.
+## regardless of weapon type.
 var display_max_damage: int:
 	get:
-		return _calculate_max_range(_get_class_attack_stat())
+		return _calculate_max_range(_get_weapon_attack_stat())
 var display_min_damage: int:
 	get:
 		return roundi(display_max_damage * mastery)
@@ -500,30 +500,35 @@ func calculate_ability_damage(_ability: AbilityData, level_stats: AbilityLevelDa
 
 
 func calculate_attack_damage() -> int:
-	if not (_equipment_component and _equipment_component.weapon_slot_data and _equipment_component.weapon_slot_data.item):
+	# Read through the active weapon accessor so PR 3's primary/secondary swap
+	# is honored — the inactive weapon must not contribute to basic-attack
+	# damage even though it stays in the equipment dictionary.
+	if not (_equipment_component and _equipment_component.active_weapon_data):
 		return 0
 
-	# Basic attacks always use WEAPONATTACK, regardless of class. A Mage's
-	# basic staff swing intentionally uses the Wooden Staff's WEAPONATTACK,
+	# Basic attacks always use WEAPONATTACK, regardless of weapon type. A
+	# Staff's basic swing intentionally uses the Wooden Staff's WEAPONATTACK,
 	# not its MAGICATTACK — abilities are the channel for MAGICATTACK and
 	# pass their own stat via `_calculate_max_range(_ability.damage_stat)`.
 	var max_range = _calculate_max_range()
 	return roundi(randf_range(max_range * mastery, max_range))
 
 
-## Returns the `Constants.ClassType` discipline of the currently-equipped
-## weapon, or -1 if there's no weapon equipped (or the equipped weapon is
-## not one of the four tier-1 disciplines). Used by the mastery-XP grant
-## path so kills only feed mastery to weapons the system actually tracks.
-## Falls back to the character's `current_class` when the weapon slot is
-## empty but the character's discipline is a tier-1 weapon, so a bare-fisted
-## kill still credits the player's chosen discipline.
+## Returns the `Constants.ClassType` discipline of the ACTIVE weapon (PR 3),
+## or -1 if there's no weapon equipped in the active slot (or the equipped
+## weapon is not one of the four tier-1 disciplines). Used by the mastery-XP
+## grant path so kills only feed mastery to weapons the system actually
+## tracks. Falls back to the character's `current_class` when the active slot
+## is empty but the character's discipline is a tier-1 weapon, so a
+## bare-fisted kill still credits the player's chosen discipline. Routes
+## through `active_weapon_data` instead of the raw `weapon_slot.item` so the
+## swap UX correctly attributes mastery to whichever weapon is wielded.
 func _active_weapon_discipline() -> int:
-	# Preferred: the actual weapon currently in the WEAPON slot.
-	if _equipment_component and _equipment_component.weapon_slot_data and _equipment_component.weapon_slot_data.item:
-		var item = _equipment_component.weapon_slot_data.item
-		if item is WeaponData:
-			var discipline := WeaponMasteryComponent.weapon_type_to_discipline(item.weapon_type)
+	# Preferred: the actual weapon currently in the ACTIVE slot.
+	if _equipment_component:
+		var weapon: WeaponData = _equipment_component.active_weapon_data
+		if weapon != null:
+			var discipline := WeaponMasteryComponent.weapon_type_to_discipline(weapon.weapon_type)
 			if discipline != -1:
 				return discipline
 
@@ -537,11 +542,18 @@ func _active_weapon_discipline() -> int:
 	return -1
 
 
-func _get_class_attack_stat() -> Constants.StatType:
-	if _class_component:
-		var primary = ResourceManager.get_primary_stat(_class_component.current_class)
-		if primary == Constants.StatType.INTELLIGENCE:
-			return Constants.StatType.MAGICATTACK
+## Returns the StatType the ACTIVE weapon's damage scales off. PR 3 replaced
+## the old class-driven attack-stat lookup with this — once the player carries
+## two weapons, the channel a Staff vs a Sword fights through is a per-weapon
+## decision, not a per-character one. Staff / Wand → MAGICATTACK;
+## anything else (including bare hands) → WEAPONATTACK.
+func _get_weapon_attack_stat() -> Constants.StatType:
+	if _equipment_component:
+		var weapon: WeaponData = _equipment_component.active_weapon_data
+		if weapon != null:
+			match weapon.weapon_type:
+				Constants.WeaponType.STAFF:
+					return Constants.StatType.MAGICATTACK
 	return Constants.StatType.WEAPONATTACK
 
 

--- a/scripts/Components/equipment.gd
+++ b/scripts/Components/equipment.gd
@@ -171,6 +171,11 @@ func get_all_slot_data() -> Array:
 ## wielded weapon contributes. Other equipment is always counted. Used by
 ## stats.gd in place of get_all_slot_data() so a stashed secondary's bonuses
 ## don't double up.
+##
+## NOTE: slots_data has mixed key types — String for the two weapon slots
+## ("WEAPON" / "SECONDARY_WEAPON") and Constants.ArmorType ints for the four
+## armor slots. The weapon-active checks must guard with `is String` so the
+## == comparison doesn't error against int keys.
 func get_stat_contributing_slot_data() -> Array:
 	var out: Array = []
 	for key in slots_data.keys():
@@ -178,10 +183,11 @@ func get_stat_contributing_slot_data() -> Array:
 		if sd == null:
 			continue
 		# Hide the inactive weapon slot from the stats pipeline.
-		if key == "WEAPON" and active_weapon != ACTIVE_PRIMARY:
-			continue
-		if key == "SECONDARY_WEAPON" and active_weapon != ACTIVE_SECONDARY:
-			continue
+		if key is String:
+			if key == "WEAPON" and active_weapon != ACTIVE_PRIMARY:
+				continue
+			if key == "SECONDARY_WEAPON" and active_weapon != ACTIVE_SECONDARY:
+				continue
 		out.append(sd)
 	return out
 

--- a/scripts/Components/equipment.gd
+++ b/scripts/Components/equipment.gd
@@ -2,12 +2,30 @@ class_name EquipmentComponent
 extends Node
 
 signal on_equipment_changed
+## Emitted whenever the active weapon flips between primary and secondary
+## (or whenever load restores it). Combat / sprite / UI listeners react to
+## this to rebuild damage stats and visuals.
+signal active_weapon_changed(active_weapon: String, active_item: ItemData)
+## Emitted when the swap-on-cooldown gate starts. The hotbar paints a radial
+## cooldown overlay across both weapon icons for this duration.
+signal swap_cooldown_started(duration: float)
+## Emitted when the swap is denied (e.g. empty secondary). The hotbar plays
+## a "denied" UI ping and flashes the empty slot. No state change.
+signal swap_denied(reason: String)
+
+## Active-weapon enum (string-typed for save-file legibility).
+const ACTIVE_PRIMARY: String = "primary"
+const ACTIVE_SECONDARY: String = "secondary"
+
+## Swap cooldown in seconds. Tunable.
+const SWAP_COOLDOWN: float = 1.5
 
 @export var head_slot: EquipmentSlot
 @export var chest_slot: EquipmentSlot
 @export var legs_slot: EquipmentSlot
 @export var feet_slot: EquipmentSlot
 @export var weapon_slot: EquipmentSlot
+@export var secondary_weapon_slot: EquipmentSlot
 
 var equipment: Dictionary = {}
 # The component-owned data model: equipment key -> SlotData. This is the real
@@ -15,6 +33,15 @@ var equipment: Dictionary = {}
 var slots_data: Dictionary = {}
 var _changed_in_frame: bool = false
 var _silent_mode: bool = false
+
+## Tracks which weapon slot is currently active. PR 3 introduces a two-weapon
+## loadout (primary + secondary); Tab cycles, the hotbar refreshes, the sprite
+## swaps. `active_weapon` only ever holds ACTIVE_PRIMARY or ACTIVE_SECONDARY.
+var active_weapon: String = ACTIVE_PRIMARY
+
+## Server-side remaining swap cooldown (seconds). Clients do not read this —
+## they paint their UI overlay from the swap_cooldown_started signal duration.
+var _swap_cooldown_remaining: float = 0.0
 
 func _ready():
 	# Configure the slots with their specific types and set their container to this component.
@@ -59,8 +86,35 @@ func _ready():
 		weapon_slot.allowed_equipment_type = Constants.EquipmentType.WEAPON
 		weapon_slot.bind_slot_data(weapon_data)
 
+	# PR 3: secondary weapon slot. Same allow-rules as the primary weapon slot.
+	# `slots_data["SECONDARY_WEAPON"]` is always present even when the UI slot
+	# is missing (bot has no UI, and the equipment-window scene may not yet
+	# expose the slot on a remote client mid-transition).
+	var secondary_weapon_data := SlotData.new()
+	secondary_weapon_data.container_kind = SlotData.CONTAINER_EQUIPMENT
+	secondary_weapon_data.key = "SECONDARY_WEAPON"
+	secondary_weapon_data.allowed_item_type = Constants.ItemType.EQUIPMENT
+	secondary_weapon_data.allowed_equipment_type = Constants.EquipmentType.WEAPON
+	slots_data["SECONDARY_WEAPON"] = secondary_weapon_data
+
+	if secondary_weapon_slot:
+		equipment["SECONDARY_WEAPON"] = secondary_weapon_slot
+		secondary_weapon_slot.set_inventory(self)
+		secondary_weapon_slot.allowed_item_type = Constants.ItemType.EQUIPMENT
+		secondary_weapon_slot.allowed_equipment_type = Constants.EquipmentType.WEAPON
+		secondary_weapon_slot.bind_slot_data(secondary_weapon_data)
+
 	# When equipment changes on the server, persist the player's data
 	# Logic moved to multiplayer_controller_v2.gd to handle both client and server
+
+
+func _process(delta: float) -> void:
+	# Server-only swap-cooldown tick. The client never reads this value — it
+	# paints its UI overlay from the swap_cooldown_started signal duration.
+	if not multiplayer.is_server():
+		return
+	if _swap_cooldown_remaining > 0.0:
+		_swap_cooldown_remaining = maxf(0.0, _swap_cooldown_remaining - delta)
 
 
 func set_silent_mode(enabled: bool) -> void:
@@ -98,6 +152,7 @@ func get_slots() -> Array[EquipmentSlot]:
 	if legs_slot: slots_array.append(legs_slot)
 	if feet_slot: slots_array.append(feet_slot)
 	if weapon_slot: slots_array.append(weapon_slot)
+	if secondary_weapon_slot: slots_array.append(secondary_weapon_slot)
 	return slots_array
 
 
@@ -111,8 +166,30 @@ func get_all_slot_data() -> Array:
 	return slots_data.values()
 
 
+## Equipment slots whose `bonus_stats` should fold into StatsComponent. The
+## INACTIVE weapon's stats are deliberately excluded — only the currently
+## wielded weapon contributes. Other equipment is always counted. Used by
+## stats.gd in place of get_all_slot_data() so a stashed secondary's bonuses
+## don't double up.
+func get_stat_contributing_slot_data() -> Array:
+	var out: Array = []
+	for key in slots_data.keys():
+		var sd: SlotData = slots_data[key]
+		if sd == null:
+			continue
+		# Hide the inactive weapon slot from the stats pipeline.
+		if key == "WEAPON" and active_weapon != ACTIVE_PRIMARY:
+			continue
+		if key == "SECONDARY_WEAPON" and active_weapon != ACTIVE_SECONDARY:
+			continue
+		out.append(sd)
+	return out
+
+
 var weapon_slot_data: SlotData:
 	get: return slots_data.get("WEAPON")
+var secondary_weapon_slot_data: SlotData:
+	get: return slots_data.get("SECONDARY_WEAPON")
 var head_slot_data: SlotData:
 	get: return slots_data.get(Constants.ArmorType.HEAD)
 var chest_slot_data: SlotData:
@@ -123,9 +200,117 @@ var feet_slot_data: SlotData:
 	get: return slots_data.get(Constants.ArmorType.FEET)
 
 
+## Returns the WeaponData currently in the ACTIVE weapon slot, or null when
+## the active slot is empty / the item is not a weapon. Combat, sprite swap,
+## and mastery-XP attribution all read through this.
+var active_weapon_data: WeaponData:
+	get:
+		var sd: SlotData = _active_weapon_slot_data()
+		if sd == null or sd.item == null:
+			return null
+		return sd.item as WeaponData
+
+
+func _active_weapon_slot_data() -> SlotData:
+	if active_weapon == ACTIVE_SECONDARY:
+		return slots_data.get("SECONDARY_WEAPON")
+	return slots_data.get("WEAPON")
+
+
 ## Refreshes the UI view bound to an equipment key, if one exists. A no-op on
 ## a headless bot scene (no equipment window).
 func refresh_view(key) -> void:
 	var view = equipment.get(key)
 	if is_instance_valid(view):
 		view.update_display()
+
+
+# ===========================================================================
+# Weapon Swap (PR 3)
+# ===========================================================================
+
+## Server-only attempt to flip the active weapon. Validates state, sets the
+## cooldown, fires signals, and emits the auth result. Returns true on a
+## successful swap, false on denial. On denial pings the initiator's UI.
+func try_perform_swap_server(initiator_id: int) -> bool:
+	if not multiplayer.is_server():
+		return false
+
+	if _swap_cooldown_remaining > 0.0:
+		# Cooldown — silently deny. The UI overlay already shows the cooldown,
+		# so don't spam a denied ping here.
+		swap_denied.emit("cooldown")
+		return false
+
+	var secondary_sd: SlotData = slots_data.get("SECONDARY_WEAPON")
+	if secondary_sd == null or secondary_sd.item == null:
+		# Empty secondary — Tab is a no-op, but ping the initiator so they get
+		# a "denied" feedback (sound + flash). No state change.
+		_broadcast_swap_denied(initiator_id, "empty_secondary")
+		return false
+
+	# Apply the flip locally (server side) and broadcast the authoritative
+	# state. Purely synchronous — no awaits, no sync-emit-await-hang risk.
+	_apply_swap_state()
+	_swap_cooldown_remaining = SWAP_COOLDOWN
+
+	# Tell every peer about the swap and its cooldown so their UI matches the
+	# server's truth. `call_local` is NOT set here because the server has
+	# already applied the state above; we don't want to double-flip on the
+	# host. Use call_remote and let clients re-run the apply locally.
+	swap_applied_rpc.rpc(active_weapon, SWAP_COOLDOWN)
+
+	return true
+
+
+## Apply the swap locally. Called from the server's intent path and from the
+## client-side RPC handler.
+func _apply_swap_state() -> void:
+	if active_weapon == ACTIVE_PRIMARY:
+		active_weapon = ACTIVE_SECONDARY
+	else:
+		active_weapon = ACTIVE_PRIMARY
+	active_weapon_changed.emit(active_weapon, active_weapon_data)
+	swap_cooldown_started.emit(SWAP_COOLDOWN)
+	# An active-weapon flip is functionally an equipment change — let stats /
+	# combat re-derive their per-weapon values via the standard path.
+	mark_changed()
+
+
+func _broadcast_swap_denied(initiator_id: int, reason: String) -> void:
+	# Server-side local emit + targeted client ping. Bots have no client; skip.
+	swap_denied.emit(reason)
+	if initiator_id > 0 and initiator_id != 1:
+		swap_denied_rpc.rpc_id(initiator_id, reason)
+
+
+## Server -> all peers. Authoritative result of a successful swap, including
+## the new cooldown so the radial overlay can paint. `call_remote` so the
+## server (which already ran _apply_swap_state) does not double-apply.
+@rpc("authority", "call_remote", "reliable")
+func swap_applied_rpc(new_active_weapon: String, cooldown_duration: float) -> void:
+	if multiplayer.is_server():
+		return
+	# Set the active flag from the server's truth and emit locally so listeners
+	# (sprite, hotbar, stats) refresh.
+	active_weapon = new_active_weapon
+	active_weapon_changed.emit(active_weapon, active_weapon_data)
+	swap_cooldown_started.emit(cooldown_duration)
+	mark_changed()
+
+
+## Server -> initiator. Ping the player's UI on a denied swap. No state change.
+@rpc("authority", "call_remote", "reliable")
+func swap_denied_rpc(reason: String) -> void:
+	if multiplayer.is_server():
+		return
+	swap_denied.emit(reason)
+
+
+## Direct setter for save/load. Skips the cooldown and any RPC broadcast —
+## the rest of the load pipeline syncs the client. Used by the player root's
+## `_load_data` to restore the persisted `active_weapon`.
+func set_active_weapon_silent(new_active_weapon: String) -> void:
+	if new_active_weapon != ACTIVE_PRIMARY and new_active_weapon != ACTIVE_SECONDARY:
+		return
+	active_weapon = new_active_weapon

--- a/scripts/Components/inventory.gd
+++ b/scripts/Components/inventory.gd
@@ -540,10 +540,18 @@ func save_inventory() -> Dictionary:
 		for eq_key in equipment_component.slots_data.keys():
 			var eq_sd: SlotData = equipment_component.slots_data[eq_key]
 			if eq_sd and eq_sd.item != null:
+				# `eq_key` may be "WEAPON" / "SECONDARY_WEAPON" (PR 3) or an
+				# armor-type int. The backend `equipment.slot_type` column is a
+				# free-form string, so "SECONDARY_WEAPON" piggybacks the same
+				# table — zero schema change.
 				equipment_data[str(eq_key)] = eq_sd.item.get_save_data()
 
 	inventory_data["slots"] = slot_entries
 	inventory_data["equipment"] = equipment_data
+	# PR 3: persist which weapon slot is currently active. Lives at the
+	# inventory-data level so it round-trips with the equipment payload.
+	if equipment_component:
+		inventory_data["active_weapon"] = equipment_component.active_weapon
 	return inventory_data
 
 
@@ -586,9 +594,11 @@ func _apply_inventory_data(inventory_data: Dictionary) -> void:
 			var item_dict: Dictionary = equipment_data_dict[key_str]
 			if item_dict.is_empty():
 				continue
+			# PR 3: string keys cover both "WEAPON" and "SECONDARY_WEAPON".
+			# Armor types are persisted as their int values (stringified).
 			var key: Variant
-			if key_str == "WEAPON":
-				key = "WEAPON"
+			if key_str == "WEAPON" or key_str == "SECONDARY_WEAPON":
+				key = key_str
 			else:
 				key = int(key_str)
 			var target_sd: SlotData = equipment_component.get_slot_data(key)
@@ -599,6 +609,11 @@ func _apply_inventory_data(inventory_data: Dictionary) -> void:
 					equipment_component.refresh_view(key)
 				else:
 					print("Failed to load equipment item from dictionary: " + str(item_dict))
+
+		# PR 3: restore the persisted active weapon. Default to primary on
+		# legacy saves that pre-date the field.
+		var saved_active_weapon: String = inventory_data.get("active_weapon", EquipmentComponent.ACTIVE_PRIMARY)
+		equipment_component.set_active_weapon_silent(saved_active_weapon)
 
 	_rebuild_item_tracking()
 
@@ -857,31 +872,31 @@ func sync_equipment_update_rpc(eq_key_str: String, item_dict: Dictionary, trigge
 	"""Client receives an equipment slot update"""
 	if multiplayer.is_server():
 		return
-	
+
 	if not equipment_component:
 		return
-	
+
 	var target_slot: Slot = null
-	if eq_key_str == "WEAPON":
-		target_slot = equipment_component.equipment.get("WEAPON")
+	if eq_key_str == "WEAPON" or eq_key_str == "SECONDARY_WEAPON":
+		target_slot = equipment_component.equipment.get(eq_key_str)
 	else:
 		var key_val := int(eq_key_str)
 		target_slot = equipment_component.equipment.get(key_val)
-	
+
 	if not target_slot:
 		return
-	
+
 	var old_item = target_slot.item
 	var item_instance = ItemData.from_dictionary(item_dict)
 	if item_instance:
 		# Use silent mode if we're batching multiple equipment changes
 		if equipment_component and not trigger_stats_recalc:
 			equipment_component.set_silent_mode(true)
-		
+
 		target_slot.item = item_instance
 		target_slot.update_display()
 		_update_item_tracking(target_slot, old_item, item_instance)
-		
+
 	# Trigger stats recalc if needed
 	if trigger_stats_recalc:
 		if is_instance_valid(stats_component):
@@ -893,13 +908,13 @@ func sync_equipment_clear_rpc(eq_key_str: String, trigger_stats_recalc: bool):
 	"""Client receives notification that an equipment slot was cleared"""
 	if multiplayer.is_server():
 		return
-	
+
 	if not equipment_component:
 		return
-	
+
 	var target_slot: Slot = null
-	if eq_key_str == "WEAPON":
-		target_slot = equipment_component.equipment.get("WEAPON")
+	if eq_key_str == "WEAPON" or eq_key_str == "SECONDARY_WEAPON":
+		target_slot = equipment_component.equipment.get(eq_key_str)
 	else:
 		var key_val := int(eq_key_str)
 		target_slot = equipment_component.equipment.get(key_val)

--- a/scripts/Components/stats.gd
+++ b/scripts/Components/stats.gd
@@ -238,9 +238,12 @@ func _recalculate_stats() -> void:
 				stats[stat_type].base_value += bonus
 
 	# Add equipment bonuses (single pass) — read the SlotData model so this
-	# works with no equipment UI (headless / bot).
+	# works with no equipment UI (headless / bot). PR 3: use the
+	# stat-contributing filter so only the ACTIVE weapon's bonus_stats fold
+	# in. The inactive (secondary or primary, depending on swap state) sits
+	# in equipment storage but does NOT contribute to live stats.
 	if _equipment_component:
-		for slot in _equipment_component.get_all_slot_data():
+		for slot in _equipment_component.get_stat_contributing_slot_data():
 			if slot.item != null and slot.item.bonus_stats != null:
 				for stat_type in slot.item.bonus_stats:
 					if stats.has(stat_type):

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -746,3 +746,9 @@ func player_input(input_type: String, data: Variant = null):
 		"attack": player_node.do_attack = true
 		"pickup": player_node.do_pickup = data
 		"portal": player_node.do_portal_interact = true
+		"weapon_swap":
+			# PR 3: route weapon-swap intent through the player node's
+			# request_weapon_swap_server RPC. The player node owns the
+			# equipment component reference and the cleanup/death gate.
+			if player_node.has_method("request_weapon_swap_server"):
+				player_node.request_weapon_swap_server()

--- a/scripts/Player/StateMachine/attack.gd
+++ b/scripts/Player/StateMachine/attack.gd
@@ -7,8 +7,13 @@ var player
 
 var attack_speed_percent: float:
 	get():
-		if parent.equipment_component.weapon_slot_data.item != null:
-			return float(100.0 / ((20.0 - parent.equipment_component.weapon_slot_data.item.weapon_attack_speed) / 16.0)) / 100
+		# PR 3: route attack speed through the ACTIVE weapon so a swap to a
+		# faster/slower weapon takes effect immediately. Reads through the
+		# active_weapon_data accessor so the inactive slot's stats don't
+		# bleed in.
+		var active_weapon: WeaponData = parent.equipment_component.active_weapon_data
+		if active_weapon != null:
+			return float(100.0 / ((20.0 - active_weapon.weapon_attack_speed) / 16.0)) / 100
 		else:
 			return 1
 

--- a/scripts/Player/StateMachine/attack.gd
+++ b/scripts/Player/StateMachine/attack.gd
@@ -63,10 +63,13 @@ func _play_animation(anim_name: String) -> void:
 				animations.play(anim_name, attack_speed_percent)
 
 func _start_basic_attack():
-	"""Executes a basic melee attack, or Arrow Shot for Archer/Ranger"""
+	"""Executes a basic melee attack, or Arrow Shot for the wielded weapon's
+	discipline. Uses the player's CURRENTLY-WIELDED discipline (via
+	get_active_discipline), not the starting class — so a Swordsman who swapped
+	to a bow correctly fires arrows, and a Mage who picked up a sword swings."""
 	var is_archer := false
-	if player.class_component:
-		var cls: int = player.class_component.current_class
+	if player.has_method("get_active_discipline"):
+		var cls: int = player.get_active_discipline()
 		is_archer = cls == Constants.ClassType.BOW or cls == Constants.ClassType.RANGER
 
 	if is_archer and _try_use_arrow_shot():

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -69,6 +69,10 @@ var _drop_through_target_y: float = 0.0
 var _sprite_base_offset_x: float
 var _is_being_cleaned_up: bool = false
 var _is_loading_data: bool = false
+## PR 3: server-side gate for the weapon-swap transition window. While true,
+## input flags are zeroed in _update_input_from_synchronizer so the player
+## can't act mid-flash. Re-enabled when the transition timer fires.
+var _swap_input_locked: bool = false
 var _context_menu: PlayerContextMenu
 
 @onready var camera: Camera2D = $Camera2D
@@ -388,6 +392,9 @@ func _setup_signals() -> void:
 
 	if equipment_component:
 		equipment_component.on_equipment_changed.connect(func(): _data_changed("equipment"))
+		# PR 3: react to active-weapon flips for sprite swap + transition FX.
+		# The active_weapon flag itself rides in the equipment save bucket.
+		equipment_component.active_weapon_changed.connect(_on_active_weapon_changed)
 
 	if class_component:
 		# Persist class changes (job advancement) so the new class survives the
@@ -510,6 +517,17 @@ func _update_input_from_synchronizer() -> void:
 		direction = 0
 		input_down = false
 		input_up = false
+		return
+
+	# PR 3: zero input during the weapon-swap transition window so the player
+	# can't act mid-flash. The lock auto-clears after SWAP_TRANSITION_DURATION.
+	if _swap_input_locked:
+		direction = 0
+		input_down = false
+		input_up = false
+		do_attack = false
+		do_jump = false
+		do_drop = false
 		return
 
 	var input_sync: Node = get_node_or_null("%InputSynchronizer")
@@ -862,6 +880,180 @@ func request_sprite_change() -> void:
 	if not multiplayer.is_server():
 		return
 	_handle_sprite_change_on_server()
+
+
+# ============================================================================
+# Weapon Swap (PR 3) — server-authoritative
+# ============================================================================
+
+const SWAP_TRANSITION_DURATION: float = 0.25
+const SWAP_FX_PATH: String = "res://assets/sprites/MiniDarkElves/MiniDarkElves/Starfall-Sheet.png"
+const SWAP_FX_FRAME_COUNT: int = 11
+const SWAP_FX_FRAME_SIZE: int = 32
+# Frame at which the sprite swap happens (visual peak of the flash).
+const SWAP_FX_SPRITE_SWAP_FRAME: int = 3
+
+## [CLIENT -> SERVER] Local player presses Tab. Forwarded by multiplayer_input.
+## Validates and applies the swap; on success, the EquipmentComponent's
+## swap_applied_rpc broadcasts the new active weapon to every peer (and our
+## _on_active_weapon_changed handler runs the sprite swap + FX).
+@rpc("any_peer", "call_local", "reliable")
+func request_weapon_swap_server() -> void:
+	if not multiplayer.is_server():
+		return
+
+	# Cleanup / death-state gate. A respawning player shouldn't swap mid-respawn.
+	if _is_being_cleaned_up:
+		return
+	if is_instance_valid(health_component) and health_component.is_dead:
+		return
+
+	if not is_instance_valid(equipment_component):
+		return
+
+	var initiator: int = multiplayer.get_remote_sender_id()
+	# When the host (peer 1) calls this locally, get_remote_sender_id() is 0.
+	# Use the player_id so the denied-ping RPC has a real target.
+	if initiator == 0:
+		initiator = player_id
+
+	equipment_component.try_perform_swap_server(initiator)
+
+
+## Signal handler. Runs on every peer that mirrors this player. Triggers the
+## sprite swap + transition FX. Sprite-swap timing is locked to frame 3 of
+## the FX animation so the swap happens at the visual peak of the flash.
+func _on_active_weapon_changed(_active_weapon: String, _active_item: ItemData) -> void:
+	if _is_being_cleaned_up:
+		return
+
+	# Persist the new active_weapon. The inventory bucket already serializes
+	# equipment + active_weapon together (see InventoryComponent.save_inventory),
+	# so queue an inventory save explicitly. The default `on_equipment_changed`
+	# handler fires the "equipment" category, which today doesn't round-trip
+	# in get_save_data — so we route through "inventory" for the swap.
+	if multiplayer.is_server() and not _is_loading_data:
+		_data_changed("inventory")
+
+	# Spawn the transition FX on every peer that has this player node.
+	_spawn_swap_transition_fx()
+
+	# Schedule the sprite swap to land at the FX's visual peak.
+	# Frame 3 of 11 frames at ~44fps (0.25s total) = ~0.068s.
+	var swap_delay: float = SWAP_TRANSITION_DURATION * (float(SWAP_FX_SPRITE_SWAP_FRAME) / float(SWAP_FX_FRAME_COUNT))
+
+	# Lock input for the full transition duration on the SERVER side only — the
+	# server is authoritative over movement; the client mirrors anyway.
+	if multiplayer.is_server():
+		_lock_input_for_swap()
+
+	get_tree().create_timer(swap_delay).timeout.connect(_apply_active_weapon_sprite)
+
+
+## Locks input for the swap transition window on the server. Sets
+## `_swap_input_locked` so `_update_input_from_synchronizer` zeros direction
+## /jump/drop/attack each frame until the transition timer fires. Auto-clears
+## via a one-shot create_timer connection.
+func _lock_input_for_swap() -> void:
+	if not multiplayer.is_server():
+		return
+	_swap_input_locked = true
+	direction = 0
+	do_attack = false
+	do_jump = false
+	do_drop = false
+	# Auto-clear after the transition completes. The timer connection is
+	# one-shot per Godot's create_timer contract — safe to wire as a fire-and-
+	# forget. No `await` here so the sync-emit-await-hang trap is avoided.
+	get_tree().create_timer(SWAP_TRANSITION_DURATION).timeout.connect(
+		func() -> void:
+			if is_instance_valid(self):
+				_swap_input_locked = false
+	)
+
+
+## Resolves the active weapon's discipline and updates the AnimatedSprite2D
+## frames. Runs on the same peers that see the FX. Reads through
+## `active_weapon_data.weapon_type` and maps to the matching tier-1 sprite.
+func _apply_active_weapon_sprite() -> void:
+	if _is_being_cleaned_up:
+		return
+	if not is_instance_valid(equipment_component) or not is_instance_valid(animated_sprite):
+		return
+	if not is_instance_valid(level_component):
+		return
+
+	var weapon: WeaponData = equipment_component.active_weapon_data
+	# If the active slot is empty (bare hands), fall back to the character's
+	# current discipline so the sprite stays sensible.
+	var discipline_class: int = -1
+	if weapon != null:
+		discipline_class = _weapon_type_to_class_type(weapon.weapon_type)
+	if discipline_class == -1 and is_instance_valid(class_component):
+		discipline_class = class_component.current_class
+
+	if discipline_class == -1:
+		return
+
+	var frames: SpriteFrames = ResourceManager.get_sprite_for_level(discipline_class, level_component.level)
+	if frames:
+		animated_sprite.sprite_frames = frames
+		animated_sprite.play("idle")
+
+
+static func _weapon_type_to_class_type(weapon_type: int) -> int:
+	match weapon_type:
+		Constants.WeaponType.SWORD:
+			return Constants.ClassType.SWORD
+		Constants.WeaponType.BOW:
+			return Constants.ClassType.BOW
+		Constants.WeaponType.STAFF:
+			return Constants.ClassType.STAFF
+		Constants.WeaponType.DAGGER:
+			return Constants.ClassType.DAGGER
+	return -1
+
+
+## Spawns the one-shot transition FX at the player's chest position. Runs on
+## every peer that has this player node (server included). Auto-frees when
+## the animation finishes.
+func _spawn_swap_transition_fx() -> void:
+	# Skip for headless dedicated server, and skip for bots whose UI subtree
+	# is freed — but DO render on the host (server + client in one tree) and
+	# on every remote client that sees this player.
+	if OS.has_feature("dedicated_server"):
+		return
+
+	if not is_instance_valid(animated_sprite):
+		return
+
+	var fx_texture: Texture2D = load(SWAP_FX_PATH)
+	if fx_texture == null:
+		return
+
+	var fx_frames := SpriteFrames.new()
+	fx_frames.add_animation("swap")
+	fx_frames.set_animation_loop("swap", false)
+	# 11 frames over 0.25s = 44 fps.
+	fx_frames.set_animation_speed("swap", float(SWAP_FX_FRAME_COUNT) / SWAP_TRANSITION_DURATION)
+
+	for i in range(SWAP_FX_FRAME_COUNT):
+		var atlas := AtlasTexture.new()
+		atlas.atlas = fx_texture
+		atlas.region = Rect2(i * SWAP_FX_FRAME_SIZE, 0, SWAP_FX_FRAME_SIZE, SWAP_FX_FRAME_SIZE)
+		fx_frames.add_frame("swap", atlas)
+
+	var fx_sprite := AnimatedSprite2D.new()
+	fx_sprite.name = "WeaponSwapFX"
+	fx_sprite.sprite_frames = fx_frames
+	fx_sprite.position = Vector2(0, -16) # Roughly the player's chest.
+	fx_sprite.z_index = 5
+	add_child(fx_sprite)
+	fx_sprite.play("swap")
+
+	# Auto-free when the animation finishes. animation_finished is one-shot
+	# per non-looping animation, so this fires exactly once.
+	fx_sprite.animation_finished.connect(fx_sprite.queue_free)
 
 
 # [SERVER -> CLIENTS] Broadcasts the sprite change to all clients.

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -572,21 +572,46 @@ func _change_sprite() -> void:
 		request_sprite_change.rpc_id(SERVER_ID) # Remote clients must ask server.
 
 		
+## Returns the discipline (Constants.ClassType) the player is CURRENTLY
+## wielding — i.e. the discipline of the active weapon. Falls back to the
+## starting class (class_component.current_class) when no weapon is equipped.
+##
+## This is the "I am my weapon" identity lookup. Use it for sprite picking,
+## attack-state branches, and anything else whose behavior should follow the
+## equipped weapon rather than the character's chosen starting class. HP/MP
+## curves intentionally stay anchored to class_component.current_class
+## (per the locked design — HP/MP doesn't shift on weapon swap).
+func get_active_discipline() -> int:
+	if is_instance_valid(equipment_component):
+		var weapon: WeaponData = equipment_component.active_weapon_data
+		if weapon != null:
+			var disc: int = _weapon_type_to_class_type(weapon.weapon_type)
+			if disc != -1:
+				return disc
+	if is_instance_valid(class_component):
+		return class_component.current_class
+	return Constants.ClassType.SWORD
+
+
 func _handle_sprite_change_on_server() -> void:
-	if not is_instance_valid(class_component) or not is_instance_valid(level_component):
+	if not is_instance_valid(level_component):
 		return
 
-	var class_type: int = class_component.current_class
+	# Use the currently-wielded discipline, not the starting class — so a
+	# Swordsman who's swapped to a bow stays an Archer sprite on level-up.
+	var discipline: int = get_active_discipline()
 	var current_level: int = level_component.level
 
-	var sprite_frames: SpriteFrames = ResourceManager.get_sprite_for_level(class_type, current_level)
+	var sprite_frames: SpriteFrames = ResourceManager.get_sprite_for_level(discipline, current_level)
 	if sprite_frames:
 		if BotManager.is_bot(player_id):
 			# A bot's node may be missing on a client mid map-transition, so
 			# route its sprite updates through MapManager (an autoload).
 			MapManager.broadcast_player_appearance(player_id)
 		else:
-			change_sprite_rpc.rpc(class_component.get_class_name(), current_level)
+			# Pass the enum-key string so change_sprite_rpc resolves the same
+			# way on every peer via ResourceManager.get_class_type_from_string.
+			change_sprite_rpc.rpc(Constants.ClassType.find_key(discipline), current_level)
 
 func change_to_map(new_map_id: String, spawn_point_name: String = ""):
 	if not multiplayer.is_server():
@@ -800,10 +825,13 @@ func _on_peer_connected(peer_id: int) -> void:
 	await get_tree().process_frame
 
 	#print("Sending sprite data for player %d to new peer %d" % [player_id, peer_id])
-	if is_instance_valid(class_component) and is_instance_valid(level_component):
-		var _class_name: String = class_component.get_class_name()
+	if is_instance_valid(level_component):
+		# Use the currently-wielded discipline (NOT class_component.current_class)
+		# so a newly-joining peer sees the player with whichever weapon they're
+		# actually holding right now, not their starting-class default.
+		var discipline: int = get_active_discipline()
 		var current_level: int = level_component.level
-		change_sprite_rpc.rpc_id(peer_id, _class_name, current_level)
+		change_sprite_rpc.rpc_id(peer_id, Constants.ClassType.find_key(discipline), current_level)
 
 
 #=============================================================================

--- a/scripts/Player/multiplayer_input.gd
+++ b/scripts/Player/multiplayer_input.gd
@@ -93,6 +93,13 @@ func _process(_delta: float) -> void:
 	if Input.is_action_just_pressed("Portal Interact"):
 		PlayerManager.player_input.rpc_id(1, "portal")
 
+	# PR 3: Tab cycles between primary and secondary weapons. Routes through
+	# PlayerManager.player_input -> the player node's request_weapon_swap_server
+	# RPC so the server validates the cooldown / occupancy and broadcasts the
+	# authoritative result.
+	if Input.is_action_just_pressed("Weapon Swap Loadout"):
+		PlayerManager.player_input.rpc_id(1, "weapon_swap")
+
 
 func _on_left_button_button_down() -> void:
 	if _is_being_cleaned_up:

--- a/scripts/UI/hotbar.gd
+++ b/scripts/UI/hotbar.gd
@@ -5,23 +5,43 @@ const HOTBARSLOT = preload("res://scenes/UI/hotbar_slot.tscn")
 const ABILITYDATA = preload("res://scripts/Resources/AbilitySystem/AbilityData.gd")
 
 @onready var slots_container: HBoxContainer = %SlotsContainer
+# The two weapon-loadout widgets live under the WeaponSwapSection. Resolved
+# in _ready() (after @onready binds slots_container) so we can use a single
+# get_node call against the swap section parent.
+var weapon_swap_section: HBoxContainer = null
+var primary_weapon_slot: HotbarWeaponSlot = null
+var secondary_weapon_slot: HotbarWeaponSlot = null
 
 var hotbar_slots: Array[Node] = []
 var slot_count: int = 8
 var player: MultiplayerPlayerV2
 var ability_component: AbilityComponent
+var equipment_component: EquipmentComponent
+var _flash_remaining: float = 0.0
+
+const HOTBAR_FLASH_DURATION := 0.1
+const HOTBAR_FLASH_COLOR := Color(1.3, 1.3, 0.7, 1.0)
 
 func _ready():
+	# Resolve weapon-swap section widgets via the unique-name lookup. `%`
+	# resolution only handles direct unique-name children, so the loadout
+	# slots are accessed off the parent section by fixed child names.
+	weapon_swap_section = get_node_or_null("%WeaponSwapSection") as HBoxContainer
+	if is_instance_valid(weapon_swap_section):
+		primary_weapon_slot = weapon_swap_section.get_node_or_null("PrimaryWeaponSlot") as HotbarWeaponSlot
+		secondary_weapon_slot = weapon_swap_section.get_node_or_null("SecondaryWeaponSlot") as HotbarWeaponSlot
+
 	# Get reference to player (adjust based on your scene structure)
 	if owner is MultiplayerPlayerV2:
 		player = owner as MultiplayerPlayerV2
 	elif get_parent() is MultiplayerPlayerV2:
 		player = get_parent() as MultiplayerPlayerV2
-	
+
 	# Get ability component
 	if player:
 		ability_component = player.ability_component
-	
+		equipment_component = player.equipment_component
+
 	if not ability_component:
 		push_error("Hotbar: Could not find AbilityComponent")
 
@@ -29,6 +49,33 @@ func _ready():
 
 	if ability_component:
 		ability_component.cooldown_started.connect(_on_cooldown_started)
+
+	# PR 3: wire the weapon-swap section. The widgets exist on every client
+	# that has the hotbar scene; bots free their UI subtree so this never runs
+	# for them.
+	if is_instance_valid(primary_weapon_slot):
+		primary_weapon_slot.click_to_swap_requested.connect(_on_weapon_slot_click)
+	if is_instance_valid(secondary_weapon_slot):
+		secondary_weapon_slot.click_to_swap_requested.connect(_on_weapon_slot_click)
+
+	if equipment_component:
+		equipment_component.on_equipment_changed.connect(_refresh_weapon_section)
+		equipment_component.active_weapon_changed.connect(_on_active_weapon_changed)
+		equipment_component.swap_cooldown_started.connect(_on_swap_cooldown_started)
+		equipment_component.swap_denied.connect(_on_swap_denied)
+
+	# Defer the first refresh by a frame — the equipment component's slots
+	# may not be populated yet when _ready fires (loaded asynchronously).
+	call_deferred("_refresh_weapon_section")
+	call_deferred("_refresh_active_highlight")
+
+
+func _process(delta: float) -> void:
+	if _flash_remaining > 0.0:
+		_flash_remaining = maxf(0.0, _flash_remaining - delta)
+		if _flash_remaining <= 0.0:
+			modulate = Color.WHITE
+
 
 func create_hotbar_slots():
 	for i in range(slot_count):
@@ -99,13 +146,24 @@ func save_hotbar_config() -> Dictionary:
 
 ## Load hotbar configuration (from save data)
 func load_hotbar_config(config: Dictionary):
-	if config.size() != hotbar_slots.size():
-		#print("Warning: Hotbar config size mismatch")
+	# PR 3: a per-weapon binding may legitimately be empty (e.g. the secondary
+	# loadout right after equipping a new weapon for the first time). Treat
+	# an empty config as "clear all slots" rather than bailing — otherwise
+	# the previous weapon's bindings would leak through after a swap.
+	if config.is_empty():
+		for slot in hotbar_slots:
+			slot._clear_slot()
 		return
-	
-	for i in range(config.size()):
+
+	if config.size() != hotbar_slots.size():
+		# Size mismatch — clear and apply what's present.
+		for slot in hotbar_slots:
+			slot._clear_slot()
+
+	for i in range(hotbar_slots.size()):
 		var entry_id: String = config.get(str(i), "")
 		if entry_id == "":
+			hotbar_slots[i]._clear_slot()
 			continue
 		# Hotbar entries store either a learned ability's id or a consumable's
 		# item_id — ability and item ids occupy distinct id spaces.
@@ -121,3 +179,71 @@ func load_hotbar_config(config: Dictionary):
 			var item_data = ResourceManager.get_item_data(entry_id)
 			if item_data is ConsumableData:
 				hotbar_slots[i]._set_consumable(item_data)
+
+
+# ============================================================================
+# Weapon-swap section (PR 3)
+# ============================================================================
+
+func _refresh_weapon_section() -> void:
+	if not is_instance_valid(equipment_component):
+		return
+
+	var primary_sd := equipment_component.weapon_slot_data
+	var secondary_sd := equipment_component.secondary_weapon_slot_data
+
+	if is_instance_valid(primary_weapon_slot):
+		primary_weapon_slot.set_weapon_item(primary_sd.item if primary_sd else null)
+	if is_instance_valid(secondary_weapon_slot):
+		secondary_weapon_slot.set_weapon_item(secondary_sd.item if secondary_sd else null)
+
+	_refresh_active_highlight()
+
+
+func _refresh_active_highlight() -> void:
+	if not is_instance_valid(equipment_component):
+		return
+	var primary_active: bool = equipment_component.active_weapon == EquipmentComponent.ACTIVE_PRIMARY
+	if is_instance_valid(primary_weapon_slot):
+		primary_weapon_slot.set_active(primary_active)
+	if is_instance_valid(secondary_weapon_slot):
+		secondary_weapon_slot.set_active(not primary_active)
+
+
+func _on_active_weapon_changed(_active_weapon: String, _active_item: ItemData) -> void:
+	_refresh_active_highlight()
+
+
+func _on_swap_cooldown_started(duration: float) -> void:
+	if is_instance_valid(primary_weapon_slot):
+		primary_weapon_slot.start_swap_cooldown(duration)
+	if is_instance_valid(secondary_weapon_slot):
+		secondary_weapon_slot.start_swap_cooldown(duration)
+
+
+func _on_swap_denied(reason: String) -> void:
+	if reason == "empty_secondary" and is_instance_valid(secondary_weapon_slot):
+		secondary_weapon_slot.flash_denied()
+	# Other denial reasons (cooldown etc.) currently no-op visually — the
+	# existing radial overlay already communicates the cooldown.
+
+
+## Click-to-swap entry from the inactive weapon icon. Routes the same RPC
+## the Tab keybind uses.
+func _on_weapon_slot_click(_slot_kind: String) -> void:
+	if not is_instance_valid(player):
+		return
+	# Local player only — clicks on a remote player's hotbar slot widgets
+	# don't happen in practice (the hotbar UI is hidden for remote players),
+	# but guard anyway.
+	if multiplayer.get_unique_id() != player.player_id:
+		return
+	PlayerManager.player_input.rpc_id(1, "weapon_swap")
+
+
+## Brief tint flash drawing the eye to the changed bindings on swap. Called
+## by AbilityComponent._on_active_weapon_changed when the live bindings have
+## been swapped in.
+func flash_swap_indicator() -> void:
+	_flash_remaining = HOTBAR_FLASH_DURATION
+	modulate = HOTBAR_FLASH_COLOR

--- a/scripts/UI/hotbar_weapon_slot.gd
+++ b/scripts/UI/hotbar_weapon_slot.gd
@@ -1,0 +1,115 @@
+extends PanelContainer
+class_name HotbarWeaponSlot
+
+## A weapon-loadout widget inside the hotbar (PR 3). One instance per
+## loadout slot — primary and secondary. Shows the equipped weapon's icon,
+## a highlight when active, a dimmer modulate when inactive, a radial
+## cooldown overlay during the 1.5s swap window, and forwards clicks on the
+## INACTIVE slot to the player's weapon-swap RPC.
+
+## Emitted when the user clicks this slot while it is NOT the active weapon.
+## The Hotbar parent routes this into request_weapon_swap_server.
+signal click_to_swap_requested(slot_kind: String)
+
+## "primary" or "secondary" — matches EquipmentComponent's active_weapon enum.
+@export var slot_kind: String = "primary"
+
+@onready var icon_rect: TextureRect = $MarginContainer/IconRect
+@onready var cooldown_overlay: ColorRect = $MarginContainer/CooldownOverlay
+@onready var label: Label = $MarginContainer/SlotLabel
+
+var _active: bool = false
+var _cooldown_timer: float = 0.0
+var _cooldown_total: float = 0.0
+var _flash_remaining: float = 0.0
+
+# Visual state colors.
+const ACTIVE_BORDER_COLOR := Color(0.95, 0.85, 0.20, 1.0)
+const INACTIVE_BORDER_COLOR := Color(0.30, 0.30, 0.35, 1.0)
+const INACTIVE_MODULATE := Color(0.55, 0.55, 0.55, 0.85)
+const ACTIVE_MODULATE := Color.WHITE
+const FLASH_COLOR := Color(1.4, 1.4, 0.6, 1.0)
+const FLASH_DURATION := 0.1
+
+func _ready() -> void:
+	mouse_filter = Control.MOUSE_FILTER_STOP
+	gui_input.connect(_on_gui_input)
+	_update_visual()
+	if is_instance_valid(cooldown_overlay):
+		cooldown_overlay.visible = false
+	if is_instance_valid(label):
+		label.text = "1" if slot_kind == "primary" else "2"
+
+
+func _process(delta: float) -> void:
+	# Tick the cooldown overlay. Server-authoritative duration arrives via
+	# the swap_cooldown_started signal handler below.
+	if _cooldown_timer > 0.0:
+		_cooldown_timer = maxf(0.0, _cooldown_timer - delta)
+		if is_instance_valid(cooldown_overlay):
+			cooldown_overlay.color.a = clampf(0.55 * (_cooldown_timer / max(_cooldown_total, 0.01)), 0.0, 0.55)
+			cooldown_overlay.visible = _cooldown_timer > 0.0
+
+	if _flash_remaining > 0.0:
+		_flash_remaining = maxf(0.0, _flash_remaining - delta)
+		if _flash_remaining <= 0.0:
+			_update_visual()
+
+
+## Called by Hotbar parent when the active weapon flips.
+func set_active(is_active: bool) -> void:
+	if is_active == _active:
+		return
+	_active = is_active
+	_update_visual()
+	# Play a flash to draw the eye on every state change.
+	flash()
+
+
+## Sets the displayed weapon icon. `null` clears to an "empty" look.
+func set_weapon_item(item: ItemData) -> void:
+	if is_instance_valid(icon_rect):
+		icon_rect.texture = item.icon if item else null
+		icon_rect.visible = item != null
+
+
+## Starts the radial cooldown overlay. Server-authoritative duration.
+func start_swap_cooldown(duration: float) -> void:
+	if duration <= 0.0:
+		return
+	_cooldown_total = duration
+	_cooldown_timer = duration
+	if is_instance_valid(cooldown_overlay):
+		cooldown_overlay.visible = true
+
+
+## Brief tint flash drawing the eye to the swap.
+func flash() -> void:
+	_flash_remaining = FLASH_DURATION
+	modulate = FLASH_COLOR
+
+
+## Visual ping for a denied attempt (e.g. empty secondary). Reuses the flash
+## with a redder tint so it reads as "denied".
+func flash_denied() -> void:
+	_flash_remaining = FLASH_DURATION * 2.0
+	modulate = Color(1.5, 0.5, 0.5, 1.0)
+
+
+func _update_visual() -> void:
+	if _active:
+		modulate = ACTIVE_MODULATE
+	else:
+		modulate = INACTIVE_MODULATE
+
+	var style: StyleBoxFlat = get_theme_stylebox("panel").duplicate() as StyleBoxFlat
+	if style:
+		style.border_color = ACTIVE_BORDER_COLOR if _active else INACTIVE_BORDER_COLOR
+		add_theme_stylebox_override("panel", style)
+
+
+func _on_gui_input(event: InputEvent) -> void:
+	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT and event.pressed:
+		# Click-to-swap only on the inactive slot. Active-slot clicks no-op.
+		if not _active:
+			click_to_swap_requested.emit(slot_kind)

--- a/scripts/UI/hotbar_weapon_slot.gd.uid
+++ b/scripts/UI/hotbar_weapon_slot.gd.uid
@@ -1,0 +1,1 @@
+uid://blld8vtkc6gln


### PR DESCRIPTION
## Summary

Third PR in the **[weapon-identity-overhaul](memory/project_weapon_identity_overhaul.md)** initiative. Stacks on **#156 (PR 2 — Mastery infrastructure)**. Delivers the "I am my weapon" UX locked in during the 2026-05-26 grill session.

Players carry **two weapons (primary + secondary)**, cycle between them with **Tab** (1.5s cooldown), the **sprite swaps** with the equipped weapon's discipline, the **hotbar shows both weapon icons side-by-side** with active highlight + click-to-swap, and **each weapon has its own independent hotbar ability bindings** (ESO model). Mid-combat swap is free; cooldowns on the swapped-out weapon's abilities keep ticking.

⚠️ **Big change** — affects equipment, combat, ability hotbar, input, and stats wiring. Requires PR 1 + PR 2 as base. Stacks behind them.

## Backend impact

**Zero.** The new `secondary_weapon` slot piggybacks on the existing `equipment` table's free-form `slot_type` string column — `"secondary_weapon"` is just a new value, no schema change. Both `primary_hotbar_bindings` and `secondary_hotbar_bindings` ride in the existing `character_data` JSONB.

## What changed

**Architecture:**
- `EquipmentComponent` gains a `secondary_weapon` slot (sixth equipment slot). `active_weapon` enum tracks which is currently active. `active_weapon_data` accessor returns the currently-equipped weapon's data.
- New RPC `request_weapon_swap_server` on the player controller. Client → server intent. Server validates (cooldown clear, secondary occupied, not dead) and broadcasts. Swap cooldown: 1.5s tunable constant.
- `combat.gd._get_class_attack_stat()` → renamed `_get_weapon_attack_stat()`. Now reads `active_weapon_data.weapon_type` instead of the class component: Staff/Wand → MAGICATTACK, everything else → WEAPONATTACK.
- `AbilityComponent` stores `primary_hotbar_bindings` + `secondary_hotbar_bindings` (two independent arrays). On swap, the active array switches and the hotbar visually re-renders.

**UX:**
- Input action `Weapon Swap Loadout` bound to **Tab** in `project.godot`.
- Hotbar extended with two weapon-icon widgets at the left, side-by-side. Active weapon highlighted; inactive dimmer. Click-to-swap on inactive. Swap cooldown renders as a radial overlay on both icons during the 1.5s window.
- Brief flash effect on the hotbar (~100ms tint) on each swap.
- Sprite swap on weapon equip change — uses `WeaponDisciplineData.sprite_frames` to pick the right discipline sprite.
- **Transition FX:** `MiniDarkElves/Starfall-Sheet.png` (11 frames @ 32×32). Spawns at the player on swap, plays over ~0.25s, sprite swap happens at frame 3 (visual peak). Input blocked for the full transition.

**Edge cases:**
- Empty secondary slot allowed; Tab press with empty secondary plays denied-sound + flashes empty slot.
- Loadout management via the existing Equipment UI (extended with the new slot).
- On death/respawn: active weapon stays whichever was active at death; cooldown clears.
- Mastery XP attribution: routed to active weapon at moment of kill/cast (PR 2's `_active_weapon_discipline()` helper now reads from `active_weapon_data`).
- Cooldowns on swap-OUT weapon's abilities keep ticking — pre-cast / swap-out / swap-back pattern works as intended.

## Notable agent decisions

- **Per-player input lock** during transition (instead of `InputManager` global lock), so the host player isn't accidentally frozen when a remote player swaps.
- **Save trigger on swap** goes through the `"inventory"` save bucket (since `"equipment"` save was a no-op and `InventoryComponent.save_inventory` already round-trips the full equipment state including `active_weapon`).
- **Stats filter:** new `EquipmentComponent.get_stat_contributing_slot_data()` excludes the inactive weapon's `bonus_stats` so they don't double-up while the secondary is "carried but not equipped."
- **Per-weapon attack speed:** `attack.gd` reads through `active_weapon_data.weapon_attack_speed`, so a fast secondary takes effect immediately.
- **`sync_all_abilities_batch` extended** to broadcast BOTH binding arrays on map change / re-spawn / spectate sync. Defaulted for legacy clients.

## Known limitations / followups

- **Bot weapon-swap parity is intentionally NOT in this PR** — flagged as **PR 3.5** in the overhaul roadmap memory. Bots remain single-weapon one-trick ponies relative to players until PR 3.5 lands. Recommended approach: partial parity (2-loadout chosen by AI archetype, swap on OOM / range mismatch, no full mid-combat cooldown swap).
- `_calculate_max_range` STR/DEX/INT/LUK primary/secondary lookup still uses `class_component.current_class` for the stat-multiplier formula. The brief only required the WEAPONATTACK/MAGICATTACK rework; deeper combat-formula primary-stat-driven-by-weapon work is a candidate for a later refinement.
- Transition FX timing (sprite swap at frame 3 / ~0.068s) is calibrated; may need an eyeball tuning pass.
- Hotbar layout offsets (±325) may need a 1080p/720p layout pass.
- Per-weapon bindings on a remote client viewing me: my friend's copy of my `AbilityComponent` runs the swap handler but their UI doesn't have my actual bindings (owner-only data); harmless but the code path runs.

## Test plan

- [ ] Project parses, no GDScript errors
- [ ] New character spawns with primary weapon equipped, secondary slot empty
- [ ] Tab key with empty secondary → denied feedback (sound + slot flash), no state change
- [ ] Equip a second weapon → Tab key swaps actively
- [ ] Swap cooldown (~1.5s) prevents spam — second Tab within window is no-op
- [ ] Sprite changes to match the new active weapon's discipline
- [ ] Transition FX plays (~0.25s puff/burst over the player)
- [ ] Hotbar shows both weapon icons; active highlighted; inactive dimmer
- [ ] Click on inactive weapon icon swaps (alternative to Tab)
- [ ] Hotbar abilities re-render after swap (different bindings per weapon)
- [ ] Bind Slash Blast to slot 1 on sword + Strafe to slot 1 on bow → both persist independently across swaps
- [ ] Stats damage channel correct: Staff equipped → MAGICATTACK; Sword/Bow/Dagger → WEAPONATTACK
- [ ] Active weapon's stat_bonuses contribute; inactive weapon's bonus_stats do NOT
- [ ] Mastery XP gain on kill goes to the active weapon's discipline
- [ ] Save / load round-trip: both weapons persist, active flag persists, per-weapon hotbar bindings persist
- [ ] Death → respawn: active weapon stays as it was at death; cooldown clears
- [ ] Map change / portal: active state and bindings survive
- [ ] Bots fight normally (single-weapon — known asymmetry, PR 3.5 will address)

🤖 Generated with [Claude Code](https://claude.com/claude-code)