### PR TITLE
[BIG] PR 4/12: Ability window per-discipline overhaul — tabs + per-weapon point pools

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -31,6 +31,18 @@ through `scripts/Networking/network_manager.gd`.
   as quests. On the wire, the save/load endpoints flatten this into two
   top-level keys (`pets`, `summoned_pet_ids`) to match Godot's existing save
   shape — see `multiplayer_controller_v2.get_save_data` and `PetManager.load_pets`.
+- `Player.weapon_mastery` (PR 2) is a **JSONB blob** keyed by lowercase
+  discipline name: `{sword: {level, xp}, bow: {level, xp}, staff: {level, xp},
+  dagger: {level, xp}}`. NULL on legacy rows; Godot's `WeaponMasteryComponent`
+  initializes missing keys to `{level: 0, xp: 0}` on load.
+- `Player.ability_points_per_discipline` (PR 4) is a **JSONB blob** keyed by
+  the same lowercase discipline names, values are int pools:
+  `{sword: 12, bow: 3, staff: 0, dagger: 0}`. The legacy `Player.ability_points`
+  int column is still populated as `sum(values)` for one release as a
+  fallback safety net but should not be read for spending decisions — the
+  authoritative pools live in the JSONB column. NULL on legacy rows; the
+  save handler distributes the legacy int evenly into all four pools (with
+  remainder going to the player's starting discipline) on first save.
 
 ## Conventions
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -54,7 +54,20 @@ class Player(db.Model):
     last_map = db.Column(db.String(255), default="town")
     party_id = db.Column(db.Integer, default=-1)
     monies = db.Column(db.Integer, default=0)
+    # Legacy single-pool ability points. PR 4 replaced this with
+    # `ability_points_per_discipline` (a JSONB dict keyed by lowercase weapon
+    # discipline -- "sword" / "bow" / "staff" / "dagger"). The legacy column
+    # stays populated as `sum(values)` for one release so older clients /
+    # tools that still read it stay coherent. A later PR can drop it once
+    # we're confident the new column round-trips reliably.
     ability_points = db.Column(db.Integer, default=0)
+    # PR 4: per-weapon-discipline ability point pools. Dict shape:
+    # `{"sword": <int>, "bow": <int>, "staff": <int>, "dagger": <int>}`.
+    # NULL means "never persisted in the new shape" -- the load handler then
+    # falls back to evenly distributing the legacy `ability_points` int across
+    # the four disciplines on the Godot side (with the remainder going to the
+    # character's starting discipline).
+    ability_points_per_discipline = db.Column(JSONB, nullable=True)
     # QuestManager.save_quests blob: {active, completed, onboarded}. Stored as a
     # single JSONB column since quests are only ever read/written wholesale per
     # character — no piecemeal queries — and the schema evolves freely on the
@@ -419,8 +432,13 @@ def load_player():
         ability_levels = {ab.ability_id: ab.level for ab in player.abilities}
         hotbar_config = {str(hb.slot_index): hb.ability_id for hb in player.hotbar}
         
+        # PR 4: emit the per-discipline pool dict. Godot's load_abilities
+        # migrates an empty/missing dict by evenly distributing the legacy
+        # `available_points` int across the four disciplines. We also keep
+        # the legacy key on the wire as a safety fallback for one release.
         response_data['abilities'] = {
             'available_points': player.ability_points if player.ability_points is not None else 0,
+            'available_points_per_discipline': player.ability_points_per_discipline or {},
             'ability_levels': ability_levels,
             'hotbar_config': hotbar_config
         }
@@ -590,9 +608,34 @@ def save_player():
         if 'abilities' in data:
             ab_data = data['abilities']
 
-            # Save ability points
-            if 'available_points' in ab_data:
-                player.ability_points = ab_data['available_points']
+            # Save ability points. PR 4: prefer the per-discipline dict; the
+            # legacy single-int `available_points` is written through as
+            # `sum(values)` for one release as a safety fallback. If only the
+            # legacy key is present (older clients pre-rollout, or a partial
+            # save written before the migration ran), distribute it evenly
+            # into the JSONB dict so the next load round-trips cleanly.
+            if 'available_points_per_discipline' in ab_data:
+                per_disc = ab_data.get('available_points_per_discipline') or {}
+                # Coerce to ints defensively -- JSON ints can arrive as floats.
+                per_disc = {str(k): int(v) for k, v in per_disc.items() if v is not None}
+                player.ability_points_per_discipline = per_disc
+                player.ability_points = sum(per_disc.values())
+            elif 'available_points' in ab_data:
+                legacy_total = int(ab_data['available_points'] or 0)
+                player.ability_points = legacy_total
+                # Server-side migration safety net: split the legacy int evenly
+                # across the four disciplines so the next load already has the
+                # new shape persisted. Remainder goes to "sword" -- the Godot
+                # client overrides this on the very next save with its own
+                # starting-discipline-weighted distribution.
+                base = legacy_total // 4
+                remainder = legacy_total - (base * 4)
+                player.ability_points_per_discipline = {
+                    "sword": base + remainder,
+                    "bow": base,
+                    "staff": base,
+                    "dagger": base,
+                }
 
             # Smart sync abilities
             incoming_abilities = ab_data.get('ability_levels', {})
@@ -709,6 +752,11 @@ def _run_migrations():
         # PR 2 of the weapon-identity-overhaul: per-discipline mastery.
         # Shape is {sword: {level, xp}, bow: {...}, staff: {...}, dagger: {...}}.
         ("players", "weapon_mastery", "ALTER TABLE players ADD COLUMN weapon_mastery JSONB"),
+        # PR 4: per-weapon-discipline ability-point pools (Sword / Bow /
+        # Staff / Dagger). Replaces the single-pool `ability_points` int,
+        # which stays populated as a fallback for one release.
+        ("players", "ability_points_per_discipline",
+         "ALTER TABLE players ADD COLUMN ability_points_per_discipline JSONB"),
     ]
     for table, column, sql in migrations:
         try:

--- a/scenes/UI/abilities_window.tscn
+++ b/scenes/UI/abilities_window.tscn
@@ -115,6 +115,18 @@ focus_mode = 0
 text = "X"
 flat = true
 
