### PR TITLE
test: ability unit-test harness + suites (skill tree, upgrades, climb-gate)

### DIFF
--- a/run_tests.bat
+++ b/run_tests.bat
@@ -1,0 +1,23 @@
+@echo off
+REM Headless unit-test runner. Set GODOT to your Godot 4.5+ binary, or rely on
+REM the default install path below.
+setlocal
+cd /d "%~dp0"
+
+set "GODOT_BIN=%GODOT%"
+if "%GODOT_BIN%"=="" set "GODOT_BIN=C:\Program Files\Godot\Godot.exe"
+
+if not exist "%GODOT_BIN%" (
+    echo ERROR: Godot executable not found at "%GODOT_BIN%".
+    echo Set the GODOT environment variable to your Godot 4.5 binary:
+    echo     set "GODOT=C:\path\to\Godot.exe"
+    exit /b 1
+)
+
+set "LOG=%~dp0test\last_run.log"
+"%GODOT_BIN%" --headless --path "%~dp0" --script res://test/run_tests.gd --log-file "%LOG%"
+set EXITCODE=%ERRORLEVEL%
+
+echo.
+type "%LOG%"
+exit /b %EXITCODE%

--- a/scripts/Resources/AbilitySystem/AbilityScalingFormula.gd
+++ b/scripts/Resources/AbilitySystem/AbilityScalingFormula.gd
@@ -37,33 +37,38 @@ func calculate(level: int) -> float:
 	match scaling_type:
 		ScalingType.FLAT:
 			return base_value + ((level - 1) * per_level)
-		
+
 		ScalingType.MULTIPLICATIVE:
 			return base_value * pow(multiplier, level - 1)
-		
+
 		ScalingType.STEPPED:
 			var result = base_value
 			var sorted_levels = step_values.keys()
 			sorted_levels.sort()
-			
+
 			for step_level in sorted_levels:
 				if level >= step_level:
 					result = step_values[step_level]
 				else:
 					break
 			return result
-		
+
 		ScalingType.CUSTOM:
 			if custom_formula.is_empty():
 				return base_value
-			
+
 			# Use Expression to evaluate custom formulas
 			var expr = Expression.new()
 			var error = expr.parse(custom_formula, ["level", "base_value"])
 			if error != OK:
 				push_error("Invalid formula: %s" % custom_formula)
 				return base_value
-			
-			return expr.execute([level, base_value])
-	
+
+			var result = expr.execute([level, base_value])
+			if expr.has_execute_failed():
+				push_error("Formula execution failed: %s" % custom_formula)
+				return base_value
+
+			return result
+
 	return base_value

