### PR TITLE
Mastery economy: 100-cap, 1pt/level, no free starter (PR 8a)

### DIFF
--- a/resources/Player/Disciplines/bow.tres
+++ b/resources/Player/Disciplines/bow.tres
@@ -34,5 +34,4 @@ stat_bonuses = Dictionary[int, int]({
 0: 2,
 2: 3
 })
-starter_ability = ExtResource("6_avqjs")
 metadata/_custom_type_script = "uid://buwbui1bka8vl"

--- a/resources/Player/Disciplines/dagger.tres
+++ b/resources/Player/Disciplines/dagger.tres
@@ -34,5 +34,4 @@ stat_bonuses = Dictionary[int, int]({
 2: 2,
 3: 3
 })
-starter_ability = ExtResource("5_twin")
 metadata/_custom_type_script = "uid://buwbui1bka8vl"

--- a/resources/Player/Disciplines/staff.tres
+++ b/resources/Player/Disciplines/staff.tres
@@ -39,5 +39,4 @@ stat_bonuses = Dictionary[int, int]({
 1: 3,
 3: 2
 })
-starter_ability = ExtResource("5_bolt")
 metadata/_custom_type_script = "uid://buwbui1bka8vl"

--- a/resources/Player/Disciplines/sword.tres
+++ b/resources/Player/Disciplines/sword.tres
@@ -33,5 +33,4 @@ stat_bonuses = Dictionary[int, int]({
 0: 3,
 2: 2
 })
-starter_ability = ExtResource("4_qbbda")
 metadata/_custom_type_script = "uid://buwbui1bka8vl"

--- a/scripts/Components/CLAUDE.md
+++ b/scripts/Components/CLAUDE.md
@@ -88,8 +88,7 @@ Player (MultiplayerPlayerV2)
     │                               keys are read by AL_*.gd. See hook section.
     │                               Respec: respec_ability(id) /
     │                               respec_discipline(disc_key) / respec_all()
-    │                               refund levels (above the free starter
-    │                               baseline) + upgrade costs back to the
+    │                               refund levels + upgrade costs back to the
     │                               pool(s), reset levels/upgrades. Shared
     │                               _refund_ability + _finalize_respec helpers.
     │                               Server-auth via respec_*_request RPCs.