+[node name="DisciplineTabBar" type="TabBar" parent="MarginContainer/VBoxContainer"]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(0, 32)
+layout_mode = 2
+theme_override_fonts/font = ExtResource("3_702f5")
+theme_override_font_sizes/font_size = 14
+tab_count = 4
+tab_0/title = "Sword"
+tab_1/title = "Bow"
+tab_2/title = "Staff"
+tab_3/title = "Dagger"
+
 [node name="HSplitContainer" type="HSplitContainer" parent="MarginContainer/VBoxContainer"]
 layout_mode = 2
 size_flags_vertical = 3

--- a/scripts/Components/CLAUDE.md
+++ b/scripts/Components/CLAUDE.md
@@ -15,11 +15,23 @@ Player (MultiplayerPlayerV2)
     ├── Mana       mana.gd        - MP, regen, consumption
     ├── Stats      stats.gd       - STR/DEX/INT/LUCK/... aggregates ALL bonuses
     ├── Combat     combat.gd      - hitboxes, damage calc, crit
-    ├── Ability    ability.gd     - learn/level/use abilities, cooldowns, passives
+    ├── Ability    ability.gd     - learn/level/use abilities, cooldowns, passives.
+    │                               Ability points are PER-DISCIPLINE (PR 4 — see
+    │                               available_points_per_discipline dict; level-up
+    │                               grants 3 to the active weapon's discipline).
+    ├── WeaponMastery weapon_mastery.gd - Per-discipline mastery levels + XP (PR 2)
+    │                                     mastery_data: {sword/bow/staff/dagger →
+    │                                     {level, xp}}. Drives STR/DEX/INT/LUK
+    │                                     scaling additively on top of class-level.
     ├── Buff       buff.gd        - timed buffs/debuffs, stacking, custom logic
-    ├── Class      class.gd       - current class, per-level sprites
+    ├── Class      class.gd       - current_class = STARTING discipline (does NOT
+    │                               change on weapon swap). Drives HP/MP curves.
+    │                               For "what am I wielding right now", use
+    │                               MultiplayerPlayerV2.get_active_discipline().
     ├── Leveling   level.gd       - experience and level-ups
-    ├── Equipment  equipment.gd   - 5 slots: head/chest/legs/feet/weapon
+    ├── Equipment  equipment.gd   - 6 slots after PR 3: head/chest/legs/feet/weapon
+    │                               + secondary_weapon. active_weapon tracks which
+    │                               weapon is current. Swap via request_weapon_swap_server.
     └── Inventory  inventory.gd   - item slots, stacking, drag-and-drop
 ```
 

--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -11,7 +11,16 @@ signal ability_used(ability_id: String)
 signal cooldown_started(ability_id: String, duration: float)
 signal ability_leveled_up(ability_id: String, new_level: int)
 signal ability_learned(ability_id: String)
-signal ability_points_changed(new_total: int)
+## PR 4: ability points are pooled per-weapon-discipline. The signal
+## carries the affected discipline ("sword" / "bow" / "staff" / "dagger")
+## and the new total for that discipline only. UI consumers should refresh
+## the matching tab; existing "mark data dirty" callbacks ignore the args
+## and just re-save.
+signal ability_points_changed(discipline_key: String, new_total: int)
+## PR 4: fired when a spend was denied because the discipline pool was
+## empty (or the ability is not bound to any tier-1 discipline). The
+## AbilityWindow uses this to surface a UI ping.
+signal ability_points_spend_denied(ability_id: String, reason: String)
 #endregion
 
 
@@ -54,8 +63,28 @@ var _weapon_mastery_component: WeaponMasteryComponent
 # State variables
 var _cooldowns: Dictionary = {} # { ability_id: time_remaining }
 var _ability_levels: Dictionary = {} # { ability_id: current_level }
-var _available_ability_points: int = 0
+## PR 4: per-weapon-discipline ability point pools. Keys are the lowercase
+## discipline strings ("sword" / "bow" / "staff" / "dagger"); values are
+## ints. Replaces the legacy single-pool `_available_ability_points: int`.
+## Save migration in `load_abilities` redistributes the legacy int evenly
+## across the four pools, with the remainder going to the player's
+## starting discipline.
+var _available_points_per_discipline: Dictionary = {
+	"sword": 0,
+	"bow": 0,
+	"staff": 0,
+	"dagger": 0,
+}
 var _loading_mode: bool = false
+
+## PR 4: how many ability points each level-up grants. Awarded entirely to
+## the active weapon's discipline pool (the discipline the player is
+## wielding at the moment the level-up signal fires).
+const ABILITY_POINTS_PER_LEVEL: int = 3
+
+## PR 4: canonical lowercase discipline keys, in display order (the order
+## the AbilityWindow renders tabs).
+const DISCIPLINE_KEYS: Array[String] = ["sword", "bow", "staff", "dagger"]
 
 # PR 3: per-weapon hotbar bindings (Option A — ESO model).
 # Each weapon carries its own independent hotbar layout. Bind Slash Blast to
@@ -256,6 +285,59 @@ func try_trigger_procs(event_type: String, target: Node = null, context: Diction
 ## Helper to check if we're a client in a multiplayer session
 func _is_multiplayer_client() -> bool:
 	return multiplayer.has_multiplayer_peer() and not multiplayer.is_server()
+
+
+## PR 4: returns the lowercase discipline key for an ability based on its
+## `required_class[0]`. Maps SWORD/CRUSADER -> "sword", BOW/RANGER ->
+## "bow", STAFF/ARCHMAGE -> "staff", DAGGER/ASSASSIN -> "dagger". Returns
+## "" for abilities without a `required_class` entry; those become
+## unspendable per the locked design ("every ability belongs to a weapon
+## tree"). Authors should fix any flagged ability instead of relying on
+## a fallback bucket.
+func _ability_primary_discipline(ability: AbilityData) -> String:
+	if ability == null:
+		return ""
+	if ability.required_class == null or ability.required_class.is_empty():
+		return ""
+	return _class_type_to_discipline_key(ability.required_class[0])
+
+
+## Maps a `Constants.ClassType` enum value (tier-1 starting discipline OR
+## tier-2 advancement) to the lowercase discipline key the per-pool dict
+## uses. Returns "" for BEGINNER (no tree).
+func _class_type_to_discipline_key(class_type: int) -> String:
+	match class_type:
+		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
+			return "sword"
+		Constants.ClassType.BOW, Constants.ClassType.RANGER:
+			return "bow"
+		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
+			return "staff"
+		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
+			return "dagger"
+	return ""
+
+
+## Returns the discipline key the player is *currently wielding* - driven
+## by the active weapon, not the starting class. Falls back to "" when no
+## weapon is equipped (callers can substitute the starting discipline).
+func _active_discipline_key() -> String:
+	if not is_instance_valid(owner):
+		return ""
+	if owner.has_method("get_active_discipline"):
+		var disc: int = owner.get_active_discipline()
+		return _class_type_to_discipline_key(disc)
+	return ""
+
+
+## Returns the discipline key for the player's starting class - used as a
+## fallback when the active weapon can't supply one (e.g. unequipped at
+## first level-up after creation) and as the "remainder" target for the
+## legacy-save even-distribute migration.
+func _starting_discipline_key() -> String:
+	if is_instance_valid(_class_component):
+		return _class_type_to_discipline_key(_class_component.current_class)
+	return ""
 
 
 ## Helper function to iterate through all learned passive abilities
@@ -493,27 +575,47 @@ func _trigger_ability_state_change(ability: AbilityData, level_stats: AbilityLev
 func _level_up_ability_local(ability_id: String) -> bool:
 	if not can_level_up_ability(ability_id):
 		##print("Validation failed for leveling up ability: %s." % ability_id)
+		# PR 4: surface a precise denial reason for the AbilityWindow to ping.
+		var ability_for_reason: AbilityData = ResourceManager.get_ability_data(ability_id)
+		if ability_for_reason:
+			var denial_key: String = _ability_primary_discipline(ability_for_reason)
+			if denial_key == "":
+				ability_points_spend_denied.emit(ability_id, "no_discipline")
+			elif int(_available_points_per_discipline.get(denial_key, 0)) <= 0:
+				ability_points_spend_denied.emit(ability_id, "no_points")
+			else:
+				ability_points_spend_denied.emit(ability_id, "blocked")
 		return false
 
 	var ability = ResourceManager.get_ability_data(ability_id)
 	var current_level = _ability_levels[ability_id]
-	
-	_available_ability_points -= 1
+
+	# PR 4: spend one point from the discipline pool that owns this ability.
+	# `can_level_up_ability` already validated the pool; we re-derive the key
+	# here rather than trust the caller.
+	var disc_key: String = _ability_primary_discipline(ability)
+	if disc_key != "" and _available_points_per_discipline.has(disc_key):
+		_available_points_per_discipline[disc_key] = max(0, int(_available_points_per_discipline[disc_key]) - 1)
 	_ability_levels[ability_id] = current_level + 1
-	
+
 	# Re-apply passive effects if a passive ability was leveled up
 	if ability.ability_type == Constants.AbilityType.PASSIVE:
 		_apply_passive_effects()
 
 	ability_leveled_up.emit(ability_id, current_level + 1)
 	##print("Leveled up %s to level %d" % [ability.ability_name, current_level + 1])
-	
+
+	# PR 4: fire the per-discipline points-changed signal so the right tab
+	# refreshes.
+	if disc_key != "":
+		ability_points_changed.emit(disc_key, int(_available_points_per_discipline.get(disc_key, 0)))
+
 	# Sync changes to clients (bots have no client UI — skip to avoid a
 	# node-addressed RPC failing on clients that lack the bot node).
 	if multiplayer.is_server() and not BotManager.is_bot(owner.player_id):
 		sync_ability_level.rpc(ability_id, current_level + 1)
-		sync_ability_points.rpc(_available_ability_points)
-	
+		sync_ability_points_per_discipline.rpc(_available_points_per_discipline.duplicate())
+
 	return true
 
 
@@ -547,14 +649,23 @@ func _apply_passive_effects() -> void:
 		_stats_component.mark_stats_dirty()
 
 
-## Adds ability points, typically called after leveling up.
-func _add_ability_points(amount: int) -> void:
-	_available_ability_points += amount
-	##print("Added %d ability points. Total: %d" % [amount, _available_ability_points])
-	ability_points_changed.emit(_available_ability_points)
+## PR 4: grants ability points to a specific weapon-discipline pool.
+## `discipline_key` is one of "sword" / "bow" / "staff" / "dagger". An
+## empty or unknown key falls back to the player's starting-class
+## discipline so level-ups never silently lose points.
+func _add_ability_points(amount: int, discipline_key: String = "") -> void:
+	var key: String = discipline_key
+	if key == "" or not _available_points_per_discipline.has(key):
+		key = _starting_discipline_key()
+	if key == "":
+		push_warning("AbilityComponent: no discipline available to credit %d points to" % amount)
+		return
+	_available_points_per_discipline[key] = int(_available_points_per_discipline.get(key, 0)) + amount
+	##print("Added %d ability points to %s. Total: %d" % [amount, key, _available_points_per_discipline[key]])
+	ability_points_changed.emit(key, int(_available_points_per_discipline[key]))
 
 	if multiplayer.is_server() and not BotManager.is_bot(owner.player_id):
-		sync_ability_points.rpc(_available_ability_points)
+		sync_ability_points_per_discipline.rpc(_available_points_per_discipline.duplicate())
 
 
 func _execute_proc(proc: ProcEffectData, target: Node, context: Dictionary) -> void:
@@ -699,7 +810,7 @@ func sync_all_abilities_to_client(peer_id: int) -> void:
 	sync_all_abilities_batch.rpc_id(
 		peer_id,
 		_ability_levels.duplicate(),
-		_available_ability_points,
+		_available_points_per_discipline.duplicate(),
 		live_config,
 		_cooldowns.duplicate(),
 		_primary_hotbar_bindings.duplicate(),
@@ -708,9 +819,12 @@ func sync_all_abilities_to_client(peer_id: int) -> void:
 
 
 @rpc("authority", "call_local", "reliable")
+## PR 4: `ability_points` is now a per-discipline Dictionary, not an int.
+## Older clients that still send an int will be normalized via the
+## migration helper so the round-trip stays safe through the rollout.
 func sync_all_abilities_batch(
 		abilities: Dictionary,
-		ability_points: int,
+		ability_points,
 		hotbar_config: Dictionary = {},
 		cooldowns: Dictionary = {},
 		primary_bindings: Dictionary = {},
@@ -721,8 +835,9 @@ func sync_all_abilities_batch(
 	for ability_id in abilities:
 		_ability_levels[ability_id] = abilities[ability_id]
 		ability_learned.emit(ability_id)
-	_available_ability_points = ability_points
-	ability_points_changed.emit(_available_ability_points)
+	_apply_per_discipline_payload(ability_points)
+	for key in DISCIPLINE_KEYS:
+		ability_points_changed.emit(key, int(_available_points_per_discipline.get(key, 0)))
 
 	# PR 3: restore both binding arrays so the inactive weapon's bindings
 	# survive client-side swaps until the next save round-trip.
@@ -824,22 +939,30 @@ func sync_ability_learned(ability_id: String, initial_level: int) -> void:
 
 
 @rpc("authority", "reliable")
-## [Server->Client] Syncs the total available ability points to all clients.
-func sync_ability_points(new_total: int) -> void:
+## [Server->Client] PR 4: syncs the per-weapon-discipline ability point pools
+## to all clients. Replaces the legacy `sync_ability_points` int RPC.
+func sync_ability_points_per_discipline(new_pools) -> void:
 	# This RPC should only be processed by clients, not the server that sent it.
 	if multiplayer.is_server(): return
-	
-	_available_ability_points = new_total
-	ability_points_changed.emit(_available_ability_points)
+
+	_apply_per_discipline_payload(new_pools)
+	for key in DISCIPLINE_KEYS:
+		ability_points_changed.emit(key, int(_available_points_per_discipline.get(key, 0)))
 #endregion
 
 
 #region #################### Signal Callbacks ####################
 ## Called when the LevelingComponent emits the `leveled_up` signal.
+## PR 4: points are granted to the discipline the player is *currently
+## wielding*. Mainline a sword -> sword gets the points. Mid-fight swap to
+## a bow then level -> bow gets them. Falls back to the starting
+## discipline when no weapon is equipped.
 func _on_leveled_up(_new_level: int) -> void:
-	# Grant 3 ability points on level up
-	#print("Leveled up to %d. Gaining 3 ability points." % new_level)
-	_add_ability_points(3)
+	var key: String = _active_discipline_key()
+	if key == "":
+		key = _starting_discipline_key()
+	#print("Leveled up to %d. Gaining %d ability points to %s." % [new_level, ABILITY_POINTS_PER_LEVEL, key])
+	_add_ability_points(ABILITY_POINTS_PER_LEVEL, key)
 
 
 func _on_class_changed(_new_class_name: String) -> void:
@@ -882,9 +1005,22 @@ func save_abilities() -> Dictionary:
 	# Sync the live binding back into the per-weapon dict so the save reflects
 	# any edits the player made since the last swap.
 	_capture_active_bindings(live_config)
+	# PR 4: defensively normalize int values (in case a level-up's max(0, ...)
+	# or similar accidentally stored a float). Sum the pools for the legacy
+	# fallback column on the backend.
+	var per_disc_copy: Dictionary = {}
+	var legacy_total: int = 0
+	for key in _available_points_per_discipline:
+		var v: int = int(_available_points_per_discipline[key])
+		per_disc_copy[key] = v
+		legacy_total += v
 	return {
 		"ability_levels": _ability_levels.duplicate(),
-		"available_points": _available_ability_points,
+		# PR 4: legacy fallback (sum of per-discipline pools). Kept populated
+		# for one release so the backend's legacy `ability_points` column
+		# stays useful if the new JSONB column is somehow missing.
+		"available_points": legacy_total,
+		"available_points_per_discipline": per_disc_copy,
 		# Legacy compatibility: keep `hotbar_config` writing the active set so
 		# older clients / tools that read it still see a coherent layout.
 		"hotbar_config": live_config,
@@ -909,7 +1045,9 @@ func load_abilities(data: Dictionary) -> void:
 	for ability_id in saved_levels:
 		_ability_levels[ability_id] = saved_levels[ability_id]
 
-	_available_ability_points = data.get("available_points", 0)
+	# PR 4: per-discipline pool migration. Defers to a helper so the priority
+	# order (new dict > legacy int > zeros) is documented in one place.
+	_load_ability_points_with_migration(data)
 
 	# PR 3: restore both binding arrays. Legacy saves that only have
 	# `hotbar_config` populate the primary binding so a returning character
@@ -936,7 +1074,10 @@ func load_abilities(data: Dictionary) -> void:
 	# Re-apply passives and update UI with loaded data
 	_apply_passive_effects()
 	if not _loading_mode:
-		ability_points_changed.emit(_available_ability_points)
+		# PR 4: fire one signal per discipline so the AbilityWindow's per-tab
+		# labels refresh.
+		for key in DISCIPLINE_KEYS:
+			ability_points_changed.emit(key, int(_available_points_per_discipline.get(key, 0)))
 		for ability_id in _ability_levels:
 			var level = _ability_levels[ability_id]
 			if level > 0:
@@ -1024,8 +1165,27 @@ func get_ability_level(ability_id: String) -> int:
 	return _ability_levels.get(ability_id, 0)
 
 
+## PR 4: returns the sum of all per-discipline pools. Preserved for bot
+## auto-spend logic and any caller that just needs "do I have any points at
+## all?". UI consumers should prefer `get_available_points_for_discipline`.
 func get_available_ability_points() -> int:
-	return _available_ability_points
+	var total: int = 0
+	for key in _available_points_per_discipline:
+		total += int(_available_points_per_discipline.get(key, 0))
+	return total
+
+
+## PR 4: returns the available points in a specific discipline pool.
+## `discipline_key` is one of "sword" / "bow" / "staff" / "dagger".
+## Returns 0 for unknown keys.
+func get_available_points_for_discipline(discipline_key: String) -> int:
+	return int(_available_points_per_discipline.get(discipline_key, 0))
+
+
+## PR 4: returns a copy of the full per-discipline pool dictionary. UI uses
+## this to render the tab header counts.
+func get_available_points_per_discipline() -> Dictionary:
+	return _available_points_per_discipline.duplicate()
 
 
 func get_cooldown_remaining(ability_id: String) -> float:
@@ -1033,21 +1193,89 @@ func get_cooldown_remaining(ability_id: String) -> float:
 
 
 ## Checks if an ability meets all criteria to be leveled up.
+## PR 4: checks the discipline-specific pool, not the global total.
 func can_level_up_ability(ability_id: String) -> bool:
-	if _available_ability_points <= 0: return false
-	
 	var ability = ResourceManager.get_ability_data(ability_id)
 	if not ability: return false
-	
+
 	var current_level = get_ability_level(ability_id)
 	if current_level >= ability.max_level: return false
-	
+
 	# Check for prerequisite ability levels
 	if ability.prerequisite_abilities:
 		for prereq_id in ability.prerequisite_abilities:
 			var required_level = ability.prerequisite_abilities[prereq_id]
 			if get_ability_level(prereq_id.ability_id) < required_level:
 				return false
-	
+
+	# PR 4: every ability belongs to exactly one weapon discipline (read off
+	# `required_class[0]`). An ability with no discipline mapping is
+	# unspendable; that's an authoring bug. Surface it but don't crash.
+	var disc_key: String = _ability_primary_discipline(ability)
+	if disc_key == "":
+		push_warning("Ability '%s' has no required_class \u2014 cannot map to a discipline pool" % ability.ability_name)
+		return false
+	if int(_available_points_per_discipline.get(disc_key, 0)) <= 0:
+		return false
+
 	return true
+
+
+## PR 4: applies the legacy-save migration logic for ability points.
+##
+## Priority order:
+##   1. `available_points_per_discipline` (the new shape) - load verbatim,
+##      coercing values to ints and filling missing keys with 0.
+##   2. `available_points` (legacy int) - distribute evenly across the four
+##      pools, remainder to the starting discipline. Logs a warning so it's
+##      visible during testing.
+##   3. Neither - initialize all four pools to 0.
+func _load_ability_points_with_migration(data: Dictionary) -> void:
+	# Reset all pools to 0 - the dict-load case may not mention every key.
+	for key in DISCIPLINE_KEYS:
+		_available_points_per_discipline[key] = 0
+
+	if data.has("available_points_per_discipline"):
+		var saved_dict = data["available_points_per_discipline"]
+		if saved_dict is Dictionary and not saved_dict.is_empty():
+			for key in DISCIPLINE_KEYS:
+				_available_points_per_discipline[key] = int(saved_dict.get(key, 0))
+			return
+
+	if data.has("available_points"):
+		var legacy_total: int = int(data["available_points"])
+		if legacy_total > 0:
+			var base: int = legacy_total / 4
+			var remainder: int = legacy_total - (base * 4)
+			for key in DISCIPLINE_KEYS:
+				_available_points_per_discipline[key] = base
+			var starting_key: String = _starting_discipline_key()
+			if starting_key == "" or not _available_points_per_discipline.has(starting_key):
+				starting_key = "sword"
+			_available_points_per_discipline[starting_key] = base + remainder
+			push_warning("AbilityComponent: migrated legacy %d ability points \u2014 per-discipline pools (remainder %d to '%s')" % [legacy_total, remainder, starting_key])
+
+
+## PR 4: normalizes a per-discipline payload from save / RPC. Accepts
+## either the new Dictionary shape OR a legacy int (for cross-version
+## compatibility during the rollout) and writes the result into
+## `_available_points_per_discipline`. Does not emit signals; the caller
+## decides whether to fan-out per-discipline notifications.
+func _apply_per_discipline_payload(payload) -> void:
+	for key in DISCIPLINE_KEYS:
+		_available_points_per_discipline[key] = 0
+	if payload is Dictionary:
+		for key in DISCIPLINE_KEYS:
+			_available_points_per_discipline[key] = int(payload.get(key, 0))
+	elif payload is int or payload is float:
+		var legacy_total: int = int(payload)
+		if legacy_total > 0:
+			var base: int = legacy_total / 4
+			var remainder: int = legacy_total - (base * 4)
+			for key in DISCIPLINE_KEYS:
+				_available_points_per_discipline[key] = base
+			var starting_key: String = _starting_discipline_key()
+			if starting_key == "" or not _available_points_per_discipline.has(starting_key):
+				starting_key = "sword"
+			_available_points_per_discipline[starting_key] = base + remainder
 #endregion

--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -140,7 +140,10 @@ func get_characters():
 							"monies": 0,
 							"inventory": {},
 							"equipment": {},
-							"abilities": {"available_points": (starting_level - 1) * 3},
+							# PR 4: per-discipline ability-point pools. New chars get the
+						# full level-1->starting-level allotment in their starting
+						# discipline's pool; the other three start at zero.
+						"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_enum, starting_level)},
 							"buffs": {},
 							"quests": {}
 						}
@@ -243,7 +246,9 @@ func create_character(char_name, class_id):
 			"monies": 0,
 			"inventory": {},
 			"equipment": {},
-			"abilities": {"available_points": (starting_level - 1) * 3},
+			# PR 4: per-discipline ability-point pools. See dev-mode site for
+			# the helper that fills the starting discipline and zeros the rest.
+			"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_id, starting_level)},
 			"buffs": {},
 			"quests": {}
 		}
@@ -347,3 +352,43 @@ func _on_delete_character_completed(result, response_code, _headers, body, http,
 		character_deletion_failed.emit(err_msg)
 
 	http.queue_free()
+
+
+## PR 4: builds the starter per-discipline ability-point pool dict for a
+## newly-created character. The character's starting `class_id` discipline
+## receives the full `(starting_level - 1) * 3` allotment; the other three
+## tier-1 disciplines start at zero. Advanced classes (Crusader / Ranger /
+## Archmage / Assassin) map to their parent tier-1 discipline.
+func _starter_ability_point_pools(class_id: int, starting_level: int) -> Dictionary:
+	var total: int = max(0, (starting_level - 1) * 3)
+	var pools := {
+		"sword": 0,
+		"bow": 0,
+		"staff": 0,
+		"dagger": 0,
+	}
+	var key: String = _class_id_to_discipline_key(class_id)
+	if key == "":
+		# Beginner or unknown class -- credit the lump to sword so points
+		# never silently vanish. AbilityComponent's first-load migration
+		# will re-credit at the right discipline if it has better info.
+		key = "sword"
+	pools[key] = total
+	return pools
+
+
+## PR 4: maps a `Constants.ClassType` int (tier-1 starting OR tier-2
+## advancement) to the lowercase discipline key. Mirrors the helper in
+## `AbilityComponent` (kept duplicated here so this autoload doesn't have
+## to reach into a sibling node before the player exists).
+func _class_id_to_discipline_key(class_id: int) -> String:
+	match class_id:
+		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
+			return "sword"
+		Constants.ClassType.BOW, Constants.ClassType.RANGER:
+			return "bow"
+		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
+			return "staff"
+		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
+			return "dagger"
+	return ""

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -379,7 +379,7 @@ func _setup_signals() -> void:
 		
 	if ability_component:
 		ability_component.ability_leveled_up.connect(func(_a, _l): _data_changed("abilities"))
-		ability_component.ability_points_changed.connect(func(_p): _data_changed("abilities"))
+		ability_component.ability_points_changed.connect(func(_k, _p): _data_changed("abilities"))
 		ability_component.ability_learned.connect(func(_a): _data_changed("abilities"))
 
 	if inventory_component:

--- a/scripts/UI/ability_window.gd
+++ b/scripts/UI/ability_window.gd
@@ -17,6 +17,19 @@ const ABILITYSLOT = preload("res://scenes/UI/ability_slot.tscn")
 @onready var cost_label: Label = %CostLabel
 @onready var level_up_button: Button = %LevelUpButton
 @onready var skill_points_label: Label = %SkillPointsLabel
+## PR 4: TabBar above the list, one tab per weapon discipline. Selecting a
+## tab filters the ability list and switches the SP label to the matching
+## discipline pool.
+@onready var discipline_tab_bar: TabBar = %DisciplineTabBar
+
+## PR 4: discipline keys in tab order. Stays in lockstep with TabBar tab
+## indices set in `abilities_window.tscn`.
+const DISCIPLINE_TAB_KEYS: Array[String] = ["sword", "bow", "staff", "dagger"]
+const DISCIPLINE_TAB_TITLES: Array[String] = ["Sword", "Bow", "Staff", "Dagger"]
+
+## PR 4: which discipline tab is currently selected. Drives both the list
+## filter and the SP-label readout.
+var _current_discipline_key: String = "sword"
 
 var selected_ability_id: String = ""
 var player: MultiplayerPlayerV2
@@ -44,22 +57,36 @@ func _ready():
 	
 	# Connect signals
 	level_up_button.pressed.connect(on_level_up_button_pressed)
-	
+
+	# PR 4: discipline tab bar drives the list filter + SP label.
+	if is_instance_valid(discipline_tab_bar):
+		discipline_tab_bar.tab_selected.connect(_on_discipline_tab_selected)
+
 	# Connect to ability component signals
 	if ability_component:
 		ability_component.ability_leveled_up.connect(_on_ability_leveled_up)
 		ability_component.ability_learned.connect(_on_ability_learned)
+		# PR 4: signal now carries (discipline_key, new_total). The handler
+		# only refreshes the UI when the changed key matches the open tab.
 		ability_component.ability_points_changed.connect(_on_ability_points_changed)
+		# PR 4: surface a UI ping when a spend is denied (empty pool, etc).
+		if ability_component.has_signal("ability_points_spend_denied"):
+			ability_component.ability_points_spend_denied.connect(_on_ability_points_spend_denied)
 		##print("AbilityWindow: Connected to ability component signals")
-	
+
+	# PR 4: default the tab to the player's currently-active discipline so
+	# someone who just swapped to a bow opens the window directly on the Bow
+	# tab. Falls back to Sword on lookup failure.
+	_select_initial_discipline()
+
 	# Load UI
 	update_skill_points_display()
 	load_ability_list()
-	
+
 	# Select first ability if any exist
-	if ability_component and not ability_component._ability_levels.is_empty():
-		var first_ability_id = ability_component._ability_levels.keys()[0]
-		select_ability(first_ability_id)
+	var first_id_in_tab: String = _first_ability_id_in_current_tab()
+	if first_id_in_tab != "":
+		select_ability(first_id_in_tab)
 	else:
 		clear_details()
 
@@ -75,11 +102,20 @@ func _process(_delta: float) -> void:
 			elif not InputManager.is_locked():
 				self.visible = true
 				if self.visible:
+					# PR 4: re-default the tab to whichever discipline the
+					# player is currently wielding -- so swap-then-open keeps
+					# the open tab in sync with the visible weapon.
+					_select_initial_discipline()
 					# Refresh the display when opening
 					update_skill_points_display()
 					load_ability_list()
-					if selected_ability_id:
+					var first_id := _first_ability_id_in_current_tab()
+					if selected_ability_id != "" and _ability_in_current_tab(selected_ability_id):
 						select_ability(selected_ability_id)
+					elif first_id != "":
+						select_ability(first_id)
+					else:
+						clear_details()
 			
 	if is_dragging:
 		global_position = get_global_mouse_position() - drag_offset
@@ -105,26 +141,32 @@ func _gui_input(event: InputEvent) -> void:
 			is_dragging = false
 
 
-## Clears the list and generates AbilitySlot nodes for each ability
+## Clears the list and generates AbilitySlot nodes for each ability.
+## PR 4: filters to the currently-selected discipline tab so each tab only
+## shows the abilities that belong to it (via AbilityData.required_class[0]).
 func load_ability_list():
 	if not ability_component:
 		return
-		
+
 	for child in ability_list_container.get_children():
 		child.queue_free()
-	
-	# Get all abilities from the ability component
+
+	# Get all abilities from the ability component, filtered by the active tab.
 	for ability_id in ability_component._ability_levels.keys():
 		var ability_data = ResourceManager.get_ability_data(ability_id)
 		if not ability_data:
 			continue
-			
+
+		# PR 4: filter by the currently-selected discipline tab.
+		if _ability_discipline_key(ability_data) != _current_discipline_key:
+			continue
+
 		var current_level = ability_component._ability_levels[ability_id]
 		var slot = ABILITYSLOT.instantiate()
 		slot.setup(ability_data, current_level)
 		slot.ability_selected.connect(select_ability)
 		ability_list_container.add_child(slot)
-		
+
 		# Select first ability if none is selected
 		if selected_ability_id.is_empty():
 			select_ability(ability_id)
@@ -236,7 +278,11 @@ func update_details(data: AbilityData, current_level: int):
 
 		# Level Up Cost/Button Logic
 		var cost = 1
-		var available_points = ability_component.get_available_ability_points()
+		# PR 4: read the per-discipline pool for the ability we're showing,
+		# not the global sum. "Not Enough SP" should fire when the *owning*
+		# discipline's pool is empty even if other tabs have spare points.
+		var ability_disc_key: String = _ability_discipline_key(data)
+		var available_points: int = ability_component.get_available_points_for_discipline(ability_disc_key) if ability_disc_key != "" else 0
 		var can_level_up = ability_component.can_level_up_ability(data.ability_id)
 		
 		# Update button text based on current level
@@ -532,14 +578,17 @@ func on_level_up_button_pressed():
 	ability_component.level_up_ability(selected_ability_id)
 
 
-## Updates the SP display in the header
+## Updates the SP display in the header.
+## PR 4: reads the active discipline tab's pool, not the global total, so
+## the header reflects what the player can actually spend in this tab.
 func update_skill_points_display():
 	if not ability_component:
 		skill_points_label.text = "SP: 0"
 		return
-		
-	var points = ability_component.get_available_ability_points()
-	skill_points_label.text = "SP: %d" % points
+
+	var tab_label: String = _current_discipline_tab_title()
+	var points = ability_component.get_available_points_for_discipline(_current_discipline_key)
+	skill_points_label.text = "%s SP: %d" % [tab_label, points]
 
 
 ## Signal callback when ability levels up
@@ -567,16 +616,142 @@ func _on_ability_learned(ability_id: String):
 		select_ability(ability_id)
 
 
-## Signal callback when ability points change
-func _on_ability_points_changed(_new_total: int):
-	##print("AbilityWindow: Ability points changed to %d" % new_total)
-	
-	# Update skill points display
-	update_skill_points_display()
-	
+## PR 4: signal callback when ability points change for a single
+## discipline. Updates the header only when the changed discipline matches
+## the currently-open tab; refreshes button state regardless so the right
+## panel reflects the new pool.
+func _on_ability_points_changed(discipline_key: String, _new_total: int):
+	##print("AbilityWindow: %s points changed to %d" % [discipline_key, _new_total])
+
+	if discipline_key == _current_discipline_key:
+		update_skill_points_display()
+
 	# Refresh the details panel to update button state
 	if selected_ability_id:
 		var selected_data = ResourceManager.get_ability_data(selected_ability_id)
 		if selected_data:
 			var current_level = ability_component.get_ability_level(selected_ability_id)
 			update_details(selected_data, current_level)
+
+
+## PR 4: surface a denial when the player tries to spend a point with an
+## empty pool (or on an unmapped ability). Lightweight UI ping only --
+## the actual cost label is already painted red by `update_details`.
+func _on_ability_points_spend_denied(_ability_id: String, _reason: String) -> void:
+	# Trigger an unobtrusive UI feedback (color flash on cost label). The
+	# existing red-coloured "Not Enough SP" text covers the empty-pool case
+	# already; this is the hook for future audio/animation polish.
+	if is_instance_valid(cost_label):
+		var prior: Color = cost_label.get_theme_color("font_color")
+		cost_label.add_theme_color_override("font_color", Color(1, 0.3, 0.3))
+		await get_tree().create_timer(0.15).timeout
+		if is_instance_valid(cost_label):
+			cost_label.add_theme_color_override("font_color", prior)
+
+
+## PR 4: called by the TabBar when the player clicks a discipline tab.
+## Switches the filter + SP label, rebuilds the list, and auto-selects the
+## first ability in the new tab (if any).
+func _on_discipline_tab_selected(tab_index: int) -> void:
+	if tab_index < 0 or tab_index >= DISCIPLINE_TAB_KEYS.size():
+		return
+	_current_discipline_key = DISCIPLINE_TAB_KEYS[tab_index]
+	selected_ability_id = ""
+	update_skill_points_display()
+	load_ability_list()
+	var first_id := _first_ability_id_in_current_tab()
+	if first_id != "":
+		select_ability(first_id)
+	else:
+		clear_details()
+
+
+## PR 4: maps an AbilityData to its primary discipline key by reading
+## `required_class[0]`. Returns "" for abilities with no required_class --
+## those don't fit in any tab and are hidden from the list.
+func _ability_discipline_key(ability: AbilityData) -> String:
+	if ability == null:
+		return ""
+	if ability.required_class == null or ability.required_class.is_empty():
+		return ""
+	return _class_type_to_discipline_key(ability.required_class[0])
+
+
+## PR 4: maps a `Constants.ClassType` int (tier-1 or tier-2 advancement)
+## to the lowercase discipline key. Mirrors `AbilityComponent`'s helper
+## so the UI doesn't have to reach back across the component boundary.
+func _class_type_to_discipline_key(class_type: int) -> String:
+	match class_type:
+		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
+			return "sword"
+		Constants.ClassType.BOW, Constants.ClassType.RANGER:
+			return "bow"
+		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
+			return "staff"
+		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
+			return "dagger"
+	return ""
+
+
+## PR 4: returns true if the given ability ID belongs to the active tab.
+## Used on window-open to decide whether to keep the previously-selected
+## ability or auto-pick the first ability in the new tab.
+func _ability_in_current_tab(ability_id: String) -> bool:
+	if ability_id.is_empty():
+		return false
+	var ability_data: AbilityData = ResourceManager.get_ability_data(ability_id)
+	if ability_data == null:
+		return false
+	return _ability_discipline_key(ability_data) == _current_discipline_key
+
+
+## PR 4: returns the first known ability ID that belongs to the current
+## discipline tab. Used to auto-select on tab change / window open.
+func _first_ability_id_in_current_tab() -> String:
+	if not ability_component:
+		return ""
+	for ability_id in ability_component._ability_levels.keys():
+		var ability_data: AbilityData = ResourceManager.get_ability_data(ability_id)
+		if ability_data == null:
+			continue
+		if _ability_discipline_key(ability_data) == _current_discipline_key:
+			return ability_id
+	return ""
+
+
+## PR 4: defaults the open tab to the player's currently-wielded
+## discipline (driven by the equipped weapon, falling back to the
+## starting class). Called on _ready and again on window open.
+func _select_initial_discipline() -> void:
+	var key: String = _resolve_active_discipline_key()
+	var idx: int = DISCIPLINE_TAB_KEYS.find(key)
+	if idx < 0:
+		idx = 0
+	_current_discipline_key = DISCIPLINE_TAB_KEYS[idx]
+	if is_instance_valid(discipline_tab_bar):
+		discipline_tab_bar.current_tab = idx
+
+
+## PR 4: queries the player for its current active-discipline ClassType
+## and translates that to a lowercase tab key. Falls back to the starting
+## class when no weapon is equipped, then to "sword" on any failure.
+func _resolve_active_discipline_key() -> String:
+	if is_instance_valid(player):
+		if player.has_method("get_active_discipline"):
+			var disc: int = player.get_active_discipline()
+			var key: String = _class_type_to_discipline_key(disc)
+			if key != "":
+				return key
+		if is_instance_valid(player.class_component):
+			var key2: String = _class_type_to_discipline_key(player.class_component.current_class)
+			if key2 != "":
+				return key2
+	return "sword"
+
+
+## PR 4: tab title string for the current tab.
+func _current_discipline_tab_title() -> String:
+	var idx: int = DISCIPLINE_TAB_KEYS.find(_current_discipline_key)
+	if idx < 0:
+		return ""
+	return DISCIPLINE_TAB_TITLES[idx]


### PR DESCRIPTION
## Summary

Fourth PR in the **[weapon-identity-overhaul](memory/project_weapon_identity_overhaul.md)** initiative. Stacks on **#157 (PR 3 — Weapon swap UX)**. Inserts the ability-window restructure into the roadmap between PR 3.5 (deferred bot parity) and the PR 5+ signature systems.

Locked design from the user (2026-05-27):
- Every ability belongs to exactly one weapon discipline (no abilities outside weapon trees).
- Each discipline has its own ability-point pool.
- AbilityWindow surfaces this via a tabbed UI (Sword/Bow/Staff/Dagger).
- Level-up grants points to the active weapon's discipline.

⚠️ **Big change** — touches save format AND adds one backend column.

## Backend change (USER-APPROVED — Option A)

One new JSONB column on `Player`, same pattern PR 2 used for `weapon_mastery`:

```python
ability_points_per_discipline = db.Column(JSONB, nullable=True)
```

Auto-migration entry in `_run_migrations()` runs `ALTER TABLE players ADD COLUMN ability_points_per_discipline JSONB` at Flask startup. **Deployed databases upgrade themselves.** No manual SQL needed.

**Legacy `ability_points` int column kept populated as `sum(values)`** for one release as a safety fallback — anything still reading the legacy column gets a sensible total. A later PR can drop it once we're confident the new column round-trips.

## What changed

**Data model:**
- `AbilityComponent.available_points: int` → **`available_points_per_discipline: Dictionary`** (lowercase string keys: `"sword"`, `"bow"`, `"staff"`, `"dagger"`)
- Ability → discipline mapping derived from existing `AbilityData.required_class[0]` — **no new field on AbilityData**, just a read-side helper that maps ClassType → lowercase discipline string. Tier-2 advancement classes (Crusader/Ranger/Archmage/Assassin) map to their tier-1 parent's discipline.
- `level_up_ability(ability_id)` decrements the discipline's pool, rejects if empty.

**Level-up routing:**
- `LevelingComponent.leveled_up` → 3 points (constant `ABILITY_POINTS_PER_LEVEL`) to `player.get_active_discipline()` (helper from PR 3 fixup). Sword main level-ups feed sword; mid-fight swap to bow and level → bow.

**Save migration (Godot side):**
- Load: if `available_points_per_discipline` is present, load directly. Else if legacy `available_points` int is present, distribute evenly across 4 disciplines (remainder → starting class's discipline). Else initialize all 4 to 0. `push_warning` flags the migration so it's visible in editor output.
- Save: always writes the new dict; backend keeps legacy int column populated as `sum(values)`.

**Backend save handler safety net:**
- If a client ever sends the old shape (legacy int only), backend distributes evenly into the JSONB column on the spot, so the next read normalizes.

**UI — tabbed AbilityWindow:**
- New `DisciplineTabBar` (TabBar — lightweight; fits the existing two-pane layout without restructuring) with 4 tabs.
- Per-tab "Available points: N" display.
- Ability list filtered by discipline (via `_ability_primary_discipline` helper).
- Initial tab on open = currently active discipline.
- New `ability_points_spend_denied(ability_id, reason)` signal (`no_discipline` / `no_points` / `blocked`) drives a brief 150ms cost-label flash for spend-rejected feedback.

**dev_login save shape updated:**
- `network_manager.gd` dev-mode pre-seed and `create_character` now both write `available_points_per_discipline` via `_starter_ability_point_pools(class_id, starting_level)`. Starting-class's discipline gets `(starting_level - 1) * 3`; other three start at 0.

**RPC name change:**
- `sync_ability_points` → `sync_ability_points_per_discipline`. Payload normalizer in `_apply_per_discipline_payload` handles both forward (server new, client old) and backward (client new, server old) cross-version RPC traffic during rollout.

## Out of scope / deferred

- **Per-tab portrait icons** (`swordsman_portrait.tres` etc.) — text labels are fine for v1; portraits are cosmetic polish.
- **Visual skill-tree layout** (lines between prerequisite nodes) — flat list inside each tab for v1.
- **Signature combat systems** — PRs 5-8 territory.
- **Cleaning up the legacy `ability_points` int column** — kept as safety net for one release; drop in a future PR.

## Test plan

- [ ] Auto-migration runs cleanly: restart Flask → backend should add the `ability_points_per_discipline` column without intervention
- [ ] Existing character loads: legacy `ability_points = 30` distributes to `{sword: 8, bow: 7, staff: 7, dagger: 7}` for a Sword-starting character (or however the modulo lands) — and a `push_warning` appears in editor output
- [ ] New character: starting-class discipline pool gets `(level-1) * 3`; other three at 0
- [ ] Level up while wielding a sword → only Sword tab's pool increases by 3
- [ ] Mid-fight swap to bow, gain XP, level up → only Bow tab's pool increases by 3
- [ ] AbilityWindow opens to the active weapon's tab by default
- [ ] Click Sword tab → see only Sword-discipline abilities + Sword pool
- [ ] Try to spend a Sword point on a Bow ability → denied (per-pool check)
- [ ] Spend a point → pool decrements, ability levels, save fires
- [ ] Save round-trip: spent values persist in Postgres (verify via Adminer at the overhaul backend)
- [ ] Tier-2 advancement abilities (when reached) end up in the right tier-1 parent's tab
- [ ] Bot characters still play correctly (they don't actively level abilities, but the load path runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)