--- a/test/ability/test_ability_component.gd
+++ b/test/ability/test_ability_component.gd
@@ -1,0 +1,413 @@
+# Behavior tests for the live AbilityComponent: cooldown ticking, per-discipline
+# ability-point pools, discipline mapping, leveling, the skill-tree climb-gate
+# (PR ~7), and ability-upgrade purchase (PR 6).
+#
+# AbilityComponent is a Node that needs to live in the SceneTree (so its
+# `multiplayer` resolves) and reads `owner.player_id`. We mount one bare
+# component under a stub owner WITHOUT Class/Stats siblings, so
+# AbilityComponent._ready() early-returns before its auto-seeding block, leaving
+# clean, deterministic state we reset between tests. The two expected error
+# lines at mount ("requires ClassComponent and StatsComponent" + missing hotbar
+# node path) are benign — the component is fully usable for the direct-API
+# behavior we exercise here.
+#
+# FIXTURES ARE RESOLVED DYNAMICALLY from ResourceManager.ability_data — never by
+# hardcoded .tres path. A prior version hardcoded A_Slash.tres and silently broke
+# when the sword abilities were renamed (A_Slash -> A_Crescent_Cleave). Dynamic
+# resolution by structural shape (discipline / type / tree position / upgrade
+# layout) survives content renames and tests the actual indexed content.
+extends "res://test/test_case.gd"
+
+class _OwnerStub extends Node:
+	var player_id: int = 1
+
+# One shared in-tree component across all tests (mounting it logs 2 expected
+# errors, so we do it once). State is reset per test in before_each().
+static var _shared_owner: Node = null
+static var _shared_component = null
+
+
+func _comp():
+	if _shared_component != null and is_instance_valid(_shared_component):
+		return _shared_component
+	var tree := Engine.get_main_loop() as SceneTree
+	var mp := tree.get_multiplayer()
+	if not (mp.multiplayer_peer is OfflineMultiplayerPeer):
+		mp.multiplayer_peer = OfflineMultiplayerPeer.new()
+	_shared_owner = _OwnerStub.new()
+	_shared_owner.name = "AbilityTestOwner"
+	_shared_component = AbilityComponent.new()
+	_shared_owner.add_child(_shared_component)
+	tree.root.add_child(_shared_owner)   # fires _ready -> early return (no siblings)
+	_shared_component.owner = _shared_owner
+	return _shared_component
+
+func before_each() -> void:
+	var c = _comp()
+	c._cooldowns = {}
+	c._ability_levels = {}
+	c._available_points_per_discipline = {"sword": 0, "bow": 0, "staff": 0, "dagger": 0}
+	c._learned_upgrades = {}
+
+
+#region #################### Dynamic fixture resolution ####################
+## First indexed ability matching `predicate(ability) -> bool`, else null.
+func _find_ability(predicate: Callable):
+	for a in ResourceManager.ability_data.values():
+		if a != null and predicate.call(a):
+			return a
+	return null
+
+## An ACTIVE, sword-discipline, path-ROOT (tree_depth 0, so the climb-gate never
+## blocks it) ability with room to level and no prerequisites — drives the
+## leveling tests deterministically regardless of its display name.
+func _sword_root_active():
+	var c = _comp()
+	return _find_ability(func(a):
+		return a.ability_type == Constants.AbilityType.ACTIVE \
+			and c._ability_primary_discipline(a) == "sword" \
+			and a.tree_depth == 0 and a.tree_path >= 0 \
+			and a.max_level >= 2 \
+			and a.prerequisite_abilities.is_empty())
+
+## A placed tree CHILD (tree_depth == 1) plus its resolved path-parent. The
+## integration test satisfies the child's prerequisites explicitly so the
+## climb-gate (parent level) is the only variable. Returns {child, parent} or {}.
+func _tree_child_with_parent() -> Dictionary:
+	var c = _comp()
+	for a in ResourceManager.ability_data.values():
+		if a == null or a.tree_path < 0 or a.tree_depth != 1:
+			continue
+		var parent = c._get_path_parent(a)
+		if parent != null:
+			return {"child": a, "parent": parent}
+	return {}
+
+## An ability carrying a full upgrade tree: a tier-1, a tier-2, and a
+## variant_group with >=2 tier-3 members — drives the purchase tests. Returns
+## {ability, t1, t2, variants:[>=2 ids]} or {} if none found.
+func _ability_with_full_upgrade_tree() -> Dictionary:
+	for a in ResourceManager.ability_data.values():
+		if a == null or a.upgrades == null or a.upgrades.is_empty():
+			continue
+		var t1 := ""
+		var t2 := ""
+		var groups := {}
+		for up in a.upgrades:
+			if up == null:
+				continue
+			if up.tier == 1 and t1 == "":
+				t1 = up.upgrade_id
+			elif up.tier == 2 and t2 == "":
+				t2 = up.upgrade_id
+			if not up.variant_group.is_empty():
+				if not groups.has(up.variant_group):
+					groups[up.variant_group] = []
+				groups[up.variant_group].append(up.upgrade_id)
+		if t1 == "" or t2 == "":
+			continue
+		for g in groups:
+			if groups[g].size() >= 2:
+				return {"ability": a, "t1": t1, "t2": t2, "variants": groups[g]}
+	return {}
+#endregion
+
+
+# ---- cooldowns ----
+
+func test_cooldown_unknown_ability_is_zero() -> void:
+	assert_almost_eq(_comp().get_cooldown_remaining("does_not_exist"), 0.0, 0.001)
+
+func test_cooldown_ticks_down_with_process() -> void:
+	var c = _comp()
+	c._cooldowns["x"] = 2.0
+	c._process(0.5)
+	assert_almost_eq(c.get_cooldown_remaining("x"), 1.5, 0.001, "after 0.5s")
+	c._process(1.0)
+	assert_almost_eq(c.get_cooldown_remaining("x"), 0.5, 0.001, "after 1.5s total")
+
+func test_cooldown_expires_and_is_erased() -> void:
+	var c = _comp()
+	c._cooldowns["x"] = 1.0
+	c._process(1.5)  # overshoot
+	assert_almost_eq(c.get_cooldown_remaining("x"), 0.0, 0.001, "expired reads as 0")
+	assert_false(c._cooldowns.has("x"), "expired cooldown removed from the dict")
+
+
+# ---- per-discipline point pools ----
+
+func test_add_points_to_one_discipline() -> void:
+	var c = _comp()
+	c._add_ability_points(5, "sword")
+	assert_eq(c.get_available_points_for_discipline("sword"), 5, "sword credited")
+	assert_eq(c.get_available_points_for_discipline("bow"), 0, "bow untouched")
+
+func test_points_sum_across_disciplines() -> void:
+	var c = _comp()
+	c._add_ability_points(3, "sword")
+	c._add_ability_points(4, "bow")
+	assert_eq(c.get_available_ability_points(), 7, "total is the sum of pools")
+
+func test_points_snapshot_is_a_copy() -> void:
+	var c = _comp()
+	c._add_ability_points(2, "staff")
+	var snap: Dictionary = c.get_available_points_per_discipline()
+	assert_eq(int(snap["staff"]), 2, "snapshot reflects pool")
+	snap["staff"] = 999
+	assert_eq(c.get_available_points_for_discipline("staff"), 2, "mutating the snapshot must not change the pool")
+
+func test_unknown_discipline_reads_zero() -> void:
+	assert_eq(_comp().get_available_points_for_discipline("bogus"), 0)
+
+
+# ---- discipline mapping ----
+
+func test_class_type_maps_to_discipline() -> void:
+	var c = _comp()
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.SWORD), "sword")
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.BOW), "bow")
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.STAFF), "staff")
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.DAGGER), "dagger")
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.CRUSADER), "sword", "tier-2 advancement maps to base discipline")
+	assert_eq(c._class_type_to_discipline_key(Constants.ClassType.BEGINNER), "", "beginner maps to no discipline")
+
+func test_ability_primary_discipline_reads_required_class() -> void:
+	var ability = _sword_root_active()
+	assert_not_null(ability, "found a sword root active fixture")
+	if ability:
+		assert_eq(_comp()._ability_primary_discipline(ability), "sword")
+
+
+# ---- leveling / gating ----
+
+func test_level_up_spends_one_point_and_increments() -> void:
+	var c = _comp()
+	var ability = _sword_root_active()
+	assert_not_null(ability, "found a sword root active fixture")
+	if not ability:
+		return
+	var id: String = ability.ability_id
+	c._ability_levels[id] = 1
+	c._available_points_per_discipline["sword"] = 3
+	var ok: bool = c._level_up_ability_local(id)
+	assert_true(ok, "level-up succeeded")
+	assert_eq(c.get_ability_level(id), 2, "ability level incremented")
+	assert_eq(c.get_available_points_for_discipline("sword"), 2, "exactly one sword point spent")
+
+func test_cannot_level_without_points() -> void:
+	var c = _comp()
+	var ability = _sword_root_active()
+	assert_not_null(ability, "fixture present")
+	if not ability:
+		return
+	c._ability_levels[ability.ability_id] = 1
+	c._available_points_per_discipline["sword"] = 0
+	assert_false(c.can_level_up_ability(ability.ability_id), "empty discipline pool blocks leveling")
+
+func test_cannot_level_at_max_level() -> void:
+	var c = _comp()
+	var ability = _sword_root_active()
+	assert_not_null(ability, "fixture present")
+	if not ability:
+		return
+	c._ability_levels[ability.ability_id] = ability.max_level
+	c._available_points_per_discipline["sword"] = 5
+	assert_false(c.can_level_up_ability(ability.ability_id), "at max_level, leveling is blocked even with points")
+
+func test_level_up_denied_leaves_state_unchanged() -> void:
+	var c = _comp()
+	var ability = _sword_root_active()
+	assert_not_null(ability, "fixture present")
+	if not ability:
+		return
+	var id: String = ability.ability_id
+	c._ability_levels[id] = 1
+	c._available_points_per_discipline["sword"] = 0
+	var ok: bool = c._level_up_ability_local(id)
+	assert_false(ok, "denied level-up returns false")
+	assert_eq(c.get_ability_level(id), 1, "level unchanged on denial")
+	assert_eq(c.get_available_points_for_discipline("sword"), 0, "no points spent on denial")
+
+
+# ---- skill-tree climb-gate ----
+
+func test_tree_root_is_always_unlocked() -> void:
+	var ability = _sword_root_active()  # tree_depth 0 == path root
+	assert_not_null(ability, "root fixture present")
+	if ability:
+		assert_true(_comp().is_tree_node_unlocked(ability.ability_id), "a path-root node is unlocked unconditionally")
+
+func test_tree_child_locked_until_parent_learned() -> void:
+	var c = _comp()
+	var pair := _tree_child_with_parent()
+	assert_false(pair.is_empty(), "found a tree child + parent fixture")
+	if pair.is_empty():
+		return
+	var child_id: String = pair.child.ability_id
+	var parent_id: String = pair.parent.ability_id
+	# Parent unlearned (level 0) -> gate closed.
+	c._ability_levels[parent_id] = 0
+	assert_false(c.is_tree_node_unlocked(child_id), "child gated while parent unlearned")
+	# Parent learned (level 1) -> gate open.
+	c._ability_levels[parent_id] = 1
+	assert_true(c.is_tree_node_unlocked(child_id), "child unlocked once parent is learned")
+
+func test_climb_gate_blocks_level_up() -> void:
+	var c = _comp()
+	var pair := _tree_child_with_parent()
+	assert_false(pair.is_empty(), "fixture present")
+	if pair.is_empty():
+		return
+	var child = pair.child
+	var parent = pair.parent
+	var child_id: String = child.ability_id
+	var disc: String = c._ability_primary_discipline(child)
+	c._ability_levels[child_id] = 1
+	c._available_points_per_discipline[disc] = 10
+	# Satisfy every prerequisite EXCEPT the path-parent (whose level we control).
+	# A child's prereq may also BE its path-parent but at a higher level (e.g.
+	# Sundering Blow needs Crescent Cleave 5; the gate only needs it >= 1) — take
+	# the max so the "allowed" case satisfies both. Match by ability_id, not
+	# object identity.
+	var parent_required: int = 1
+	for prereq in child.prerequisite_abilities:
+		var req: int = int(child.prerequisite_abilities[prereq])
+		if prereq.ability_id == parent.ability_id:
+			parent_required = max(parent_required, req)
+		else:
+			c._ability_levels[prereq.ability_id] = req
+	# Gate closed: path-parent unlearned.
+	c._ability_levels[parent.ability_id] = 0
+	assert_false(c.can_level_up_ability(child_id), "blocked while path-parent unlearned")
+	# Gate open + all prerequisites satisfied.
+	c._ability_levels[parent.ability_id] = parent_required
+	if child.max_level > 1:
+		assert_true(c.can_level_up_ability(child_id), "allowed once path-parent learned to required level")
+
+
+# ---- ability upgrades (PR 6 purchase API) ----
+
+func test_upgrade_requires_learned_ability() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "found an ability with a full upgrade tree")
+	if fx.is_empty():
+		return
+	var id: String = fx.ability.ability_id
+	c._ability_levels[id] = 0  # unlearned
+	var res: Dictionary = c.can_purchase_upgrade(id, fx.t1)
+	assert_false(res.ok, "cannot buy an upgrade for an unlearned ability")
+	assert_eq(res.reason, "not_learned")
+
+func test_upgrade_requires_max_level() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var id: String = fx.ability.ability_id
+	c._ability_levels[id] = 1  # learned but below max
+	if fx.ability.max_level <= 1:
+		return
+	var res: Dictionary = c.can_purchase_upgrade(id, fx.t1)
+	assert_false(res.ok, "cannot buy upgrades before the ability is maxed")
+	assert_eq(res.reason, "not_maxed")
+
+func test_upgrade_tier_gating() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var ability = fx.ability
+	var id: String = ability.ability_id
+	var disc: String = c._ability_primary_discipline(ability)
+	c._ability_levels[id] = ability.max_level
+	c._available_points_per_discipline[disc] = 10
+	# Tier-2 is locked until a tier-1 is owned.
+	var t2res: Dictionary = c.can_purchase_upgrade(id, fx.t2)
+	assert_false(t2res.ok, "tier-2 locked with no tier-1 owned")
+	assert_eq(t2res.reason, "tier_locked")
+	# Buy tier-1, then tier-2 unlocks.
+	assert_true(c.can_purchase_upgrade(id, fx.t1).ok, "tier-1 purchasable")
+	assert_true(c.purchase_upgrade(id, fx.t1), "bought tier-1")
+	assert_true(c.can_purchase_upgrade(id, fx.t2).ok, "tier-2 unlocked after tier-1")
+
+func test_upgrade_purchase_deducts_points_and_records() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var ability = fx.ability
+	var id: String = ability.ability_id
+	var disc: String = c._ability_primary_discipline(ability)
+	var t1up = c._find_upgrade(ability, fx.t1)
+	c._ability_levels[id] = ability.max_level
+	c._available_points_per_discipline[disc] = 10
+	assert_false(c.has_upgrade(id, fx.t1), "not owned before purchase")
+	assert_true(c.purchase_upgrade(id, fx.t1), "purchase succeeds")
+	assert_true(c.has_upgrade(id, fx.t1), "owned after purchase")
+	assert_eq(c.get_available_points_for_discipline(disc), 10 - t1up.point_cost, "point_cost deducted")
+	assert_true(c.get_learned_upgrades(id).has(fx.t1), "recorded in learned-upgrades list")
+	# Re-buying the same upgrade is rejected.
+	var again: Dictionary = c.can_purchase_upgrade(id, fx.t1)
+	assert_false(again.ok, "cannot re-buy an owned upgrade")
+	assert_eq(again.reason, "already_owned")
+
+func test_upgrade_variant_mutex() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var ability = fx.ability
+	var id: String = ability.ability_id
+	var disc: String = c._ability_primary_discipline(ability)
+	c._ability_levels[id] = ability.max_level
+	c._available_points_per_discipline[disc] = 20
+	# Open the tier gate up to tier-3 (buy a t1 and t2).
+	assert_true(c.purchase_upgrade(id, fx.t1), "bought tier-1")
+	assert_true(c.purchase_upgrade(id, fx.t2), "bought tier-2")
+	var v0: String = fx.variants[0]
+	var v1: String = fx.variants[1]
+	assert_true(c.can_purchase_upgrade(id, v0).ok, "first variant purchasable")
+	assert_true(c.purchase_upgrade(id, v0), "bought first variant")
+	# Mutex: a second variant in the same group is now blocked.
+	var blocked: Dictionary = c.can_purchase_upgrade(id, v1)
+	assert_false(blocked.ok, "second variant in the same group is blocked")
+	assert_eq(blocked.reason, "variant_taken")
+
+func test_upgrade_insufficient_points() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var ability = fx.ability
+	var id: String = ability.ability_id
+	var disc: String = c._ability_primary_discipline(ability)
+	c._ability_levels[id] = ability.max_level
+	c._available_points_per_discipline[disc] = 0
+	var res: Dictionary = c.can_purchase_upgrade(id, fx.t1)
+	assert_false(res.ok, "cannot buy without points")
+	assert_eq(res.reason, "no_points")
+
+func test_upgrade_magnitude_helpers() -> void:
+	var c = _comp()
+	var fx := _ability_with_full_upgrade_tree()
+	assert_false(fx.is_empty(), "fixture present")
+	if fx.is_empty():
+		return
+	var ability = fx.ability
+	var id: String = ability.ability_id
+	var disc: String = c._ability_primary_discipline(ability)
+	var t1up = c._find_upgrade(ability, fx.t1)
+	c._ability_levels[id] = ability.max_level
+	c._available_points_per_discipline[disc] = 10
+	assert_true(c.purchase_upgrade(id, fx.t1), "bought tier-1")
+	# The per-ability and player-wide magnitude sums include the owned upgrade.
+	var per_ability: float = c.get_ability_upgrade_magnitude(id, t1up.effect_key)
+	var player_wide: float = c.get_total_upgrade_magnitude(t1up.effect_key)
+	assert_almost_eq(per_ability, t1up.magnitude, 0.001, "per-ability magnitude reflects the owned upgrade")
+	assert_almost_eq(player_wide, t1up.magnitude, 0.001, "player-wide magnitude includes it too")

