### PR TITLE
Fix PR 4: stop re-migrating legacy ability points on every load

### DIFF
--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -1383,25 +1383,41 @@ func can_level_up_ability(ability_id: String) -> bool:
 
 ## PR 4: applies the legacy-save migration logic for ability points.
 ##
-## Priority order:
-##   1. `available_points_per_discipline` (the new shape) - load verbatim,
-##      coercing values to ints and filling missing keys with 0.
-##   2. `available_points` (legacy int) - distribute evenly across the four
-##      pools, remainder to the starting discipline. Logs a warning so it's
-##      visible during testing.
-##   3. Neither - initialize all four pools to 0.
+## Priority order (revised 2026-05-28):
+##   1. `available_points_per_discipline` PRESENT in `data` at all (even as
+##      an empty dict) \u2192 trust it as the source of truth. Load verbatim
+##      with missing keys defaulting to 0. Do NOT fall through to legacy.
+##   2. New key completely absent BUT legacy `available_points` int present
+##      AND > 0 \u2192 one-shot migrate: distribute evenly across the four
+##      pools, remainder to the starting discipline. Logs a warning.
+##   3. Neither \u2192 initialize all four pools to 0.
+##
+## Bug fix (2026-05-28): previously the new-shape branch required the dict
+## to be non-empty (`not saved_dict.is_empty()`). An empty dict \u2014 which the
+## backend can legitimately return when the new JSONB column is NULL or the
+## save layer hands back `{}` for a fresh-but-zeroed-pool character \u2014 fell
+## through to the legacy migration, double-granting `available_points`
+## worth of points on EVERY load. A player who spent their 3 mastery points
+## would get the migrated 3 added back on next load, ad infinitum.
+##
+## The rule now is: PRESENCE of the new key (not its contents) signals
+## "this save was written by the per-discipline-aware codepath; trust it."
+## A truly fresh character with no points still ends up with all-zero pools
+## via the dict, which is correct. Legacy migration only fires for saves
+## that predate the per-discipline shape entirely.
 func _load_ability_points_with_migration(data: Dictionary) -> void:
-	# Reset all pools to 0 - the dict-load case may not mention every key.
+	# Reset all pools to 0 \u2014 the dict-load case may not mention every key.
 	for key in DISCIPLINE_KEYS:
 		_available_points_per_discipline[key] = 0
 
 	if data.has("available_points_per_discipline"):
 		var saved_dict = data["available_points_per_discipline"]
-		if saved_dict is Dictionary and not saved_dict.is_empty():
+		if saved_dict is Dictionary:
 			for key in DISCIPLINE_KEYS:
 				_available_points_per_discipline[key] = int(saved_dict.get(key, 0))
 			return
 
+	# Only legacy migration path \u2014 fires exactly once for saves predating PR 4.
 	if data.has("available_points"):
 		var legacy_total: int = int(data["available_points"])
 		if legacy_total > 0:


### PR DESCRIPTION
## Summary

A player who gained mastery 1 (+3 ability points), spent all 3 leveling Slash, then reloaded got **another 3 points granted "from migration"** — and every subsequent load kept firing the legacy-int migration on top of already-migrated state, duplicating points indefinitely.

## Root cause

In `_load_ability_points_with_migration`:

```gdscript
if data.has("available_points_per_discipline"):
    var saved_dict = data["available_points_per_discipline"]
    if saved_dict is Dictionary and not saved_dict.is_empty():
        # load new shape; return
# falls through to legacy `available_points` migration here
```

The `not saved_dict.is_empty()` guard lets an empty dict fall through to the legacy migration branch. Empty dicts can come from:
- Backend returning `{}` when the new JSONB column is NULL (column added by auto-migration but never written for that row yet)
- A freshly-zeroed character whose per-discipline pools are all 0 (sum = 0, and the serializer might write `{}`)
- Save layer normalizations

When the dict falls through, the legacy `available_points` int (which `save_abilities` ALSO writes as a sum-of-pools for backend compat) is redistributed across the four pools — duplicating points the player already spent. Save fires after migration → writes the migrated state → next load fires migration again on the same legacy int → grants more points forever.

## Fix

PRESENCE of `available_points_per_discipline` in the save dict signals "trust this." If the key exists at all (even as an empty dict), load it as-is and return — never fall through to the legacy branch. Empty dict = all-zero pools, which is correct for a fresh / spent-out character.

```diff
 if data.has("available_points_per_discipline"):
     var saved_dict = data["available_points_per_discipline"]
-    if saved_dict is Dictionary and not saved_dict.is_empty():
+    if saved_dict is Dictionary:
         for key in DISCIPLINE_KEYS:
             _available_points_per_discipline[key] = int(saved_dict.get(key, 0))
         return
```

Legacy migration now only fires for genuinely-pre-PR-4 saves (where the new key is completely absent from `data`). After that one round-trip, save writes the new dict, and subsequent loads correctly take the new-shape branch.

## Caveat for existing characters

Players who already accumulated phantom points from this bug will keep them in their save — the buggy state is "baked in" to whatever the most recent save wrote. Going forward, no new duplication. If a particular character is way off baseline, manually adjust via debug console.

## Test plan

- [ ] Fresh character → gain mastery 1 (3 sword points) → spend 3 on Slash → reload → no migration warning, points still 0
- [ ] Restart server multiple times in a row, watch console for the warning text "AbilityComponent: migrated legacy" — should appear at most once per character (for legitimately-pre-PR-4 saves) and never thereafter
- [ ] Genuinely-pre-PR-4 character (if any still exist in test DB) → one migration on first load, then stable
- [ ] Multi-discipline character with various spent/unspent pools (e.g. sword 3, bow 1, staff 0, dagger 2) → round-trip preserves exact values
- [ ] Bot characters → no spurious warnings, save/load clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)