### PR TITLE
Vanish -> Killing Edge + Cutthroat redesign (PR 8d)

### DIFF
--- a/resources/Abilities/Dagger/A_Vanish.tres
+++ b/resources/Abilities/Dagger/A_Vanish.tres
@@ -22,8 +22,8 @@ logic_script = ExtResource("2_drks1")
 
 [sub_resource type="Resource" id="Resource_drks2"]
 script = ExtResource("7_drks1")
-base_value = 10.0
-per_level = 2
+base_value = 5.0
+per_level = 1.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_drks5"]
@@ -62,8 +62,8 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 [resource]
 script = ExtResource("3_drks1")
 ability_id = "4971141151039211-10180-16141116-8591-12491086711491465"
-ability_name = "Vanish"
-description = "Melts into the shadows, becoming untargetable by enemies for $[buff_duration]."
+ability_name = "Killing Edge"
+description = "Sharpens your blades to a killing edge — a short burst window granting +$[stat_bonus]% critical chance and critical damage for $[buff_duration]."
 ability_icon = ExtResource("1_8vb02")
 max_level = 10
 required_class = Array[int]([3])

--- a/resources/Abilities/Dagger/A_Vigor.tres
+++ b/resources/Abilities/Dagger/A_Vigor.tres
@@ -17,13 +17,13 @@ script = ExtResource("2_vig1")
 
 [sub_resource type="Resource" id="Resource_vig_hp"]
 script = ExtResource("5_vig1")
-base_value = 2.0
-per_level = 2
+base_value = 4.0
+per_level = 4.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_vig_sbf"]
 script = ExtResource("4_vig1")
-stat_type = 10
+stat_type = 11
 flat_bonus_formula = SubResource("Resource_vig_hp")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 
@@ -36,7 +36,7 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 script = ExtResource("6_vig1")
 ability_id = "5118105103111114951-9043-1410149-105135-1410158678120211"
 ability_name = "Cutthroat"
-description = "Permanently increases critical hit chance by $[stat_bonus]%."
+description = "Permanently increases critical damage by $[stat_bonus]%."
 ability_icon = ExtResource("1_vig1")
 max_level = 5
 ability_type = 1

--- a/resources/Abilities/Dagger/Upgrades/U_VAN_Linger.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VAN_Linger.tres
@@ -6,6 +6,6 @@
 script = ExtResource("1_aud")
 upgrade_id = "van_t1_linger"
 upgrade_name = "Linger"
-description = "Vanish lasts 3 seconds longer."
+description = "Killing Edge lasts 3 seconds longer."
 effect_key = "buff_duration_bonus"
 magnitude = 3

--- a/resources/Abilities/Dagger/Upgrades/U_VAN_Phantom.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VAN_Phantom.tres
@@ -6,7 +6,7 @@
 script = ExtResource("1_aud")
 upgrade_id = "van_t3_phantom"
 upgrade_name = "Phantom Reflex"
-description = "While invisible, gain +30 weapon attack."
+description = "While Killing Edge is active, gain +30 weapon attack."
 point_cost = 2
 tier = 3
 variant_group = "van_cloak_variant"

--- a/resources/Abilities/Dagger/Upgrades/U_VAN_Shroud.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VAN_Shroud.tres
@@ -6,7 +6,7 @@
 script = ExtResource("1_aud")
 upgrade_id = "van_t3_shroud"
 upgrade_name = "Endless Shroud"
-description = "While invisible, gain +30% critical hit chance for the burst window."
+description = "While Killing Edge is active, gain an additional +30% critical hit chance."
 point_cost = 2
 tier = 3
 variant_group = "van_cloak_variant"

--- a/resources/Abilities/Dagger/Upgrades/U_VAN_Silence.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VAN_Silence.tres
@@ -6,7 +6,7 @@
 script = ExtResource("1_aud")
 upgrade_id = "van_t2_silence"
 upgrade_name = "Silent Steps"
-description = "While invisible, gain +50% critical damage for the burst window."
+description = "While Killing Edge is active, gain an additional +50% critical damage."
 tier = 2
 effect_key = "buff_critdamage_bonus"
 magnitude = 50