--- a/test/ability/test_ability_component.gd.uid
+++ b/test/ability/test_ability_component.gd.uid
@@ -1,0 +1,1 @@
+uid://bmc7vodf0yn33

--- a/test/ability/test_ability_data.gd
+++ b/test/ability/test_ability_data.gd
@@ -1,0 +1,65 @@
+# Unit tests for AbilityData — level-stat lookup with bounds clamping and the
+# tooltip placeholder substitution ($[damage_percent], etc.).
+extends "res://test/test_case.gd"
+
+func _flat(base: float, per_level: float) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.FLAT
+	f.base_value = base
+	f.per_level = per_level
+	return f
+
+func _make_ability(max_level: int) -> AbilityData:
+	var ability := AbilityData.new()
+	ability.ability_name = "Power Strike"
+	ability.ability_type = Constants.AbilityType.ACTIVE
+	ability.max_level = max_level
+	var scaling := AbilityScalingData.new()
+	scaling.damage_percent_formula = _flat(150.0, 10.0)
+	scaling.mana_cost_formula = _flat(20.0, 0.0)
+	scaling.cooldown_formula = _flat(3.0, 0.0)
+	ability.scaling_data = scaling
+	return ability
+
+
+func test_get_level_stats_below_one_is_null() -> void:
+	assert_null(_make_ability(10).get_level_stats(0))
+
+func test_get_level_stats_above_max_is_null() -> void:
+	assert_null(_make_ability(10).get_level_stats(11))
+
+func test_get_level_stats_valid_level_returns_data() -> void:
+	var stats := _make_ability(10).get_level_stats(5)
+	assert_not_null(stats, "level 5 within range")
+	assert_eq(stats.level, 5)
+	assert_eq(stats.damage_percent, 190, "150 + (5-1)*10")
+
+func test_get_level_stats_at_max_level_is_valid() -> void:
+	assert_not_null(_make_ability(10).get_level_stats(10))
+
+func test_get_level_stats_without_scaling_data_is_null() -> void:
+	# Misconfigured ability (no scaling_data) returns null rather than crashing.
+	# The ERROR line printed below is the expected push_error guard.
+	var ability := AbilityData.new()
+	ability.max_level = 5
+	ability.scaling_data = null
+	assert_null(ability.get_level_stats(1))
+
+func test_tooltip_substitutes_damage_placeholder() -> void:
+	var ability := _make_ability(10)
+	ability.description = "Deals $[damage_percent] damage to one enemy."
+	var tooltip := ability.get_tooltip_text(1)
+	assert_true("150%" in tooltip, "placeholder replaced with level-1 value")
+	assert_false("$[damage_percent]" in tooltip, "raw placeholder removed")
+
+func test_tooltip_shows_level_line_when_learned() -> void:
+	var tooltip := _make_ability(10).get_tooltip_text(3)
+	assert_true("Level 3 / 10" in tooltip, "current/max level shown")
+
+func test_tooltip_unlearned_uses_level_one_preview() -> void:
+	# At level 0 the line says Unlearned but placeholders preview level-1 values.
+	var ability := _make_ability(10)
+	ability.description = "Deals $[damage_percent] damage."
+	var tooltip := ability.get_tooltip_text(0)
+	assert_true("Unlearned" in tooltip, "marked unlearned")
+	assert_true("150%" in tooltip, "still previews level-1 damage")