@@ -97,9 +96,9 @@ Player (MultiplayerPlayerV2)
     │                               reconcile_ability_points() recomputes each
     │                               pool from first principles — granted
     │                               (mastery_level * ABILITY_POINTS_PER_MASTERY_LEVEL,
-    │                               6 since the 2026-05-28 balance pass) minus
-    │                               spent (levels above the free starter baseline
-    │                               + owned upgrade costs) = unused — and corrects
+    │                               1 since the PR 8 2026-05-31 redesign) minus
+    │                               spent (every level + owned upgrade costs)
+    │                               = unused — and corrects
     │                               any drift either way (so a grant-constant
     │                               change is retroactive on load). Called at end of
     │                               load_abilities (do_sync=false during load;

--- a/scripts/Components/ability.gd
+++ b/scripts/Components/ability.gd
@@ -99,14 +99,20 @@ var _loading_mode: bool = false
 ## level grant rule which leaked points evenly across the 4 trees and let a
 ## character earn points for trees they never touched.
 ##
-## PR 6 balance pass (2026-05-28): raised 3 -> 6 so a maxed-mastery discipline
-## (MASTERY_CAP 20) yields 120 points. Target endgame build at 120: MAX 3
-## actives + fully upgrade them (3 * 24) + 2 filler actives + MAX 2 passives +
-## passive upgrades. You still can't max all 8 actives, so build identity comes
-## from WHICH abilities + upgrades you pick. The reconcile_ability_points()
-## guard makes this retroactive — existing characters get the new total on
-## next load (granted = mastery_level * 6 recomputed against spent).
-const ABILITY_POINTS_PER_MASTERY_LEVEL: int = 6
+## PR 8 (2026-05-31): dropped 6 -> 1 alongside MASTERY_CAP 20 -> 100. Pool at
+## cap is now 100 points, reached around character level 70 (build phase ends,
+## refinement phase begins). One point per mastery rank = maximum reward
+## frequency — the player gets a meaningful pickup almost every char level.
+## The 100-pt budget is intentionally tight: Specialist build (~82 pts: 5
+## actives + 4 passives + 3 upgrade paths) fits, Deep Specialist (~105) does
+## not — every point is a forced trade-off. No "free discipline starter"
+## anymore: all abilities cost equally, and the player picks where their
+## first point lands at character creation (bootstrap_chosen_discipline
+## bumps mastery to 1 immediately so the grant pathway gives them that pt).
+## The reconcile_ability_points() guard makes this retroactive — existing
+## characters get the new total on next load (granted = mastery_level * 1
+## recomputed against spent).
+const ABILITY_POINTS_PER_MASTERY_LEVEL: int = 1
 
 ## PR 4: canonical lowercase discipline keys, in display order (the order
 ## the AbilityWindow renders tabs).
@@ -196,34 +202,21 @@ func _ready() -> void:
 	# Initialize class abilities on the server or in single-player.
 	# Clients will receive this data via an RPC sync when they connect.
 	#
-	# Each discipline's starter ability (configured on WeaponDisciplineData.starter_ability)
-	# is auto-leveled to 1 so a fresh character can cast something immediately.
-	# Without this, classes like Mage (whose basic attack uses the staff's
-	# tiny WEAPONATTACK while their kit is built around MAGICATTACK abilities)
-	# can't fight effectively until they earn their first ability point on
-	# level-up. Save data still overrides this — returning characters keep
-	# whatever level they had leveled the ability to.
-	#
-	# PR 4 fix (2026-05-28): all FOUR tier-1 disciplines' starter abilities
-	# are auto-leveled to 1, not just the player's starting class's starter.
-	# So when a Swordsman picks up a bow they immediately have Double Shot
-	# ready to fire instead of being stuck with a basic-attack swing of a
-	# weapon they have no abilities for. Each discipline's full ability list
-	# is also added at level 0 so the AbilityWindow can show them with a
-	# "Learn" / "+" affordance.
+	# PR 8 (2026-05-31): no more "discipline starter ability" auto-grant. All
+	# abilities are added at level 0 — including every tier-1 discipline's
+	# tree — so the AbilityWindow can show them with a "Learn" / "+"
+	# affordance. The player's first ability point comes from being
+	# bootstrapped to mastery 1 in their chosen discipline (handled by
+	# load_abilities's fresh-character check, or at character creation
+	# directly). They then choose which ability to spend it on.
 	if not multiplayer.has_multiplayer_peer() or multiplayer.is_server():
-		# Original class abilities first (keeps the existing per-class starter
-		# behavior intact for the player's chosen discipline).
-		var starter: AbilityData = _class_component.get_starter_ability() if _class_component else null
+		# Current class's abilities first.
 		for ability_data in _class_component.get_class_abilities():
 			if ability_data and not _ability_levels.has(ability_data.ability_id):
-				var initial_level: int = 1 if (starter and ability_data == starter) else 0
-				_learn_ability_local(ability_data.ability_id, initial_level, false)
+				_learn_ability_local(ability_data.ability_id, 0, false)
 
-		# Then iterate the OTHER three tier-1 disciplines and seed their
-		# starter abilities at level 1 + the rest of each tree at level 0.
-		# Skips the starting discipline (already handled above) and tier-2
-		# advancement classes (those live in their tier-1 parent's tree).
+		# Then the OTHER tier-1 disciplines' trees so they appear in the
+		# AbilityWindow tabs (at level 0 = locked/learnable).
 		var starting_class: int = _class_component.current_class if _class_component else -1
 		for tier1_disc in [
 			Constants.ClassType.SWORD,
@@ -236,12 +229,10 @@ func _ready() -> void:
 			var disc_data: WeaponDisciplineData = ResourceManager.get_class_data(tier1_disc)
 			if disc_data == null:
 				continue
-			var disc_starter: AbilityData = disc_data.starter_ability
 			for ability_data in disc_data.skills:
 				if ability_data == null or _ability_levels.has(ability_data.ability_id):
 					continue
-				var initial_level: int = 1 if (disc_starter and ability_data == disc_starter) else 0
-				_learn_ability_local(ability_data.ability_id, initial_level, false)
+				_learn_ability_local(ability_data.ability_id, 0, false)
 
 	##print("AbilityComponent ready. Loaded abilities: ", _ability_levels)
 
@@ -1140,33 +1131,23 @@ func _on_mastery_level_up(discipline: int, _new_level: int) -> void:
 
 
 func _on_class_changed(_new_class_name: String) -> void:
-	# On initial character creation the component pre-loaded the default
-	# class's abilities in _ready() (including its starter at level 1)
-	# before the real class was assigned, so anything not in the new class
-	# must be dropped — including a stale level-1 starter from the default
-	# class. Job advancement stays safe because the advanced class's skill
-	# list is a superset of the base class's, so any leveled ability is
-	# present in new_class_ids and survives.
+	# On class change, prune any ability that doesn't belong to a known
+	# tier-1 discipline's skill list, then ensure every tier-1 discipline's
+	# tree shows up at level 0 in the AbilityWindow. Job advancement stays
+	# safe because the advanced class's skill list is a superset of its
+	# parent tier-1's tree, so any leveled ability survives the prune.
 	#
-	# PR 4 fix (2026-05-28): "valid" abilities span ALL FOUR tier-1
-	# disciplines now, not just the new class's skills. Without this, the
-	# all-disciplines-starter init in _ready was getting wiped here — class
-	# change from default → BOW would prune Sword/Staff/Dagger starters
-	# because they weren't in Bow's skills list. With the broadened set,
-	# only stale non-tier-1 abilities (e.g. from a default BEGINNER class)
-	# get pruned, while cross-discipline starters persist.
+	# PR 8 (2026-05-31): no starter re-seed — abilities only enter
+	# _ability_levels at level 0 here, and only the player's purchases
+	# (or load_abilities) push them above 0.
 	#
 	# RPCs are not broadcast here because the class change itself is synced,
 	# so clients run this same logic locally.
 	if not multiplayer.has_multiplayer_peer() or multiplayer.is_server():
-		var new_class_ids: Dictionary = {}
-		# Include the current class's abilities (covers tier-2 advancements
-		# whose superset includes their tier-1 parent's tree).
+		var valid_ability_ids: Dictionary = {}
 		for ability_data in _class_component.get_class_abilities():
 			if ability_data:
-				new_class_ids[ability_data.ability_id] = true
-		# Also include every tier-1 discipline's abilities so cross-discipline
-		# starters aren't pruned.
+				valid_ability_ids[ability_data.ability_id] = true
 		for tier1_disc in [
 			Constants.ClassType.SWORD,
 			Constants.ClassType.BOW,
@@ -1178,16 +1159,14 @@ func _on_class_changed(_new_class_name: String) -> void:
 				continue
 			for ability_data in disc_data.skills:
 				if ability_data:
-					new_class_ids[ability_data.ability_id] = true
+					valid_ability_ids[ability_data.ability_id] = true
 
 		for ability_id in _ability_levels.keys():
-			if not new_class_ids.has(ability_id):
+			if not valid_ability_ids.has(ability_id):
 				_ability_levels.erase(ability_id)
 
-		# Re-seed each tier-1 discipline's starter ability at level 1 if it's
-		# missing from _ability_levels (defensive — the init in _ready does
-		# this, but the prune above could have removed it in edge cases).
-		# Other abilities get added at level 0 so they show in the UI.
+		# Seed any tier-1 discipline ability we don't yet know about at level 0
+		# so the AbilityWindow can show it as learnable.
 		for tier1_disc in [
 			Constants.ClassType.SWORD,
 			Constants.ClassType.BOW,
@@ -1197,20 +1176,16 @@ func _on_class_changed(_new_class_name: String) -> void:
 			var disc_data: WeaponDisciplineData = ResourceManager.get_class_data(tier1_disc)
 			if disc_data == null:
 				continue
-			var disc_starter: AbilityData = disc_data.starter_ability
 			for ability_data in disc_data.skills:
 				if ability_data == null or _ability_levels.has(ability_data.ability_id):
 					continue
-				var initial_level: int = 1 if (disc_starter and ability_data == disc_starter) else 0
-				_learn_ability_local(ability_data.ability_id, initial_level, false)
+				_learn_ability_local(ability_data.ability_id, 0, false)
 
-		# Re-seed the current class's starter too (covers tier-2 advancement
-		# starter abilities that aren't in any tier-1 tree).
-		var starter: AbilityData = _class_component.get_starter_ability()
+		# Cover any current-class abilities not in a tier-1 tree (tier-2
+		# advancement classes with abilities of their own).
 		for ability_data in _class_component.get_class_abilities():
 			if ability_data and not _ability_levels.has(ability_data.ability_id):
-				var initial_level: int = 1 if (starter and ability_data == starter) else 0
-				_learn_ability_local(ability_data.ability_id, initial_level, false)
+				_learn_ability_local(ability_data.ability_id, 0, false)
 
 #endregion
 
@@ -1338,6 +1313,44 @@ func load_abilities(data: Dictionary) -> void:
 	#else:
 		#for ability_id in _ability_levels:
 			#print("Loaded ability: %s at level %d" % [ability_id, _ability_levels[ability_id]])
+
+
+## PR 8 (2026-05-31): one-shot bootstrap for a fresh character. Replaces the
+## old free-discipline-starter system. If this character has never spent a
+## point AND has earned no mastery in any discipline, bump their chosen
+## class's mastery from 0 to 1 — the existing mastery_level_changed pathway
+## then grants them 1 ability point, which they spend at character creation
+## on whichever ability they want.
+##
+## Safe to call on every login: the guards make it a no-op for any returning
+## character (mastery > 0 in any discipline, or any ability above level 0).
+## Server-only — clients receive the resulting mastery + point sync via the
+## standard RPCs.
+func bootstrap_fresh_character_if_needed() -> void:
+	if multiplayer.has_multiplayer_peer() and not multiplayer.is_server():
+		return
+	if not is_instance_valid(_weapon_mastery_component) or not is_instance_valid(_class_component):
+		return
+	# Any spent point or earned mastery means this isn't a fresh char.
+	for ability_id in _ability_levels:
+		if int(_ability_levels[ability_id]) > 0:
+			return
+	for disc in [
+		Constants.ClassType.SWORD,
+		Constants.ClassType.BOW,
+		Constants.ClassType.STAFF,
+		Constants.ClassType.DAGGER,
+	]:
+		if _weapon_mastery_component.get_mastery_level(disc) > 0:
+			return
+	# Chosen class must be a tier-1 discipline (the only ones that earn mastery).
+	var chosen: int = _class_component.current_class
+	if chosen != Constants.ClassType.SWORD \
+		and chosen != Constants.ClassType.BOW \
+		and chosen != Constants.ClassType.STAFF \
+		and chosen != Constants.ClassType.DAGGER:
+		return
+	_weapon_mastery_component.bootstrap_chosen_discipline(chosen)
 
 
 ## PR 3 helper. Picks the currently-active weapon's binding dict for a load.
@@ -1658,14 +1671,13 @@ func respec_discipline(disc_key: String) -> bool:
 func _respec_discipline_local(disc_key: String) -> bool:
 	if not _available_points_per_discipline.has(disc_key):
 		return false
-	var starter_id: String = _discipline_starter_ability_id(disc_key)
 	var reset_ids: Array[String] = []
 	var refund: int = 0
 	for ability_id in _ability_levels.keys():
 		var ability: AbilityData = ResourceManager.get_ability_data(ability_id)
 		if ability == null or _ability_primary_discipline(ability) != disc_key:
 			continue
-		refund += _refund_ability(ability_id, starter_id, reset_ids)
+		refund += _refund_ability(ability_id, reset_ids)
 	_available_points_per_discipline[disc_key] = int(_available_points_per_discipline.get(disc_key, 0)) + refund
 	_finalize_respec([disc_key], reset_ids)
 	return true
@@ -1696,9 +1708,8 @@ func _respec_ability_local(ability_id: String) -> bool:
 	var disc_key: String = _ability_primary_discipline(ability)
 	if disc_key == "" or not _available_points_per_discipline.has(disc_key):
 		return false
-	var starter_id: String = _discipline_starter_ability_id(disc_key)
 	var reset_ids: Array[String] = []
-	var refund: int = _refund_ability(ability_id, starter_id, reset_ids)
+	var refund: int = _refund_ability(ability_id, reset_ids)
 	_available_points_per_discipline[disc_key] = int(_available_points_per_discipline.get(disc_key, 0)) + refund
 	_finalize_respec([disc_key], reset_ids)
 	return true
@@ -1731,8 +1742,7 @@ func _respec_all_local() -> bool:
 		var disc_key: String = _ability_primary_discipline(ability)
 		if disc_key == "":
 			continue
-		var starter_id: String = _discipline_starter_ability_id(disc_key)
-		refund_by_disc[disc_key] = int(refund_by_disc.get(disc_key, 0)) + _refund_ability(ability_id, starter_id, reset_ids)
+		refund_by_disc[disc_key] = int(refund_by_disc.get(disc_key, 0)) + _refund_ability(ability_id, reset_ids)
 	for disc_key in refund_by_disc:
 		_available_points_per_discipline[disc_key] = int(_available_points_per_discipline.get(disc_key, 0)) + int(refund_by_disc[disc_key])
 	_finalize_respec(DISCIPLINE_KEYS, reset_ids)
@@ -1748,23 +1758,27 @@ func respec_all_request() -> void:
 	_respec_all_local()
 
 
-## Refund + reset ONE ability: points for levels above the free starter
-## baseline + all owned upgrade costs. Mutates _ability_levels /
-## _learned_upgrades, appends to reset_ids if the level changed. Returns the
-## refund. No emit/sync — callers batch that via _finalize_respec.
-func _refund_ability(ability_id: String, starter_id: String, reset_ids: Array) -> int:
+## Refund + reset ONE ability: points for current level + all owned upgrade
+## costs. Mutates _ability_levels / _learned_upgrades, appends to reset_ids
+## if the level changed. Returns the refund. No emit/sync — callers batch
+## that via _finalize_respec.
+##
+## PR 8 (2026-05-31): no more starter ability discount. All abilities reset
+## to level 0 and refund their full level + upgrade cost. The previous
+## "starter ability stays at L1 free" baseline went away with the starter
+## concept itself.
+func _refund_ability(ability_id: String, reset_ids: Array) -> int:
 	var ability: AbilityData = ResourceManager.get_ability_data(ability_id)
 	if ability == null:
 		return 0
-	var baseline: int = 1 if ability_id == starter_id else 0
 	var current_level: int = int(_ability_levels.get(ability_id, 0))
-	var refund: int = maxi(0, current_level - baseline)
+	var refund: int = current_level
 	for owned_id in _learned_upgrades.get(ability_id, []):
 		var up: AbilityUpgradeData = _find_upgrade(ability, owned_id)
 		if up != null:
 			refund += up.point_cost
-	if current_level != baseline:
-		_ability_levels[ability_id] = baseline
+	if current_level != 0:
+		_ability_levels[ability_id] = 0
 		reset_ids.append(ability_id)
 	_learned_upgrades.erase(ability_id)
 	return refund
@@ -1783,23 +1797,6 @@ func _finalize_respec(disc_keys: Array, reset_ids: Array) -> void:
 			sync_ability_level.rpc(ability_id, int(_ability_levels.get(ability_id, 0)))
 		sync_ability_points_per_discipline.rpc(_available_points_per_discipline.duplicate())
 		sync_learned_upgrades.rpc(_learned_upgrades.duplicate(true))
-
-
-## Maps a discipline key to its starter ability's id (the one auto-leveled to
-## 1 at character creation), via the WeaponDisciplineData. "" if unknown.
-func _discipline_starter_ability_id(disc_key: String) -> String:
-	var class_type: int = -1
-	match disc_key:
-		"sword": class_type = Constants.ClassType.SWORD
-		"bow": class_type = Constants.ClassType.BOW
-		"staff": class_type = Constants.ClassType.STAFF
-		"dagger": class_type = Constants.ClassType.DAGGER
-	if class_type == -1:
-		return ""
-	var disc_data = ResourceManager.get_class_data(class_type)
-	if disc_data and disc_data.starter_ability:
-		return disc_data.starter_ability.ability_id
-	return ""
 
 
 ## Safety net (PR 6): recompute each discipline's UNUSED point pool from first
@@ -1838,19 +1835,17 @@ func reconcile_ability_points(do_sync: bool = true) -> void:
 		sync_ability_points_per_discipline.rpc(_available_points_per_discipline.duplicate())
 
 
-## Non-mutating sum of points SPENT in a discipline: levels above each ability's
-## free baseline (1 for the discipline starter, else 0) + the point_cost of
-## every owned upgrade. Mirrors what _refund_ability would hand back, without
-## resetting anything.
+## Non-mutating sum of points SPENT in a discipline: every ability's level
+## (no free baseline anymore — PR 8 removed the starter ability discount)
+## + the point_cost of every owned upgrade. Mirrors what _refund_ability
+## would hand back, without resetting anything.
 func _points_spent_in_discipline(disc_key: String) -> int:
-	var starter_id: String = _discipline_starter_ability_id(disc_key)
 	var spent: int = 0
 	for ability_id in _ability_levels:
 		var ability: AbilityData = ResourceManager.get_ability_data(ability_id)
 		if ability == null or _ability_primary_discipline(ability) != disc_key:
 			continue
-		var baseline: int = 1 if ability_id == starter_id else 0
-		spent += maxi(0, int(_ability_levels[ability_id]) - baseline)
+		spent += int(_ability_levels[ability_id])
 		for owned_id in _learned_upgrades.get(ability_id, []):
 			var up: AbilityUpgradeData = _find_upgrade(ability, owned_id)
 			if up != null:

--- a/scripts/Components/class.gd
+++ b/scripts/Components/class.gd
@@ -48,15 +48,6 @@ func get_available_abilities() -> Array[AbilityData]:
 	return ResourceManager.get_class_skills(current_class)
 
 
-## Returns the ability auto-granted at level 1 to a new character of this
-## class (the class's "starter skill" — Slash for Swordsman, Magic Bolt for
-## Mage, etc.). Returns null if the class has no starter configured.
-func get_starter_ability() -> AbilityData:
-	var data: WeaponDisciplineData = ResourceManager.get_class_data(current_class)
-	if data == null:
-		return null
-	return data.starter_ability
-
 func change_class(new_class: Constants.ClassType) -> void:
 	if new_class != current_class:
 		##print("ClassComponent: Changing class from %s to %s" % [get_class_name(), ResourceManager.get_class_name(new_class)])

--- a/scripts/Components/weapon_mastery.gd
+++ b/scripts/Components/weapon_mastery.gd
@@ -15,7 +15,13 @@ extends Node
 #region #################### Constants ####################
 
 ## Maximum mastery level a single discipline can reach.
-const MASTERY_CAP: int = 20
+## PR 8 (2026-05-31): raised 20 → 100 to align with the character level cap.
+## Mastery climbs ~1.4× faster than character level via the recalibrated XP
+## curve, so a focused player reaches mastery 100 around character level 70.
+## Char 70-100 is the "refinement phase" — mastery already capped, char XP
+## continues for attribute points + gear. See
+## docs/adr/... and project_ability_point_economy_redesign memory note.
+const MASTERY_CAP: int = 100
 
 ## XP granted to the active weapon's discipline when its wielder lands a HIT
 ## with an ability. PR 4 fix (2026-05-28): the grant moved from cast-time
@@ -82,24 +88,27 @@ static func compute_kill_xp(enemy_level: int, player_level: int) -> int:
 	)
 	return max(KILL_XP_FLOOR, roundi(base_xp * modifier))
 
-## XP curve (PR 4 fix 2026-05-28 — replaced flat linear (N+1)*100):
-## `_xp_to_next_level(N) = XP_BASE + XP_LINEAR * N + XP_QUADRATIC * N * N`.
-## Quick early levels for instant gratification, then quadratic ramp so
-## maxing a weapon is a real commitment (New World-style mastery feel).
+## XP curve (PR 8 — recalibrated for MASTERY_CAP 100 alignment with char 70):
+## `_xp_to_next_level(N) = XP_BASE + XP_LINEAR*N + XP_QUADRATIC*N² + XP_CUBIC*N³`.
+## Front-loaded (cheap early levels for instant gratification) with a cubic
+## tail so late ranks are a real commitment. Target: cumulative XP to rank 100
+## ≈ 1.1M, which matches what a focused at-level grinder earns hitting char
+## level 70 (verified against leveling_curve.tres + monster_exp_curve.tres).
 ##
-##   level 0 -> 1:    30 XP    (~6 kills, ~30 seconds)
-##   level 4 -> 5:   550 XP    (~110 kills, ~10 minutes)
-##   level 9 -> 10: 2,325 XP   (~465 kills, ~30-45 minutes)
-##   level 14 -> 15: 5,350 XP  (~1,070 kills, ~1-2 hours)
-##   level 19 -> 20: 9,625 XP  (~1,925 kills, ~3+ hours)
-##   total 0 -> 20:  ~68,000 XP (~10-15 hours focused play per weapon)
+##   level 0 -> 1:        30 XP    (~3-6 kills, ~30 seconds — first pick immediately)
+##   level 9 -> 10:      580 XP    (~115 at-lvl-10 kills, ~5 minutes)
+##   level 29 -> 30:   4,080 XP    (~135 at-lvl-30 kills)
+##   level 49 -> 50:  12,780 XP    (~80 at-lvl-50 kills — char XP per kill grows faster)
+##   level 69 -> 70:  29,080 XP    (~80 at-lvl-70 kills)
+##   level 99 -> 100: 71,000 XP    (~50 at-lvl-99 kills)
+##   total 0 -> 100: ~1.1M XP — reached around character level 70
 ##
-## Tune these constants together — they trade off early gratification vs.
-## late-game commitment. Raising XP_QUADRATIC most steeply punishes late
-## levels; raising XP_BASE most slows the first few levels.
+## Tune these constants together. Raising XP_CUBIC most steeply punishes late
+## levels; raising XP_BASE slows the first few levels.
 const XP_BASE: int = 30
 const XP_LINEAR: int = 30
-const XP_QUADRATIC: int = 25
+const XP_QUADRATIC: int = 2
+const XP_CUBIC: float = 0.05
 
 #endregion
 
@@ -175,7 +184,7 @@ func get_mastery_xp(discipline: int) -> int:
 ## the cost-per-level table.
 func _xp_to_next_level(current_level: int) -> int:
 	var n: int = current_level
-	return XP_BASE + XP_LINEAR * n + XP_QUADRATIC * n * n
+	return XP_BASE + XP_LINEAR * n + XP_QUADRATIC * n * n + int(XP_CUBIC * n * n * n)
 
 
 ## Returns the XP cost to advance from a discipline's CURRENT level. Useful
@@ -238,6 +247,32 @@ func grant_mastery_xp_server(discipline: int, amount: int) -> void:
 
 	# Persist. The player root listens for this through the same _data_changed
 	# path the other stateful components use.
+	_mark_owner_save_dirty()
+
+
+## PR 8: Server-only. Bumps a discipline's mastery level from 0 to 1 without
+## requiring earned XP — used at character creation so the player has 1 ability
+## point to spend on their first ability of choice (replacing the old "free
+## starter ability" system). Idempotent: if the discipline is already past 0,
+## does nothing. Emits mastery_level_changed so AbilityComponent grants the
+## point through its normal pathway.
+func bootstrap_chosen_discipline(discipline: int) -> void:
+	if not multiplayer.is_server():
+		return
+	if not _is_tier1_discipline(discipline):
+		return
+	if not mastery_data.has(discipline):
+		mastery_data[discipline] = {"level": 0, "xp": 0}
+	var entry: Dictionary = mastery_data[discipline]
+	if int(entry.get("level", 0)) > 0:
+		return  # already bootstrapped
+	entry["level"] = 1
+	entry["xp"] = 0
+	mastery_data[discipline] = entry
+	if not BotManager.is_bot(owner.player_id):
+		sync_mastery_to_client.rpc_id(owner.player_id, discipline, 1, 0)
+	mastery_level_changed.emit(discipline, 1)
+	mastery_xp_changed.emit(discipline, 0, _xp_to_next_level(1))
 	_mark_owner_save_dirty()
 
 

--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -354,27 +354,21 @@ func _on_delete_character_completed(result, response_code, _headers, body, http,
 	http.queue_free()
 
 
-## PR 4: builds the starter per-discipline ability-point pool dict for a
-## newly-created character. The character's starting `class_id` discipline
-## receives the full `(starting_level - 1) * 3` allotment; the other three
-## tier-1 disciplines start at zero. Advanced classes (Crusader / Ranger /
-## Archmage / Assassin) map to their parent tier-1 discipline.
-func _starter_ability_point_pools(class_id: int, starting_level: int) -> Dictionary:
-	var total: int = max(0, (starting_level - 1) * 3)
-	var pools := {
+## PR 8 (2026-05-31): seeds an empty per-discipline ability-point pool dict
+## for a newly-created character. All four tier-1 pools start at zero — the
+## starting point comes from AbilityComponent.bootstrap_fresh_character_if_needed
+## bumping the chosen discipline to mastery 1 (which grants 1 ability point
+## through the normal mastery_level_changed pathway). The legacy
+## (starting_level - 1) * 3 allotment is gone with the per-char-level grant.
+## class_id is kept for future use (e.g. advanced classes might bootstrap to
+## a higher mastery level), even though it's unused right now.
+func _starter_ability_point_pools(_class_id: int, _starting_level: int) -> Dictionary:
+	return {
 		"sword": 0,
 		"bow": 0,
 		"staff": 0,
 		"dagger": 0,
 	}
-	var key: String = _class_id_to_discipline_key(class_id)
-	if key == "":
-		# Beginner or unknown class -- credit the lump to sword so points
-		# never silently vanish. AbilityComponent's first-load migration
-		# will re-credit at the right discipline if it has better info.
-		key = "sword"
-	pools[key] = total
-	return pools
 
 
 ## PR 4: maps a `Constants.ClassType` int (tier-1 starting OR tier-2

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -834,7 +834,13 @@ func _load_data(data: Dictionary) -> void:
 		var ability_data = data.get("abilities", {})
 		if not ability_data.is_empty():
 			ability_component.load_abilities(ability_data)
-			
+		# PR 8 (2026-05-31): fresh-character bootstrap. No-op for any returning
+		# character (guarded by "no mastery, no spent points" check inside).
+		# Bumps chosen discipline to mastery 1 so the player gets 1 ability
+		# point to spend at character creation — replaces the old free
+		# discipline starter ability.
+		ability_component.bootstrap_fresh_character_if_needed()
+
 	if is_instance_valid(level_component):
 		level_component.set_block_signals(false)
 		level_component.leveled_up.emit(level_component.level)

--- a/scripts/Resources/CLAUDE.md
+++ b/scripts/Resources/CLAUDE.md
@@ -121,12 +121,10 @@ the player save under `pets: []`, not as `.tres`. See
   `variant` rolls). All static fields are re-derived from the canonical `.tres` on
   load. Don't add a field expecting it to round-trip per-instance unless you also
   extend the variant serialization (`_append_variant_data` / `_apply_variant_data`).
-- `WeaponDisciplineData.starter_ability` is the ability auto-granted at **level 1** to a
-  brand-new character of that discipline. New discipline `.tres` files should set it so the
-  player has a castable skill from spawn — otherwise disciplines whose basic attack
-  is weak (Staff's basic attack scales off the +3 WEAPONATTACK staff) feel unplayable before
-  earning their first ability point. Returning characters keep their saved levels;
-  the auto-grant only matters on first creation.
+- `WeaponDisciplineData` no longer has a `starter_ability` field (PR 8 removed it).
+  New characters spawn with **1 ability point** in their chosen discipline's pool —
+  bootstrapped to mastery 1 at first login (see `AbilityComponent.bootstrap_fresh_character_if_needed`).
+  Players pick where that first point goes through the regular Ability Window.
 
 ## Creating content
 

--- a/scripts/Resources/DisciplineSystem/WeaponDisciplineData.gd
+++ b/scripts/Resources/DisciplineSystem/WeaponDisciplineData.gd
@@ -22,13 +22,6 @@ extends Resource
 	Constants.StatType.LUCK: 4
 }
 @export var stat_bonuses: Dictionary[Constants.StatType, int] = { }
-## Ability auto-granted at level 1 to a brand-new character of this discipline.
-## Learned at level 1 instead of the default level 0, so the player has a
-## castable skill from the moment they spawn (otherwise disciplines whose basic
-## attack scales off WEAPONATTACK — particularly Staff with its low-WEAPONATTACK
-## — would be unable to fight effectively before earning their first
-## ability point at level 2). Save data overrides this on subsequent logins.
-@export var starter_ability: AbilityData
 
 
 func get_sprite_for_level(level: int) -> SpriteFrames:


### PR DESCRIPTION
First of a 3-PR stack reshaping the ability point economy. **Stacked on \`feat/weapon-identity-overhaul\`.** PR 9 (halve ability max_levels + weak passive fixes) and PR 10 (QoL upgrade redesign) follow.

## Diagnosis

The current mastery 20 cap is reached around character level 30-40, not 100 — a focused at-level grinder accumulates ~2-5M cumulative mastery XP over the journey to char cap, but the cap only requires ~68k. So 60+ char levels had no ability point growth, and the build settled two-thirds of the way through.

## Design (locked direction, see [project_ability_point_economy_redesign](https://github.com/breckdareck/multiplayer-test/blob/feat/weapon-identity-overhaul/.. ) memory file)

| Knob | Before | After |
|---|---|---|
| MASTERY_CAP | 20 | **100** |
| ABILITY_POINTS_PER_MASTERY_LEVEL | 6 | **1** |
| Total budget at cap | 120 | **100** (every pt forced trade-off) |
| Mastery XP curve | \`30 + 30N + 25N²\` | \`30 + 30N + 2N² + 0.05N³\` (cumulative ~1.1M at rank 100) |
| Mastery 100 lands at | unreachable in practice | **~char level 70** (build phase ends, refinement phase begins) |
| Free discipline starter | sword: Crescent Cleave, etc. | **removed** — players pick where their 1 starting pt goes |

## Changes

- **\`weapon_mastery.gd\`** — \`MASTERY_CAP\`, XP curve constants, new \`bootstrap_chosen_discipline()\` public method (bumps mastery 0→1 without earned XP).
- **\`ability.gd\`** — \`ABILITY_POINTS_PER_MASTERY_LEVEL\` constant, simplified \`_ready\` + \`_on_class_changed\` (no starter seed), \`_refund_ability\` signature drops \`starter_id\` (baseline always 0), \`_points_spent_in_discipline\` baseline always 0, \`_discipline_starter_ability_id\` deleted, three respec callsites updated, new \`bootstrap_fresh_character_if_needed()\` public method.
- **\`class.gd\`** — removed \`get_starter_ability()\`.
- **\`WeaponDisciplineData.gd\`** + **4 discipline \`.tres\`** — removed \`starter_ability\` field & lines.
- **\`network_manager.gd\`** — \`_starter_ability_point_pools()\` simplified to all zeros (bootstrap handles the starting pt).
- **\`multiplayer_controller_v2.gd\`** — calls \`bootstrap_fresh_character_if_needed()\` after \`load_abilities\`.
- **CLAUDE.md docs** — updated \`Components/CLAUDE.md\` reconcile description + \`Resources/CLAUDE.md\` starter section.

## Existing characters

\`reconcile_ability_points()\` already handles granted-vs-spent drift. On next login it'll recompute \`granted = mastery × 1\` (vs old \`× 6\`) and refund the surplus into the pool. Chars with a starter at L1 from the old system: the L1 still counts as a spent point now, so they keep their starter, just it's no longer 'free' — the bootstrap covers it via the mastery 1 grant.

## Tests

\`run_tests.gd\` headless harness — **79/81 pass, same 2 pre-existing failures** (\`test_tree_child_locked_until_parent_learned\` and \`test_climb_gate_blocks_level_up\` both call \`_get_path_parent\` which doesn't exist on AbilityComponent — predates this PR, verified by stashing the diff and re-running).

## Follow-ups in PR 9 + 10

- **PR 9**: halve ability \`max_level\` (active 20→10, passive 10→5), double \`per_level\` on FLAT formulas to preserve endpoint power, update \`MAX_LEVEL\` constants in 9 AL_*.gd logic scripts, fix weak passives (Keen Eye, Killer Instinct, Mana Flow, Surefoot).
- **PR 10**: redesign all-QoL upgrade sets (Steady Aim, Eagle Eye, Bloodlust, Vanish) with real behavior variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)