--- a/resources/Abilities/Dagger/Upgrades/U_VAN_SwiftExit.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VAN_SwiftExit.tres
@@ -6,7 +6,7 @@
 script = ExtResource("1_aud")
 upgrade_id = "van_t3_swift_exit"
 upgrade_name = "Swift Exit"
-description = "Vanish lasts 5 seconds longer."
+description = "Killing Edge lasts 5 seconds longer."
 point_cost = 2
 tier = 3
 variant_group = "van_cloak_variant"

--- a/resources/Buffs/B_Dark_Sight.tres
+++ b/resources/Buffs/B_Dark_Sight.tres
@@ -1,16 +1,13 @@
-[gd_resource type="Resource" script_class="BuffData" load_steps=5 format=3 uid="uid://bdarksite0001"]
+[gd_resource type="Resource" script_class="BuffData" load_steps=3 format=3 uid="uid://bdarksite0001"]
 
 [ext_resource type="Script" uid="uid://bcuvemv85jprb" path="res://scripts/Resources/BuffSystem/BuffData.gd" id="1_dkst2"]
 [ext_resource type="Texture2D" uid="uid://3nomn5ckt1dh" path="res://assets/sprites/Abilities/dark_sight.webp" id="1_tfn6t"]
-[ext_resource type="Script" uid="uid://bldrksght001x" path="res://scripts/Buffs/BL_DarkSight.gd" id="2_tfn6t"]
-[ext_resource type="Script" uid="uid://cptesvvlfbytw" path="res://scripts/Resources/StatSystem/StatData.gd" id="4_pv34y"]
 
 [resource]
 resource_local_to_scene = true
 script = ExtResource("1_dkst2")
 buff_id = "4114118107105103-10410400-989905-7201-561201321019"
-buff_name = "Vanish"
-description = "Hidden in shadow — untargetable by enemies."
+buff_name = "Killing Edge"
+description = "Blade edge sharpened to a killing point. Bonus crit chance and critical damage."
 buff_icon = ExtResource("1_tfn6t")
-logic_script = ExtResource("2_tfn6t")
 metadata/_custom_type_script = "uid://bcuvemv85jprb"

--- a/scripts/Abilities/AL_DarkSight.gd
+++ b/scripts/Abilities/AL_DarkSight.gd
@@ -1,7 +1,16 @@
 extends Node
 
-## Ability logic for the Dagger discipline's Vanish.
-## Applies an invisibility buff that prevents enemies from targeting the player.
+## Ability logic for the Dagger discipline's Killing Edge (formerly Vanish).
+##
+## PR 11 (2026-05-31): Vanish was redundant with the dagger's signature
+## stealth (ShadowmeldComponent). Repurposed as a non-stealth burst-window
+## self-buff: short duration (L1: 5s, L10: 15s) granting +CRITCHANCE and
+## +CRITDAMAGE for a focused damage push. Materially different from the bow's
+## Steady Aim — Steady Aim is sustained ATK + CRITCHANCE, this is short-burst
+## CRITCHANCE + CRITDAMAGE.
+##
+## Upgrades (buff_attack_bonus / buff_critchance_bonus / buff_critdamage_bonus)
+## layer on top of the base stats — same pattern as the other 3 buff abilities.
 
 func execute(owner_node: Node, ability: AbilityData, level_stats: AbilityLevelData):
 	var buff_component: BuffComponent = owner_node.get_node_or_null("Components/Buff")