--- a/test/ability/test_ability_data.gd.uid
+++ b/test/ability/test_ability_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bhgpkt1r2lxvx

--- a/test/ability/test_ability_level_data.gd
+++ b/test/ability/test_ability_level_data.gd
@@ -1,0 +1,52 @@
+# Unit tests for AbilityLevelData — the per-level stat bundle: modifier getters
+# (default 1.0 multipliers) and proc event resolution.
+extends "res://test/test_case.gd"
+
+func test_constructor_sets_level() -> void:
+	assert_eq(AbilityLevelData.new(7).level, 7)
+
+func test_default_level_is_one() -> void:
+	assert_eq(AbilityLevelData.new().level, 1)
+
+func test_modifier_getters_default_to_identity() -> void:
+	# Abilities not present in the modifier dicts return a 1.0 multiplier so
+	# unmodified abilities are unaffected.
+	var data := AbilityLevelData.new(1)
+	assert_almost_eq(data.get_ability_damage_modifier("unknown"), 1.0, 0.001, "damage")
+	assert_almost_eq(data.get_ability_cooldown_modifier("unknown"), 1.0, 0.001, "cooldown")
+	assert_almost_eq(data.get_ability_mana_modifier("unknown"), 1.0, 0.001, "mana")
+
+func test_modifier_getters_return_configured_value() -> void:
+	var data := AbilityLevelData.new(1)
+	data.ability_damage_modifiers["fireball"] = 1.5
+	data.ability_cooldown_modifiers["fireball"] = 0.8
+	assert_almost_eq(data.get_ability_damage_modifier("fireball"), 1.5, 0.001, "damage")
+	assert_almost_eq(data.get_ability_cooldown_modifier("fireball"), 0.8, 0.001, "cooldown")
+	assert_almost_eq(data.get_ability_damage_modifier("other"), 1.0, 0.001, "unrelated stays 1.0")
+
+func test_try_proc_event_returns_proc_when_chance_certain() -> void:
+	var data := AbilityLevelData.new(1)
+	var proc := ProcEffectData.new()
+	proc.proc_chance = 1.0  # randf() < 1.0 is always true => deterministic
+	data.on_hit_proc = proc
+	assert_eq(data.try_proc_event("on_hit"), proc)
+
+func test_try_proc_event_returns_null_when_chance_zero() -> void:
+	var data := AbilityLevelData.new(1)
+	var proc := ProcEffectData.new()
+	proc.proc_chance = 0.0
+	data.on_hit_proc = proc
+	assert_null(data.try_proc_event("on_hit"))
+
+func test_try_proc_event_unknown_event_returns_null() -> void:
+	var data := AbilityLevelData.new(1)
+	assert_null(data.try_proc_event("on_nonexistent_event"))
+
+func test_try_proc_event_routes_by_event_type() -> void:
+	# A proc on on_crit must not fire for an on_hit query.
+	var data := AbilityLevelData.new(1)
+	var crit_proc := ProcEffectData.new()
+	crit_proc.proc_chance = 1.0
+	data.on_crit_proc = crit_proc
+	assert_eq(data.try_proc_event("on_crit"), crit_proc, "on_crit resolves")
+	assert_null(data.try_proc_event("on_hit"), "on_hit has no proc")

--- a/test/ability/test_ability_level_data.gd.uid
+++ b/test/ability/test_ability_level_data.gd.uid
@@ -1,0 +1,1 @@
+uid://bsuok4ck0lqfm

--- a/test/ability/test_ability_resources.gd
+++ b/test/ability/test_ability_resources.gd
@@ -1,0 +1,210 @@
+# Content-validation tests over EVERY real ability .tres in resources/Abilities/.
+# These load the actual authored content and assert per-ability, per-level
+# invariants — so an authoring mistake (missing scaling_data, an active with no
+# behavior, an impossible prerequisite, a level that fails to generate) fails CI
+# instead of shipping. Failure messages name the offending ability + level.
+extends "res://test/test_case.gd"
+
+const ABILITIES_ROOT := "res://resources/Abilities"
+
+# Loading + scanning every ability is the same for all tests, so cache it across
+# the fresh-per-test instances the runner creates.
+static var _cache: Array = []
+
+
+func _all_abilities() -> Array:
+	if _cache.is_empty():
+		var paths: Array[String] = []
+		_scan(ABILITIES_ROOT, paths)
+		for p in paths:
+			var res = load(p)
+			if res is AbilityData:
+				_cache.append(res)
+	return _cache
+
+func _scan(dir_path: String, out_paths: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		var full := dir_path + "/" + entry
+		if dir.current_is_dir():
+			if not entry.begins_with("."):
+				_scan(full, out_paths)
+		elif entry.ends_with(".tres"):
+			out_paths.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+# Mirrors AbilityComponent._class_type_to_discipline_key. PR-7 renamed the
+# ClassType enum to weapon disciplines (SWORD/BOW/STAFF/DAGGER); tier-2
+# advancement members map back to their base discipline.
+func _discipline_for_class(class_type: int) -> String:
+	match class_type:
+		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
+			return "sword"
+		Constants.ClassType.BOW, Constants.ClassType.RANGER:
+			return "bow"
+		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
+			return "staff"
+		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
+			return "dagger"
+	return ""
+
+
+func test_ability_resources_load() -> void:
+	# Guards against a broken scan silently making every other test vacuous.
+	var abilities := _all_abilities()
+	assert_true(abilities.size() >= 10, "expected to load the authored abilities, got %d" % abilities.size())
+
+func test_every_ability_has_identity() -> void:
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		assert_false(ability.ability_id.is_empty(), "%s has empty ability_id" % ability.resource_path)
+		assert_false(ability.ability_name.is_empty(), "%s has empty ability_name" % ability.resource_path)
+		assert_true(ability.max_level >= 1, "%s has max_level %d (< 1)" % [ability.ability_name, ability.max_level])
+
+func test_every_level_generates_stats() -> void:
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		for level in range(1, ability.max_level + 1):
+			var stats: AbilityLevelData = ability.get_level_stats(level)
+			assert_not_null(stats, "%s failed to generate level %d (missing scaling_data?)" % [ability.ability_name, level])
+			if stats:
+				assert_eq(stats.level, level, "%s level %d tagged wrong" % [ability.ability_name, level])
+
+func test_level_stats_are_sane() -> void:
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		# Enemy-targeting actives must hit >=1 target >=1 time. Self/ally buffs,
+		# passives, and utility (teleport, stealth) legitimately resolve to 0.
+		var enemy_targeting: bool = ability.ability_type == Constants.AbilityType.ACTIVE \
+			and ability.active_behavior != null \
+			and ability.active_behavior.target_type == Constants.TargetType.ENEMY
+		for level in range(1, ability.max_level + 1):
+			var s: AbilityLevelData = ability.get_level_stats(level)
+			if s == null:
+				continue
+			var where := "%s level %d" % [ability.ability_name, level]
+			assert_true(s.mana_cost >= 0, "%s mana_cost %d < 0" % [where, s.mana_cost])
+			assert_true(s.cooldown_time >= 0.0 and is_finite(s.cooldown_time), "%s cooldown %s invalid" % [where, str(s.cooldown_time)])
+			assert_true(s.damage_percent >= 0, "%s damage_percent %d < 0" % [where, s.damage_percent])
+			assert_true(s.max_targets >= 0, "%s max_targets %d < 0" % [where, s.max_targets])
+			assert_true(s.max_hits >= 0, "%s max_hits %d < 0" % [where, s.max_hits])
+			if enemy_targeting:
+				assert_true(s.max_targets >= 1, "%s is enemy-targeting but max_targets is %d" % [where, s.max_targets])
+				assert_true(s.max_hits >= 1, "%s is enemy-targeting but max_hits is %d" % [where, s.max_hits])
+
+func test_level_bounds_return_null() -> void:
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		assert_null(ability.get_level_stats(0), "%s should return null at level 0" % ability.ability_name)
+		assert_null(ability.get_level_stats(ability.max_level + 1), "%s should return null above max_level" % ability.ability_name)
+
+func test_active_abilities_have_active_behavior() -> void:
+	# _trigger_ability_state_change push_errors without active_behavior, so an
+	# active ability missing it is unusable in combat.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		if ability.ability_type == Constants.AbilityType.ACTIVE:
+			assert_not_null(ability.active_behavior, "active ability %s has no active_behavior" % ability.ability_name)
+
+func test_required_class_maps_to_a_discipline() -> void:
+	# PR-4 invariant: an ability's class must map to a weapon discipline pool.
+	# Class-neutral debug abilities (empty required_class, e.g. FMA) are exempt.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		for class_type in ability.required_class:
+			assert_ne(_discipline_for_class(class_type), "", "%s required_class %d maps to no discipline" % [ability.ability_name, class_type])
+
+func test_prerequisites_are_satisfiable() -> void:
+	# A prerequisite that demands a level above the prereq ability's max_level
+	# can never be met — a soft-lock authoring bug.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		for prereq in ability.prerequisite_abilities:
+			var required_level: int = ability.prerequisite_abilities[prereq]
+			assert_true(prereq != null, "%s has a null prerequisite ability" % ability.ability_name)
+			if prereq:
+				assert_true(required_level <= prereq.max_level,
+					"%s requires %s level %d but its max_level is %d" % [ability.ability_name, prereq.ability_name, required_level, prereq.max_level])
+
+func test_tooltips_render_at_min_and_max_level() -> void:
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		var low: String = ability.get_tooltip_text(1)
+		var high: String = ability.get_tooltip_text(ability.max_level)
+		assert_true(ability.ability_name in low, "%s level-1 tooltip missing its name" % ability.ability_name)
+		assert_true(ability.ability_name in high, "%s max-level tooltip missing its name" % ability.ability_name)
+		assert_false("$[damage_percent]" in low, "%s left a raw $[damage_percent] placeholder" % ability.ability_name)
+
+
+# ---- skill-tree layout (PR ~7: tree_path / tree_depth + climb-gate) ----
+
+# Discipline key for an ability via its first required_class, else "" (unplaced /
+# class-neutral). Mirrors AbilityComponent._ability_primary_discipline.
+func _ability_discipline(ability) -> String:
+	if ability.required_class == null or ability.required_class.is_empty():
+		return ""
+	return _discipline_for_class(ability.required_class[0])
+
+func test_tree_fields_in_valid_range() -> void:
+	# tree_path: -1 (unplaced), 0 (Path A), or 1 (Path B). tree_depth: row >= 0.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		assert_true(ability.tree_path >= -1 and ability.tree_path <= 1,
+			"%s has tree_path %d (expected -1, 0, or 1)" % [ability.ability_name, ability.tree_path])
+		assert_true(ability.tree_depth >= 0,
+			"%s has tree_depth %d (< 0)" % [ability.ability_name, ability.tree_depth])
+
+func test_placed_tree_nodes_have_a_path_parent() -> void:
+	# The climb-gate requires the same-discipline, same-path node at depth-1.
+	# A placed node deeper than the root with no such parent is unreachable —
+	# a soft-lock authoring bug (you could never satisfy the gate to learn it).
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		if ability.tree_path < 0 or ability.tree_depth <= 0:
+			continue
+		var disc := _ability_discipline(ability)
+		var found_parent := false
+		for other in abilities:
+			if other == ability:
+				continue
+			if other.tree_path == ability.tree_path \
+					and other.tree_depth == ability.tree_depth - 1 \
+					and _ability_discipline(other) == disc:
+				found_parent = true
+				break
+		assert_true(found_parent,
+			"%s (%s path %d depth %d) has no depth-%d path-parent — unreachable via climb-gate" \
+			% [ability.ability_name, disc, ability.tree_path, ability.tree_depth, ability.tree_depth - 1])
+
+func test_each_populated_path_has_a_root() -> void:
+	# Every (discipline, path) that has any placed node must have a depth-0 root,
+	# otherwise the whole path is unreachable.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	var paths_seen := {}      # "disc:path" -> true
+	var roots_seen := {}      # "disc:path" -> true (has a depth-0 node)
+	for ability in abilities:
+		if ability.tree_path < 0:
+			continue
+		var key := "%s:%d" % [_ability_discipline(ability), ability.tree_path]
+		paths_seen[key] = true
+		if ability.tree_depth == 0:
+			roots_seen[key] = true
+	assert_false(paths_seen.is_empty(), "expected at least one placed skill-tree node")
+	for key in paths_seen:
+		assert_true(roots_seen.has(key), "tree path '%s' has nodes but no depth-0 root" % key)

--- a/test/ability/test_ability_resources.gd.uid
+++ b/test/ability/test_ability_resources.gd.uid
@@ -1,0 +1,1 @@
+uid://cvvmhorrqmxie

--- a/test/ability/test_ability_scaling_data.gd
+++ b/test/ability/test_ability_scaling_data.gd
@@ -1,0 +1,78 @@
+# Unit tests for AbilityScalingData.generate_level_data() — composes the
+# per-stat formulas into a single AbilityLevelData for a given level.
+extends "res://test/test_case.gd"
+
+func _flat(base: float, per_level: float) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.FLAT
+	f.base_value = base
+	f.per_level = per_level
+	return f
+
+
+func test_generated_level_is_tagged() -> void:
+	var data := AbilityScalingData.new()
+	var level_data := data.generate_level_data(5)
+	assert_eq(level_data.level, 5)
+
+func test_basic_stats_are_generated_from_formulas() -> void:
+	var data := AbilityScalingData.new()
+	data.mana_cost_formula = _flat(10.0, 2.0)
+	data.cooldown_formula = _flat(5.0, -0.1)
+	data.damage_percent_formula = _flat(100.0, 8.0)
+
+	var l1 := data.generate_level_data(1)
+	assert_eq(l1.mana_cost, 10, "mana L1")
+	assert_almost_eq(l1.cooldown_time, 5.0, 0.001, "cooldown L1")
+	assert_eq(l1.damage_percent, 100, "damage L1")
+
+	var l5 := data.generate_level_data(5)
+	assert_eq(l5.mana_cost, 18, "mana L5")
+	assert_almost_eq(l5.cooldown_time, 4.6, 0.001, "cooldown L5")
+	assert_eq(l5.damage_percent, 132, "damage L5")
+
+func test_int_stats_truncate_fractional_values() -> void:
+	# mana_cost is an int; 10.5 must become 10, not round to 11.
+	var data := AbilityScalingData.new()
+	data.mana_cost_formula = _flat(10.0, 0.5)
+	assert_eq(data.generate_level_data(2).mana_cost, 10)
+
+func test_absent_formulas_keep_level_data_defaults() -> void:
+	# A scaling config with no formulas yields the AbilityLevelData defaults.
+	var level_data := AbilityScalingData.new().generate_level_data(1)
+	assert_eq(level_data.mana_cost, 0, "default mana")
+	assert_eq(level_data.damage_percent, 100, "default damage")
+	assert_eq(level_data.max_targets, 1, "default targets")
+	assert_eq(level_data.max_hits, 1, "default hits")
+	assert_almost_eq(level_data.cooldown_time, 0.0, 0.001, "default cooldown")
+
+func test_stat_bonus_formula_populates_stat_bonuses() -> void:
+	var sbf := StatBonusFormula.new()
+	sbf.stat_type = Constants.StatType.STRENGTH
+	sbf.flat_bonus_formula = _flat(5.0, 1.0)  # L1 = 5, L3 = 7
+
+	var data := AbilityScalingData.new()
+	data.stat_bonus_formulas = [sbf]
+
+	var level_data := data.generate_level_data(3)
+	assert_true(level_data.stat_bonuses.has(Constants.StatType.STRENGTH), "STRENGTH key present")
+	var stat: StatData = level_data.stat_bonuses[Constants.StatType.STRENGTH]
+	assert_eq(stat.flat_bonus_value, 7, "flat STR bonus at L3")
+
+func test_proc_is_generated_when_event_type_set() -> void:
+	var data := AbilityScalingData.new()
+	data.proc_event_type = "on_hit"
+	data.proc_chance_formula = _flat(0.1, 0.01)
+	data.proc_damage_formula = _flat(50.0, 5.0)
+
+	var level_data := data.generate_level_data(1)
+	assert_not_null(level_data.on_hit_proc, "on_hit proc generated")
+	assert_almost_eq(level_data.on_hit_proc.proc_chance, 0.1, 0.001, "proc chance")
+	assert_eq(level_data.on_hit_proc.damage_percent, 50, "proc damage")
+
+func test_no_proc_without_event_type() -> void:
+	# A chance formula alone, with no proc_event_type, generates nothing.
+	var data := AbilityScalingData.new()
+	data.proc_chance_formula = _flat(0.5, 0.0)
+	var level_data := data.generate_level_data(1)
+	assert_null(level_data.on_hit_proc, "no proc when event type empty")