@@ -9,25 +18,25 @@ func execute(owner_node: Node, ability: AbilityData, level_stats: AbilityLevelDa
 		return
 
 	var duration: float = ability.buff_duration_formula.calculate(level_stats.level)
+	# Base scaling (L1 -> L10):
+	#   crit chance: 5 + L*2  -> L1: 7%, L10: 25%
+	#   crit damage: 10 + L*3 -> L1: 13%, L10: 40%
+	var crit_chance_bonus: float = 5.0 + level_stats.level * 2.0
+	var crit_damage_bonus: float = 10.0 + level_stats.level * 3.0
 
-	# PR 8 upgrade: buff_duration_bonus (+s). mana_flat_reduction is consumed
-	# generically in AbilityComponent._consume_ability_resources — no read here.
 	var ability_comp = owner_node.get("ability_component")
 	if ability_comp and ability_comp.has_method("get_ability_upgrade_magnitude"):
 		duration += ability_comp.get_ability_upgrade_magnitude(ability.ability_id, "buff_duration_bonus")
 
-	buff_component.apply_buff("Vanish", owner_node, duration)
+	buff_component.apply_buff("Killing Edge", owner_node, duration)
 
-	var active_buff = buff_component._active_buffs.get("Vanish")
+	var active_buff = buff_component._active_buffs.get("Killing Edge")
 	if not active_buff:
 		return
 	if active_buff.custom_logic_instance:
 		active_buff.custom_logic_instance.source_ability_level = level_stats.level
 
-	# PR 10 upgrades: Vanish has no base stat bonuses (pure stealth), but the
-	# upgrade keys let it layer ATK / CRIT bonuses for "buff window" damage.
-	# Applied identically to the other 3 buff abilities (Steady Aim, Eagle Eye,
-	# Bloodlust) so the upgrade pattern is consistent.
+	# PR 10 upgrade extras: layer on top of base.
 	var extra_atk: int = 0
 	var extra_critchance: float = 0.0
 	var extra_critdmg: float = 0.0
@@ -36,22 +45,26 @@ func execute(owner_node: Node, ability: AbilityData, level_stats: AbilityLevelDa
 		extra_critchance = ability_comp.get_ability_upgrade_magnitude(ability.ability_id, "buff_critchance_bonus")
 		extra_critdmg = ability_comp.get_ability_upgrade_magnitude(ability.ability_id, "buff_critdamage_bonus")
 
-	if extra_atk > 0 or extra_critchance > 0.0 or extra_critdmg > 0.0:
-		active_buff.buff_data = active_buff.buff_data.duplicate()
-		active_buff.buff_data.stat_modifiers.clear()
-		if extra_atk > 0:
-			var atk = StatData.new(Constants.StatType.WEAPONATTACK, 0)
-			atk.flat_bonus_value = extra_atk
-			active_buff.buff_data.stat_modifiers[Constants.StatType.WEAPONATTACK] = atk
-		if extra_critchance > 0.0:
-			var critchance = StatData.new(Constants.StatType.CRITCHANCE, 0)
-			critchance.percent_bonus_value = extra_critchance
-			active_buff.buff_data.stat_modifiers[Constants.StatType.CRITCHANCE] = critchance
-		if extra_critdmg > 0.0:
-			var critdmg = StatData.new(Constants.StatType.CRITDAMAGE, 0)
-			critdmg.percent_bonus_value = extra_critdmg
-			active_buff.buff_data.stat_modifiers[Constants.StatType.CRITDAMAGE] = critdmg
-		buff_component._force_stat_recalc()
+	active_buff.buff_data = active_buff.buff_data.duplicate()
+	active_buff.buff_data.stat_modifiers.clear()
 
-	print("%s activated Vanish (Level %d) — invisible for %.0fs" % [
-		owner_node.name, level_stats.level, duration])
+	var critchance_stat = StatData.new(Constants.StatType.CRITCHANCE, 0)
+	critchance_stat.percent_bonus_value = crit_chance_bonus + extra_critchance
+	active_buff.buff_data.stat_modifiers[Constants.StatType.CRITCHANCE] = critchance_stat
+
+	var critdmg_stat = StatData.new(Constants.StatType.CRITDAMAGE, 0)
+	critdmg_stat.percent_bonus_value = crit_damage_bonus + extra_critdmg
+	active_buff.buff_data.stat_modifiers[Constants.StatType.CRITDAMAGE] = critdmg_stat
+
+	if extra_atk > 0:
+		var atk_stat = StatData.new(Constants.StatType.WEAPONATTACK, 0)
+		atk_stat.flat_bonus_value = extra_atk
+		active_buff.buff_data.stat_modifiers[Constants.StatType.WEAPONATTACK] = atk_stat
+
+	buff_component._force_stat_recalc()
+
+	print("%s activated Killing Edge (Level %d) — +%.1f%% crit / +%.1f%% critdmg for %.0fs" % [
+		owner_node.name, level_stats.level,
+		crit_chance_bonus + extra_critchance,
+		crit_damage_bonus + extra_critdmg,
+		duration])


### PR DESCRIPTION
Fourth in the ability cleanup stack. **Stacks on [#169](https://github.com/breckdareck/multiplayer-test/pull/169)** which stacks on [#168](https://github.com/breckdareck/multiplayer-test/pull/168) → [#167](https://github.com/breckdareck/multiplayer-test/pull/167).

Per the user's call-out:

1. **Vanish is redundant with dagger's signature stealth.** ShadowmeldComponent already provides untargetable invisibility — Vanish duplicated that mechanic at a higher cost.
2. **Cutthroat and Killer Instinct were both +crit chance passives** (L5=10% vs L5=11%) — no meaningful build choice between them.

## Vanish → Killing Edge

Non-stealth short-duration self-buff. Slot keeps the same .tres so existing upgrades / hotbar bindings carry over; the file rename to A_Killing_Edge.tres comes in PR 5.

| | Old Vanish | New Killing Edge |
|---|---|---|
| Effect | Invisibility | +crit chance + crit damage |
| Duration | base 10s, L20 = 48s | base 5s + 1s/level, L1=6s, L10=15s |
| Base crit chance | — | 5% + 2%/level (L10 = 25%) |
| Base crit damage | — | 10% + 3%/level (L10 = 40%) |
| Stealth dependency | Yes (BL_DarkSight set is_invisible) | None |

**Distinguished from bow's Steady Aim:** Steady Aim is sustained ATK + crit chance (30s+ duration, low burst), Killing Edge is a short crit-damage burst window. Different rhythm, different stat priorities.

**AL_DarkSight rewritten** — applies the renamed buff with crit modifiers, layers PR 10's upgrade keys (\`buff_attack_bonus\` / \`buff_critchance_bonus\` / \`buff_critdamage_bonus\`) on top. The 5 U_VAN_*.tres upgrades from PR 10 work as-is; only descriptions updated to mention Killing Edge instead of Vanish.

**B_Dark_Sight.tres** stripped of \`logic_script\` (BL_DarkSight set is_invisible — no longer needed). Now a pure stat-vessel buff.

## Cutthroat redesign

| | Old | New |
|---|---|---|
| Stat | CRITCHANCE (10) | CRITDAMAGE (11) |
| Formula | base 2, per_level 2 | base 4, per_level 4 |
| L5 value | +10% crit chance | +20% crit damage |

The two dagger crit passives now complement:
- **Killer Instinct** → +crit chance (L5: 11%) — land more crits
- **Cutthroat** → +crit damage (L5: 20%) — crits hit harder
- Both stack into a burst-crit build; player has a real choice on which to invest in first.

Daggers being the crit-damage spec class is thematic — bow already has Lethality (+18% critdmg at L5), so Cutthroat's 20% slightly edges it out, reinforcing dagger as the burst class.

## Followups (PR 5 will cover)

- Rename `A_Vanish.tres` → `A_Killing_Edge.tres`
- Rename `AL_DarkSight.gd` → `AL_KillingEdge.gd` (and similarly the other misaligned AL_*.gd: AL_Haste→AL_Bloodlust, AL_ManaShield→AL_AetherWard, AL_Brandish→AL_SteelFlurry, AL_Disorder→AL_Cripple, AL_SharpEyes→AL_EagleEye, AL_Focus→AL_SteadyAim, AL_Meditation→AL_Communion, AL_Maple_Warrior→AL_VowOfTheVanguard).
- Rename 13 misaligned ability .tres files (A_Iron_Sinews→A_Aggression, A_Vital_Bloom→A_Mana_Flow, A_Vigor→A_Cutthroat, etc).
- Optionally clean up stale dark_sight.webp asset / rename to killing_edge sprite.
- Delete BL_DarkSight.gd (no longer referenced).

## Tests

79/81 (same 2 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)