--- a/test/ability/test_ability_scaling_data.gd.uid
+++ b/test/ability/test_ability_scaling_data.gd.uid
@@ -1,0 +1,1 @@
+uid://y7j6eg3s4cgk

--- a/test/ability/test_ability_scaling_formula.gd
+++ b/test/ability/test_ability_scaling_formula.gd
@@ -1,0 +1,107 @@
+# Unit tests for AbilityScalingFormula.calculate() — the per-level scaling math
+# that every ability stat is generated from.
+extends "res://test/test_case.gd"
+
+func _flat(base: float, per_level: float) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.FLAT
+	f.base_value = base
+	f.per_level = per_level
+	return f
+
+func _mult(base: float, multiplier: float) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.MULTIPLICATIVE
+	f.base_value = base
+	f.multiplier = multiplier
+	return f
+
+func _stepped(base: float, steps: Dictionary) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.STEPPED
+	f.base_value = base
+	# step_values is a typed Dictionary[int, int]; copy into a typed local so the
+	# assignment doesn't fail the runtime type check on an untyped literal.
+	var typed: Dictionary[int, int] = {}
+	for key in steps:
+		typed[int(key)] = int(steps[key])
+	f.step_values = typed
+	return f
+
+func _custom(base: float, expr: String) -> AbilityScalingFormula:
+	var f := AbilityScalingFormula.new()
+	f.scaling_type = AbilityScalingFormula.ScalingType.CUSTOM
+	f.base_value = base
+	f.custom_formula = expr
+	return f
+
+
+# ---- FLAT: base + (level - 1) * per_level ----
+
+func test_flat_level_one_returns_base() -> void:
+	assert_almost_eq(_flat(100.0, 5.0).calculate(1), 100.0, 0.001)
+
+func test_flat_scales_linearly_per_level() -> void:
+	var f := _flat(100.0, 5.0)
+	assert_almost_eq(f.calculate(2), 105.0, 0.001, "level 2")
+	assert_almost_eq(f.calculate(10), 145.0, 0.001, "level 10")
+
+func test_flat_zero_per_level_is_constant() -> void:
+	var f := _flat(42.0, 0.0)
+	assert_almost_eq(f.calculate(1), 42.0, 0.001)
+	assert_almost_eq(f.calculate(99), 42.0, 0.001)
+
+func test_flat_negative_per_level_decays() -> void:
+	# e.g. cooldown shrinking with level
+	assert_almost_eq(_flat(5.0, -0.1).calculate(5), 4.6, 0.001)
+
+
+# ---- MULTIPLICATIVE: base * multiplier ^ (level - 1) ----
+
+func test_multiplicative_level_one_returns_base() -> void:
+	assert_almost_eq(_mult(100.0, 1.1).calculate(1), 100.0, 0.001)
+
+func test_multiplicative_compounds() -> void:
+	var f := _mult(100.0, 1.1)
+	assert_almost_eq(f.calculate(2), 110.0, 0.001, "level 2")
+	assert_almost_eq(f.calculate(3), 121.0, 0.001, "level 3")
+	assert_almost_eq(f.calculate(5), 146.41, 0.001, "level 5")
+
+
+# ---- STEPPED: holds a value until the next breakpoint ----
+
+func test_stepped_holds_value_between_breakpoints() -> void:
+	var f := _stepped(50.0, {1: 100, 5: 150, 10: 200})
+	assert_almost_eq(f.calculate(1), 100.0, 0.001, "at first breakpoint")
+	assert_almost_eq(f.calculate(4), 100.0, 0.001, "before second breakpoint")
+	assert_almost_eq(f.calculate(5), 150.0, 0.001, "at second breakpoint")
+	assert_almost_eq(f.calculate(9), 150.0, 0.001, "before third breakpoint")
+	assert_almost_eq(f.calculate(10), 200.0, 0.001, "at third breakpoint")
+	assert_almost_eq(f.calculate(100), 200.0, 0.001, "past last breakpoint")
+
+func test_stepped_below_first_breakpoint_returns_base() -> void:
+	# No breakpoint at or below the level => falls back to base_value.
+	assert_almost_eq(_stepped(50.0, {5: 150}).calculate(1), 50.0, 0.001)
+
+func test_stepped_empty_returns_base() -> void:
+	assert_almost_eq(_stepped(77.0, {}).calculate(10), 77.0, 0.001)
+
+
+# ---- CUSTOM: GDScript expression with `level` and `base_value` ----
+
+func test_custom_evaluates_expression() -> void:
+	var f := _custom(100.0, "base_value + (level * 5)")
+	assert_almost_eq(f.calculate(1), 105.0, 0.001, "level 1")
+	assert_almost_eq(f.calculate(10), 150.0, 0.001, "level 10")
+
+func test_custom_can_use_level_quadratically() -> void:
+	assert_almost_eq(_custom(0.0, "level * level").calculate(4), 16.0, 0.001)
+
+func test_custom_empty_formula_returns_base() -> void:
+	assert_almost_eq(_custom(7.0, "").calculate(50), 7.0, 0.001)
+
+func test_custom_invalid_formula_falls_back_to_base() -> void:
+	# Malformed expression -> calculate() push_errors and returns base_value.
+	# The ERROR line printed during this test is expected and asserts graceful
+	# degradation (regression guard for the execute-failure fallback).
+	assert_almost_eq(_custom(9.0, "this is +/+ not valid").calculate(3), 9.0, 0.001)

--- a/test/ability/test_ability_scaling_formula.gd.uid
+++ b/test/ability/test_ability_scaling_formula.gd.uid
@@ -1,0 +1,1 @@
+uid://dj05eisndg4md

--- a/test/ability/test_ability_upgrades.gd
+++ b/test/ability/test_ability_upgrades.gd
@@ -1,0 +1,171 @@
+# Content-validation tests for the PR-6 ability upgrade trees. Walks every
+# AbilityData.upgrades entry across all abilities and asserts the invariants the
+# purchase/save systems rely on: stable unique ids, valid tiers/costs, coherent
+# tier-gating, and well-formed T3 variant groups. Failure messages name the
+# offending upgrade so authoring mistakes are actionable.
+extends "res://test/test_case.gd"
+
+const ABILITIES_ROOT := "res://resources/Abilities"
+
+static var _ability_cache: Array = []
+
+
+func _all_abilities() -> Array:
+	if _ability_cache.is_empty():
+		var paths: Array[String] = []
+		_scan(ABILITIES_ROOT, paths)
+		for p in paths:
+			var res = load(p)
+			if res is AbilityData:
+				_ability_cache.append(res)
+	return _ability_cache
+
+func _scan(dir_path: String, out_paths: Array[String]) -> void:
+	var dir := DirAccess.open(dir_path)
+	if dir == null:
+		return
+	dir.list_dir_begin()
+	var entry := dir.get_next()
+	while entry != "":
+		var full := dir_path + "/" + entry
+		if dir.current_is_dir():
+			if not entry.begins_with("."):
+				_scan(full, out_paths)
+		elif entry.ends_with(".tres"):
+			out_paths.append(full)
+		entry = dir.get_next()
+	dir.list_dir_end()
+
+# Every upgrade reachable through an ability's `upgrades` array, deduped by
+# resource_path (an upgrade resource shared by two abilities counts once).
+func _unique_upgrades() -> Array:
+	var seen := {}
+	var out: Array = []
+	for ability in _all_abilities():
+		for up in ability.upgrades:
+			if up == null:
+				continue
+			var path: String = up.resource_path
+			if seen.has(path):
+				continue
+			seen[path] = true
+			out.append(up)
+	return out
+
+
+func test_upgrade_content_exists() -> void:
+	# Guards against an empty/broken scan making the rest vacuous.
+	assert_true(_unique_upgrades().size() >= 10, "expected upgrade content, found %d" % _unique_upgrades().size())
+
+func test_every_upgrade_has_identity() -> void:
+	var upgrades := _unique_upgrades()
+	assert_false(upgrades.is_empty(), "no upgrades loaded")
+	for up in upgrades:
+		assert_false(up.upgrade_id.is_empty(), "%s has empty upgrade_id" % up.resource_path)
+		assert_false(up.upgrade_name.is_empty(), "%s (%s) has empty upgrade_name" % [up.upgrade_id, up.resource_path])
+
+func test_upgrade_ids_are_globally_unique() -> void:
+	# Save/load persists owned upgrades by upgrade_id, so collisions corrupt state.
+	var id_to_path := {}
+	var dupes: Array[String] = []
+	for up in _unique_upgrades():
+		var id: String = up.upgrade_id
+		if id_to_path.has(id):
+			dupes.append("'%s' on %s and %s" % [id, id_to_path[id], up.resource_path])
+		else:
+			id_to_path[id] = up.resource_path
+	assert_true(id_to_path.size() > 0, "no upgrades found")
+	assert_true(dupes.is_empty(), "duplicate upgrade_ids: %s" % str(dupes))
+
+func test_upgrade_tier_in_range() -> void:
+	var upgrades := _unique_upgrades()
+	assert_false(upgrades.is_empty(), "no upgrades loaded")
+	for up in upgrades:
+		assert_true(up.tier >= 1 and up.tier <= 3, "%s has tier %d (expected 1-3)" % [up.upgrade_id, up.tier])
+
+func test_upgrade_point_cost_positive() -> void:
+	var upgrades := _unique_upgrades()
+	assert_false(upgrades.is_empty(), "no upgrades loaded")
+	for up in upgrades:
+		assert_true(up.point_cost >= 1, "%s has point_cost %d (< 1)" % [up.upgrade_id, up.point_cost])
+
+func test_upgrade_has_effect_key() -> void:
+	# Consuming code (AbilityComponent generic keys, or the ability's AL_ script)
+	# dispatches on effect_key; an empty one is a dead upgrade.
+	var upgrades := _unique_upgrades()
+	assert_false(upgrades.is_empty(), "no upgrades loaded")
+	for up in upgrades:
+		assert_false(up.effect_key.is_empty(), "%s has empty effect_key" % up.upgrade_id)
+
+func test_tier_gating_is_coherent() -> void:
+	# T2 unlocks behind a T1, T3 behind a T2 — so an ability offering a higher
+	# tier must also offer the lower tier, or the higher tier is unreachable.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	for ability in abilities:
+		var tiers := {}
+		for up in ability.upgrades:
+			if up != null:
+				tiers[up.tier] = true
+		if tiers.is_empty():
+			continue
+		if tiers.has(2):
+			assert_true(tiers.has(1), "%s offers a Tier-2 upgrade but no Tier-1" % ability.ability_name)
+		if tiers.has(3):
+			assert_true(tiers.has(2), "%s offers a Tier-3 upgrade but no Tier-2" % ability.ability_name)
+
+func test_variant_groups_are_well_formed() -> void:
+	# A variant_group is a mutually-exclusive Tier-3 choice. HARD invariant: every
+	# member of a group is Tier-3, and the mutex system has at least one real
+	# (>=2 member) group. SOFT check: a single-member group is a content smell
+	# (likely an incomplete variant set) — logged as a warning, not failed, so a
+	# known WIP gap (currently `cc_finisher_variant`) doesn't block the suite.
+	var groups := {}
+	for up in _unique_upgrades():
+		if up.variant_group.is_empty():
+			continue
+		if not groups.has(up.variant_group):
+			groups[up.variant_group] = []
+		groups[up.variant_group].append(up)
+	assert_false(groups.is_empty(), "expected at least one variant group")
+
+	var multi_member_count := 0
+	var lone_groups: Array[String] = []
+	for group_name in groups:
+		var members: Array = groups[group_name]
+		if members.size() >= 2:
+			multi_member_count += 1
+		else:
+			lone_groups.append(group_name)
+		# HARD: every member of any group must be Tier-3.
+		for m in members:
+			assert_eq(m.tier, 3, "variant_group '%s' member %s is tier %d (variants should be Tier-3)" % [group_name, m.upgrade_id, m.tier])
+
+	assert_true(multi_member_count >= 1, "expected at least one real (>=2 member) variant mutex")
+	if not lone_groups.is_empty():
+		print("  ⚠ CONTENT WARNING: single-member variant_group(s) — a 1-option mutex does nothing; finish or clear the tag: %s" % str(lone_groups))
+
+func test_conditional_damage_bonus_upgrades_are_on_passives() -> void:
+	# PR (conditional passives): a conditional passive's upgrade tree scales its
+	# bonus via the generic "conditional_damage_bonus" effect_key, which
+	# AbilityComponent only reads inside _foreach_learned_passive. An upgrade with
+	# this key on a NON-passive ability is dead weight — catch that authoring bug.
+	var abilities := _all_abilities()
+	assert_false(abilities.is_empty(), "no abilities loaded")
+	var found := 0
+	for ability in abilities:
+		for up in ability.upgrades:
+			if up != null and up.effect_key == "conditional_damage_bonus":
+				found += 1
+				assert_eq(ability.ability_type, Constants.AbilityType.PASSIVE,
+					"%s carries a conditional_damage_bonus upgrade (%s) but is not a PASSIVE" % [ability.ability_name, up.upgrade_id])
+	assert_true(found >= 1, "expected conditional_damage_bonus upgrades to exist (feature wiring present)")
+
+func test_upgrade_tooltips_render() -> void:
+	var upgrades := _unique_upgrades()
+	assert_false(upgrades.is_empty(), "no upgrades loaded")
+	for up in upgrades:
+		var unowned: String = up.get_tooltip_text(false)
+		var owned: String = up.get_tooltip_text(true)
+		assert_true(up.upgrade_name in unowned, "%s tooltip missing its name" % up.upgrade_id)
+		assert_true("Owned" in owned, "%s owned-tooltip missing 'Owned' marker" % up.upgrade_id)

--- a/test/ability/test_ability_upgrades.gd.uid
+++ b/test/ability/test_ability_upgrades.gd.uid
@@ -1,0 +1,1 @@
+uid://vmsmlbd5o72a

--- a/test/run_tests.gd
+++ b/test/run_tests.gd
@@ -1,0 +1,96 @@
+# Headless unit-test runner. No third-party dependency.
+#
+# Run from the project root:
+#   <godot> --headless --path . --script res://test/run_tests.gd
+#
+# (or use test/run_tests.bat). Exit code is 0 when every test passes, 1 when
+# any test fails — so CI can gate on it.
+#
+# Tests run on the first processed frame (not in _initialize) so autoload
+# singletons (ResourceManager, BotManager, ...) have finished their _ready and
+# are fully populated — the AbilityComponent suite depends on that.
+extends SceneTree
+
+const SUITES: Array[String] = [
+	"res://test/ability/test_ability_scaling_formula.gd",
+	"res://test/ability/test_ability_scaling_data.gd",
+	"res://test/ability/test_ability_level_data.gd",
+	"res://test/ability/test_ability_data.gd",
+	"res://test/ability/test_ability_resources.gd",
+	"res://test/ability/test_ability_upgrades.gd",
+	"res://test/ability/test_ability_component.gd",
+]
+
+var _ran := false
+
+func _process(_delta: float) -> bool:
+	if _ran:
+		return true
+	_ran = true
+	var any_failed := _run_all()
+	quit(1 if any_failed else 0)
+	return true
+
+## Runs every suite. Returns true if any test failed.
+func _run_all() -> bool:
+	var total: int = 0
+	var passed: int = 0
+	var failed_names: Array[String] = []
+
+	print("\n========== Ability unit tests ==========")
+	for suite_path in SUITES:
+		var script: GDScript = load(suite_path)
+		var suite_name: String = suite_path.get_file().trim_suffix(".gd")
+		if script == null:
+			print("  [LOAD FAIL] %s" % suite_path)
+			failed_names.append("%s (failed to load)" % suite_name)
+			total += 1
+			continue
+
+		print("\n-- %s --" % suite_name)
+		# get_script_method_list returns only methods declared in this script,
+		# so inherited asserts / before_each are excluded automatically.
+		var suite_test_count := 0
+		for method_info in script.get_script_method_list():
+			var method_name: String = method_info.name
+			if not method_name.begins_with("test_"):
+				continue
+
+			suite_test_count += 1
+			total += 1
+			var instance = script.new()  # fresh instance per test for isolation
+			instance.before_each()
+			instance.callv(method_name, [])
+
+			# A genuine pass has no failures AND ran at least one assertion. Zero
+			# assertions usually means the test errored out before asserting (a
+			# runtime error in setup), so treat that as a failure rather than a
+			# silent false-positive pass.
+			if instance.failures.is_empty() and instance.assertion_count > 0:
+				passed += 1
+				print("  [PASS] %s" % method_name)
+			else:
+				failed_names.append("%s::%s" % [suite_name, method_name])
+				print("  [FAIL] %s" % method_name)
+				if instance.assertion_count == 0:
+					print("         (no assertions ran — test errored or is empty)")
+				for failure in instance.failures:
+					print("         %s" % failure)
+
+		# A suite that loaded but exposes no test_ methods is almost always a
+		# parse error in the suite (the broken script still loads non-null) or an
+		# empty file — either way it must not pass silently.
+		if suite_test_count == 0:
+			total += 1
+			failed_names.append("%s (no tests found — parse error or empty)" % suite_name)
+			print("  [SUITE ERROR] no test_ methods found (parse error or empty suite)")
+
+	print("\n========================================")
+	print("  %d / %d passed" % [passed, total])
+	if not failed_names.is_empty():
+		print("  FAILED:")
+		for name in failed_names:
+			print("    - %s" % name)
+	print("========================================\n")
+
+	return not failed_names.is_empty()

--- a/test/run_tests.gd.uid
+++ b/test/run_tests.gd.uid
@@ -1,0 +1,1 @@
+uid://dc0nkafnphrgn

--- a/test/test_case.gd
+++ b/test/test_case.gd
@@ -1,0 +1,52 @@
+# Base class for the lightweight headless unit-test harness.
+# Test suites do `extends "res://test/test_case.gd"` and define methods named
+# `test_*`. The runner (test/run_tests.gd) instantiates one fresh suite per
+# test method, calls `before_each()`, runs the method, then reads `failures`.
+# No global class_name on purpose — keeps the project's class namespace clean.
+extends RefCounted
+
+var failures: Array[String] = []
+var assertion_count: int = 0
+
+## Override in a suite for per-test setup.
+func before_each() -> void:
+	pass
+
+func fail(msg: String) -> void:
+	failures.append(msg)
+
+func assert_true(cond: bool, msg: String = "") -> void:
+	assertion_count += 1
+	if not cond:
+		failures.append("assert_true failed. %s" % msg)
+
+func assert_false(cond: bool, msg: String = "") -> void:
+	assertion_count += 1
+	if cond:
+		failures.append("assert_false failed. %s" % msg)
+
+func assert_eq(actual, expected, msg: String = "") -> void:
+	assertion_count += 1
+	if actual != expected:
+		failures.append("assert_eq failed: expected <%s> got <%s>. %s" % [str(expected), str(actual), msg])
+
+func assert_ne(actual, unexpected, msg: String = "") -> void:
+	assertion_count += 1
+	if actual == unexpected:
+		failures.append("assert_ne failed: did not expect <%s>. %s" % [str(unexpected), msg])
+
+## Float comparison with an absolute tolerance.
+func assert_almost_eq(actual: float, expected: float, eps: float, msg: String = "") -> void:
+	assertion_count += 1
+	if absf(actual - expected) > eps:
+		failures.append("assert_almost_eq failed: expected <%s> +/- <%s> got <%s>. %s" % [str(expected), str(eps), str(actual), msg])
+
+func assert_null(value, msg: String = "") -> void:
+	assertion_count += 1
+	if value != null:
+		failures.append("assert_null failed: got <%s>. %s" % [str(value), msg])
+
+func assert_not_null(value, msg: String = "") -> void:
+	assertion_count += 1
+	if value == null:
+		failures.append("assert_not_null failed. %s" % msg)

--- a/test/test_case.gd.uid
+++ b/test/test_case.gd.uid
@@ -1,0 +1,1 @@
+uid://dwunqqhvpy3nj


### PR DESCRIPTION
## What

Adds a **zero-dependency headless test harness** and **81 ability tests** to the overhaul, plus one source fix the suite uncovered.

### Harness (`test/`)
- `run_tests.gd` (SceneTree) runs all suites on the first processed frame (so autoloads are populated). Exit `0` = all pass, `1` = any fail — CI-gateable.
- `test_case.gd` — GUT-style asserts. A zero-assertion test or a suite with no `test_` methods (parse error) is reported as a failure, never a silent pass.
- Run with `run_tests.bat` or `godot --headless --script res://test/run_tests.gd --log-file test/last_run.log`.

### Coverage (81 tests, all green)
- **Scaling math** — FLAT/MULTIPLICATIVE/STEPPED/CUSTOM formula + per-level generation.
- **All ability `.tres`** — identity, every level generates, sane stats, bounds, `active_behavior`, discipline mapping, prerequisites satisfiable, tooltips.
- **Skill tree** (recent) — `tree_path`/`tree_depth` in range, every placed node has a path-parent (no climb-gate orphans), each populated path has a depth-0 root.
- **Upgrades** (PR 6) — unique ids, tier/cost, tier gating, variant groups all tier-3, `conditional_damage_bonus` upgrades live on PASSIVE abilities.
- **Live AbilityComponent** — cooldown tick/expiry, per-discipline point pools, leveling + gating, the **climb-gate** (`is_tree_node_unlocked`, `can_level_up_ability`), and the **upgrade purchase API** (tier gating, variant mutex, point spend, magnitude helpers). Fixtures resolve dynamically via `ResourceManager` so content renames don't break them.

## Source fix (1 commit)
`AbilityScalingFormula.calculate()` returned `0.0` (failed result) instead of `base_value` when a CUSTOM formula fails at `execute()` time. Guarded with `has_execute_failed()`, mirroring the existing parse-error fallback.

## Notes for review
- ⚠ **Content smell surfaced (non-blocking):** `cc_finisher_variant` (Crescent Cleave) is a single-member variant group — a 1-option mutex does nothing. Logged as a warning by the suite, not a failure. Fix by authoring the other two finisher variants or clearing the tag.
- This PR contains **only** the test harness + the formula fix. Unrelated working-tree WIP (training dummy, health/bot_manager/hotbar/EnemyData) is intentionally left uncommitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)