### PR TITLE
Accuracy + Evasion stats, reshape Bow/Staff/Dagger Defense passives

### DIFF
--- a/passives_review.html
+++ b/passives_review.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>All Passives Review — post weapon-identity-overhaul (PR 8a-e)</title>
+<style>
+  :root {
+    --bg: #14161c;
+    --panel: #1c1f28;
+    --panel-2: #232836;
+    --accent: #ffb347;
+    --accent-2: #6ec1e4;
+    --text: #e8eaf0;
+    --dim: #8a8f9c;
+    --good: #5acf6e;
+    --warn: #e0a040;
+    --bad: #ff6363;
+    --border: #2e3342;
+    --c-direct: #6ec1e4;
+    --c-percent: #b58df0;
+    --c-regen: #5acf6e;
+    --c-conditional: #ffb347;
+    --c-utility: #8a8f9c;
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 32px 48px;
+    background: var(--bg);
+    color: var(--text);
+    font: 14px/1.55 -apple-system, "Segoe UI", system-ui, sans-serif;
+    max-width: 1600px; margin-left: auto; margin-right: auto;
+  }
+  h1 { font-size: 22px; margin: 0 0 4px; }
+  h2 { font-size: 16px; margin: 32px 0 12px; color: var(--accent); border-bottom: 1px solid var(--border); padding-bottom: 6px; }
+  .lede { color: var(--dim); margin: 0 0 24px; }
+  .grid4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+  .disc-col {
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 16px;
+  }
+  .disc-col h3 {
+    margin: 0 0 12px;
+    font-size: 14px;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    color: var(--accent);
+    border-bottom: 1px solid var(--border);
+    padding-bottom: 8px;
+  }
+  .disc-col.sword h3   { color: #e0a040; }
+  .disc-col.bow h3     { color: #5acf6e; }
+  .disc-col.staff h3   { color: #6ec1e4; }
+  .disc-col.dagger h3  { color: #b58df0; }
+
+  .passive {
+    background: var(--panel-2);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--border);
+    border-radius: 4px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+  }
+  .passive.direct      { border-left-color: var(--c-direct); }
+  .passive.percent     { border-left-color: var(--c-percent); }
+  .passive.regen       { border-left-color: var(--c-regen); }
+  .passive.conditional { border-left-color: var(--c-conditional); }
+  .passive.utility     { border-left-color: var(--c-utility); }
+  .passive.changed { box-shadow: 0 0 0 1px var(--accent) inset; }
+  .passive.flagged { box-shadow: 0 0 0 1px var(--bad) inset; }
+
+  .p-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    gap: 8px; margin-bottom: 4px;
+  }
+  .p-name {
+    font-weight: 600; font-size: 14px;
+  }
+  .p-type {
+    font-size: 10px; color: var(--dim); text-transform: uppercase; letter-spacing: 0.5px;
+  }
+  .p-stat {
+    font-size: 12px; color: var(--text); margin-bottom: 4px;
+  }
+  .p-formula {
+    font-size: 11px; color: var(--dim);
+    font-family: ui-monospace, "SF Mono", Consolas, monospace;
+    margin-bottom: 6px;
+  }
+  .p-range {
+    display: grid; grid-template-columns: 1fr 1fr; gap: 4px;
+    font-size: 12px; margin-bottom: 4px;
+  }
+  .p-range .lv {
+    background: var(--bg); padding: 3px 6px; border-radius: 3px;
+    display: flex; justify-content: space-between;
+  }
+  .p-range .lv b { color: var(--accent-2); font-variant-numeric: tabular-nums; }
+  .p-meta {
+    font-size: 11px; color: var(--dim); margin-top: 4px;
+  }
+  .tag {
+    display: inline-block; padding: 1px 5px; border-radius: 3px;
+    font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+    margin-left: 4px;
+  }
+  .tag.new { background: rgba(255,179,71,0.18); color: var(--accent); }
+  .tag.changed { background: rgba(110,193,228,0.18); color: var(--accent-2); }
+  .tag.flag { background: rgba(255,99,99,0.18); color: var(--bad); }
+  .legend {
+    display: flex; flex-wrap: wrap; gap: 16px; padding: 12px 16px;
+    background: var(--panel); border: 1px solid var(--border); border-radius: 8px;
+    margin-bottom: 20px; font-size: 12px;
+  }
+  .legend span { display: flex; align-items: center; gap: 6px; color: var(--dim); }
+  .legend .sw { width: 12px; height: 12px; border-radius: 2px; border-left: 3px solid; background: var(--panel-2); }
+  .note-panel {
+    background: linear-gradient(135deg, rgba(255,99,99,0.10), rgba(224,160,64,0.06));
+    border: 1px solid var(--bad);
+    border-radius: 8px;
+    padding: 14px 18px;
+    margin-bottom: 20px;
+  }
+  .note-panel strong { color: var(--bad); }
+  .footnote { color: var(--dim); font-size: 11px; }
+  table.summary {
+    width: 100%; border-collapse: collapse; margin-top: 8px;
+    font-size: 12px;
+  }
+  table.summary th, table.summary td {
+    text-align: left; padding: 6px 8px; border-bottom: 1px solid var(--border);
+  }
+  table.summary th { color: var(--dim); font-weight: 500; text-transform: uppercase; font-size: 11px; letter-spacing: 0.5px; }
+  table.summary td.num { text-align: right; font-variant-numeric: tabular-nums; }
+</style>
+</head>
+<body>
+
+<h1>All Passives Review</h1>
+<p class="lede">
+24 passives across 4 weapon disciplines after PRs #167–#171.
+Max level halved 10 → 5 (PR #168); per_level doubled to preserve endpoints.
+Weak passives buffed (PR #168). Cutthroat repointed to crit damage (PR #170).
+</p>
+
+<div class="legend">
+  <span><span class="sw" style="border-left-color: var(--c-direct);"></span> direct stat (flat)</span>
+  <span><span class="sw" style="border-left-color: var(--c-percent);"></span> percent stat (% bonus)</span>
+  <span><span class="sw" style="border-left-color: var(--c-regen);"></span> regen / sustain</span>
+  <span><span class="sw" style="border-left-color: var(--c-conditional);"></span> conditional damage</span>
+  <span><span class="sw" style="border-left-color: var(--c-utility);"></span> utility / niche stat</span>
+  <span><span class="tag changed">CHANGED</span> tweaked in PR 8a–e stack</span>
+  <span><span class="tag flag">FLAG</span> needs followup attention</span>
+</div>
+
+<!-- ============================================================ -->
+<h2>Passive matrix — by discipline</h2>
+
+<div class="grid4">
+
+  <!-- ============================== SWORD ============================== -->
+  <div class="disc-col sword">
+    <h3>Sword (6 passives)</h3>
+
+    <div class="passive direct">
+      <div class="p-head"><span class="p-name">Battle-Hardened</span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Defense (flat)</div>
+      <div class="p-formula">FLAT · base 3 + per_level 6</div>
+      <div class="p-range"><div class="lv">L1 <b>+3 DEF</b></div><div class="lv">L5 <b>+27 DEF</b></div></div>
+      <div class="p-meta">3 upgrades · A_Battle_Hardened.tres</div>
+    </div>
+
+    <div class="passive regen">
+      <div class="p-head"><span class="p-name">Second Wind</span><span class="p-type">HP regen</span></div>
+      <div class="p-stat">+ HP regeneration (flat)</div>
+      <div class="p-formula">FLAT · base 2 + per_level 2</div>
+      <div class="p-range"><div class="lv">L1 <b>+2 HP/s</b></div><div class="lv">L5 <b>+10 HP/s</b></div></div>
+      <div class="p-meta">3 upgrades · A_Second_Wind.tres (was A_Battle_Instinct)</div>
+    </div>
+
+    <div class="passive percent">
+      <div class="p-head"><span class="p-name">Hardened Frame</span><span class="p-type">Percent stat</span></div>
+      <div class="p-stat">+% Max HP</div>
+      <div class="p-formula">PERCENT · base 2% + per_level 4%</div>
+      <div class="p-range"><div class="lv">L1 <b>+2% HP</b></div><div class="lv">L5 <b>+18% HP</b></div></div>
+      <div class="p-meta">3 upgrades · A_Hardened_Frame.tres</div>
+    </div>
+
+    <div class="passive regen flagged">
+      <div class="p-head"><span class="p-name">Bloodthirst <span class="tag flag">AL HARDCODE</span></span><span class="p-type">Heal on kill</span></div>
+      <div class="p-stat">Heal % Max HP per enemy kill</div>
+      <div class="p-formula">AL_Bloodthirst · 0.5 + 0.3·(L-1) <span style="color:var(--bad)">(stale — .tres says 0.6)</span></div>
+      <div class="p-range"><div class="lv">L1 <b>+0.5% HP</b></div><div class="lv">L5 <b>+1.7% HP</b></div></div>
+      <div class="p-meta"><span class="tag flag">FLAG</span> AL_Bloodthirst.gd hardcoded PER_LEVEL_HEAL_PCT=0.3 wasn't updated when PR 9 doubled the .tres per_level → 0.6. Should be L5=+2.9%. <br>3 upgrades · A_Bloodthirst.tres</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Aggression <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg vs targets above 90% HP</div>
+      <div class="p-formula">AL_Aggression · 30% × (L / 5) — linear</div>
+      <div class="p-range"><div class="lv">L1 <b>+6%</b></div><div class="lv">L5 <b>+30%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Aggression.tres (was A_Iron_Sinews)</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Last Stand <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg while self below 35% HP</div>
+      <div class="p-formula">AL_LastStand · 35% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+7%</b></div><div class="lv">L5 <b>+35%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Last_Stand.tres (was A_Savage_Blows)</div>
+    </div>
+  </div>
+
+  <!-- ============================== BOW ============================== -->
+  <div class="disc-col bow">
+    <h3>Bow (6 passives)</h3>
+
+    <div class="passive direct">
+      <div class="p-head"><span class="p-name">Iron Hide</span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Defense (flat)</div>
+      <div class="p-formula">FLAT · base 3 + per_level 6</div>
+      <div class="p-range"><div class="lv">L1 <b>+3 DEF</b></div><div class="lv">L5 <b>+27 DEF</b></div></div>
+      <div class="p-meta">3 upgrades · A_Iron_Hide.tres</div>
+    </div>
+
+    <div class="passive direct changed">
+      <div class="p-head"><span class="p-name">Keen Eye <span class="tag changed">BUFFED</span></span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Critical Hit Chance</div>
+      <div class="p-formula">FLAT · base 2 + per_level 2 (was CUSTOM ceil(L/2.0))</div>
+      <div class="p-range"><div class="lv">L1 <b>+2%</b></div><div class="lv">L5 <b>+10%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Keen_Eye.tres · was capped at +5% with CUSTOM formula → now linear/doubled</div>
+    </div>
+
+    <div class="passive direct">
+      <div class="p-head"><span class="p-name">Lethality</span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Critical Damage</div>
+      <div class="p-formula">FLAT · base 2 + per_level 4</div>
+      <div class="p-range"><div class="lv">L1 <b>+2%</b></div><div class="lv">L5 <b>+18%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Lethality.tres</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Tailwind <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg scaled by Bow Momentum stacks</div>
+      <div class="p-formula">AL_Tailwind · 30% × (stacks / 10) × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 full <b>+6%</b></div><div class="lv">L5 full <b>+30%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Tailwind.tres (was A_Deep_Reserves) · synergy with BowMomentum gauge</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Execution <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg vs targets below 30% HP</div>
+      <div class="p-formula">AL_Execution · 45% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+9%</b></div><div class="lv">L5 <b>+45%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Execution.tres (was A_Fleet_Fingers) · highest conditional bonus of the set</div>
+    </div>
+
+    <div class="passive utility changed">
+      <div class="p-head"><span class="p-name">Surefoot <span class="tag changed">RENAMED</span></span><span class="p-type">Niche stat</span></div>
+      <div class="p-stat">+ Knockback Resistance</div>
+      <div class="p-formula">FLAT · base 5 + per_level 4</div>
+      <div class="p-range"><div class="lv">L1 <b>+5 KBR</b></div><div class="lv">L5 <b>+21 KBR</b></div></div>
+      <div class="p-meta">3 upgrades · A_Surefoot.tres (was A_Survival_Instinct) · stat used by stats.rolls_knockback</div>
+    </div>
+  </div>
+
+  <!-- ============================== STAFF ============================== -->
+  <div class="disc-col staff">
+    <h3>Staff (6 passives)</h3>
+
+    <div class="passive direct changed">
+      <div class="p-head"><span class="p-name">Stoneskin <span class="tag changed">RENAMED</span></span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Defense (flat)</div>
+      <div class="p-formula">FLAT · base 3 + per_level 4</div>
+      <div class="p-range"><div class="lv">L1 <b>+3 DEF</b></div><div class="lv">L5 <b>+19 DEF</b></div></div>
+      <div class="p-meta">3 upgrades · A_Stoneskin.tres (was A_Arcane_Fury)</div>
+    </div>
+
+    <div class="passive direct">
+      <div class="p-head"><span class="p-name">Spell Ward</span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Magic Defense (flat)</div>
+      <div class="p-formula">FLAT · base 3 + per_level 6</div>
+      <div class="p-range"><div class="lv">L1 <b>+3 MDEF</b></div><div class="lv">L5 <b>+27 MDEF</b></div></div>
+      <div class="p-meta">3 upgrades · A_Spell_Ward.tres</div>
+    </div>
+
+    <div class="passive percent">
+      <div class="p-head"><span class="p-name">Deep Wellspring</span><span class="p-type">Percent stat</span></div>
+      <div class="p-stat">+% Max Mana</div>
+      <div class="p-formula">PERCENT · base 2% + per_level 4%</div>
+      <div class="p-range"><div class="lv">L1 <b>+2% MP</b></div><div class="lv">L5 <b>+18% MP</b></div></div>
+      <div class="p-meta">3 upgrades · A_Deep_Wellspring.tres</div>
+    </div>
+
+    <div class="passive regen changed">
+      <div class="p-head"><span class="p-name">Mana Flow <span class="tag changed">RENAMED + BUFFED</span></span><span class="p-type">MP regen</span></div>
+      <div class="p-stat">+ MP regeneration (flat)</div>
+      <div class="p-formula">FLAT · base 2 + per_level 3 (was per_level 1, then 2)</div>
+      <div class="p-range"><div class="lv">L1 <b>+2 MP/s</b></div><div class="lv">L5 <b>+14 MP/s</b></div></div>
+      <div class="p-meta">3 upgrades · A_Mana_Flow.tres (was A_Vital_Bloom) · bumped beyond PR 9 standard doubling</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Killing Spree <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg for 4s after any kill</div>
+      <div class="p-formula">AL_KillingSpree · 30% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+6%</b></div><div class="lv">L5 <b>+30%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Killing_Spree.tres (was A_Arcane_Mind)</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Overload <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg while above 50% mana</div>
+      <div class="p-formula">AL_Overload · 25% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+5%</b></div><div class="lv">L5 <b>+25%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Overload.tres (was A_Keen_Mind) · pairs with high-mana playstyle</div>
+    </div>
+  </div>
+
+  <!-- ============================== DAGGER ============================== -->
+  <div class="disc-col dagger">
+    <h3>Dagger (6 passives)</h3>
+
+    <div class="passive direct">
+      <div class="p-head"><span class="p-name">Evasion</span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Defense (flat)</div>
+      <div class="p-formula">FLAT · base 3 + per_level 6</div>
+      <div class="p-range"><div class="lv">L1 <b>+3 DEF</b></div><div class="lv">L5 <b>+27 DEF</b></div></div>
+      <div class="p-meta">3 upgrades · A_Evasion.tres</div>
+    </div>
+
+    <div class="passive direct changed">
+      <div class="p-head"><span class="p-name">Killer Instinct <span class="tag changed">BUFFED</span></span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Critical Hit Chance</div>
+      <div class="p-formula">FLAT · base 3 + per_level 2 (was CUSTOM ceil(L/2.0))</div>
+      <div class="p-range"><div class="lv">L1 <b>+3%</b></div><div class="lv">L5 <b>+11%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Killer_Instinct.tres · "land more crits"</div>
+    </div>
+
+    <div class="passive direct changed">
+      <div class="p-head"><span class="p-name">Cutthroat <span class="tag changed">REPOINTED</span></span><span class="p-type">Direct stat</span></div>
+      <div class="p-stat">+ Critical Damage <span style="color:var(--dim);font-size:11px">(was Crit Chance — duplicated Killer Instinct)</span></div>
+      <div class="p-formula">FLAT · base 4 + per_level 4</div>
+      <div class="p-range"><div class="lv">L1 <b>+4%</b></div><div class="lv">L5 <b>+20%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Cutthroat.tres (was A_Vigor) · "crits hit harder"</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Opportunist <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg while stealthed (Shadowmeld)</div>
+      <div class="p-formula">AL_Opportunist · 35% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+7%</b></div><div class="lv">L5 <b>+35%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Opportunist.tres (was A_Deep_Pockets) · stacks with Shadowmeld ambush ×2</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Toxicology <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg vs POISONED targets</div>
+      <div class="p-formula">AL_Toxicology · 30% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+6%</b></div><div class="lv">L5 <b>+30%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Toxicology.tres (was A_Exploit_Weakness) · synergy with Envenom DoT</div>
+    </div>
+
+    <div class="passive conditional changed">
+      <div class="p-head"><span class="p-name">Composure <span class="tag changed">RENAMED</span></span><span class="p-type">Conditional dmg</span></div>
+      <div class="p-stat">Bonus dmg while above 80% HP</div>
+      <div class="p-formula">AL_Composure · 25% × (L / 5)</div>
+      <div class="p-range"><div class="lv">L1 <b>+5%</b></div><div class="lv">L5 <b>+25%</b></div></div>
+      <div class="p-meta">3 upgrades · A_Composure.tres (was A_Larcenous_Luck) · opposite of Sword's Last Stand</div>
+    </div>
+  </div>
+
+</div>
+
+<!-- ============================================================ -->
+<h2>Build identity per discipline</h2>
+
+<table class="summary">
+  <thead>
+    <tr>
+      <th>Discipline</th>
+      <th>Defense passive</th>
+      <th>Resource / regen</th>
+      <th>Damage / DPS</th>
+      <th>Conditional bonus (L5 max)</th>
+      <th>Theme</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><b>Sword</b></td>
+      <td>Battle-Hardened (+27 DEF), Hardened Frame (+18% HP)</td>
+      <td>Second Wind (+10/s), Bloodthirst heal-on-kill</td>
+      <td>—</td>
+      <td>Aggression (vs &gt;90% HP, +30%) · Last Stand (self &lt;35%, +35%)</td>
+      <td>Tank / sustain bruiser</td>
+    </tr>
+    <tr>
+      <td><b>Bow</b></td>
+      <td>Iron Hide (+27 DEF), Surefoot (KB resist)</td>
+      <td>—</td>
+      <td>Keen Eye (+10% crit), Lethality (+18% critdmg)</td>
+      <td>Tailwind (Momentum scaling, +30%) · Execution (&lt;30% HP, +45%)</td>
+      <td>Sustained ranged DPS</td>
+    </tr>
+    <tr>
+      <td><b>Staff</b></td>
+      <td>Stoneskin (+19 DEF), Spell Ward (+27 MDEF)</td>
+      <td>Deep Wellspring (+18% MP), Mana Flow (+14/s)</td>
+      <td>—</td>
+      <td>Killing Spree (post-kill 4s, +30%) · Overload (&gt;50% MP, +25%)</td>
+      <td>Mana-driven caster</td>
+    </tr>
+    <tr>
+      <td><b>Dagger</b></td>
+      <td>Evasion (+27 DEF)</td>
+      <td>—</td>
+      <td>Killer Instinct (+11% crit), <b>Cutthroat (+20% critdmg)</b></td>
+      <td>Opportunist (stealth, +35%) · Toxicology (vs poisoned, +30%) · Composure (&gt;80% HP, +25%)</td>
+      <td>Crit-burst / stealth-strike</td>
+    </tr>
+  </tbody>
+</table>
+
+<!-- ============================================================ -->
+<h2>Observations &amp; followup candidates</h2>
+
+<div class="note-panel">
+  <p style="margin:0 0 8px"><strong>Bloodthirst AL hardcode (Sword)</strong></p>
+  <p style="margin:0 0 6px"><code>AL_Bloodthirst.gd</code> has <code>PER_LEVEL_HEAL_PCT = 0.3</code> hardcoded — PR 9 doubled the <code>.tres</code> per_level to 0.6, but the AL script wasn't synced. Bloodthirst is currently giving <b>L5 = +1.7% Max HP per kill</b> instead of the intended <b>+2.9%</b>. Fix: bump <code>PER_LEVEL_HEAL_PCT</code> to 0.6, or move the scaling to read from <code>ability.damage_percent_formula.calculate(level)</code>. Same family of AL hardcode bugs as <code>AL_EnhancedBasics</code> / <code>AL_ManaShield</code> (now renamed) flagged in PR 10.</p>
+</div>
+
+<div class="note-panel" style="background: linear-gradient(135deg, rgba(224,160,64,0.10), rgba(110,193,228,0.06)); border-color: var(--warn);">
+  <p style="margin:0 0 8px; color: var(--warn);"><strong>Defense passive sameness</strong></p>
+  <p style="margin:0 0 6px">All four disciplines have a +Defense flat passive (Battle-Hardened, Iron Hide, Evasion, Stoneskin) with identical base=3, per_level=6 (Stoneskin is per_level=4). Functionally interchangeable. This is by-design baseline survival, but the per-discipline FLAVOR is missing — could differentiate by adding small secondary stat: Battle-Hardened could also give a small +HP, Iron Hide a small +KB resist, Evasion a small +crit avoidance (if implemented), Stoneskin a small +MDEF.</p>
+</div>
+
+<div class="note-panel" style="background: linear-gradient(135deg, rgba(110,193,228,0.10), rgba(255,179,71,0.06)); border-color: var(--accent-2);">
+  <p style="margin:0 0 8px; color: var(--accent-2);"><strong>Conditional passive coverage</strong></p>
+  <p style="margin:0 0 6px">Every discipline has 2–3 conditional damage passives that read like real build identity (Aggression / Execution / Killing Spree / Opportunist etc). These are the strongest design layer in the system — the player picks one based on playstyle. Worth keeping consistent: each new ability cycle should ship with a discipline-themed conditional.</p>
+</div>
+
+<div class="note-panel" style="background: linear-gradient(135deg, rgba(138,143,156,0.10), rgba(255,255,255,0.02)); border-color: var(--dim);">
+  <p style="margin:0 0 8px; color: var(--dim);"><strong>Per-discipline passive count is now even (6/6/6/6)</strong></p>
+  <p style="margin:0 0 6px">All four disciplines have 6 passives. With max_level 5 each, fully maxing every passive in a discipline costs 30 points — about a third of the new 100-pt budget. Investment in 4–5 passives + the rest spent on actives feels tight but workable per the budget model from #167.</p>
+</div>
+
+<p class="footnote" style="margin-top:32px; text-align:center">
+  Generated 2026-05-31 after PR stack 8a–e merged into feat/weapon-identity-overhaul.
+  Numbers verified against the .tres / AL_*.gd source.
+</p>
+
+</body>
+</html>

--- a/resources/Abilities/Bow/A_Marksmans_Focus.tres
+++ b/resources/Abilities/Bow/A_Marksmans_Focus.tres
@@ -17,13 +17,13 @@ script = ExtResource("2_ih1")
 
 [sub_resource type="Resource" id="Resource_ih_def"]
 script = ExtResource("5_ih1")
-base_value = 3.0
-per_level = 6
+base_value = 2.0
+per_level = 2.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_ih_sbf"]
 script = ExtResource("4_ih1")
-stat_type = 8
+stat_type = 16
 flat_bonus_formula = SubResource("Resource_ih_def")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 
@@ -35,8 +35,8 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 [resource]
 script = ExtResource("6_ih1")
 ability_id = "9151514110410851-9043-1410149-105135-1410158678120193"
-ability_name = "Iron Hide"
-description = "Permanently increases Defense by $[stat_bonus]."
+ability_name = "Marksman's Focus"
+description = "Permanently increases your Accuracy by $[stat_bonus]%, helping your shots connect against higher-level enemies."
 ability_icon = ExtResource("1_ih1")
 max_level = 5
 ability_type = 1

--- a/resources/Abilities/Dagger/A_Evasion.tres
+++ b/resources/Abilities/Dagger/A_Evasion.tres
@@ -17,13 +17,13 @@ script = ExtResource("2_eva1")
 
 [sub_resource type="Resource" id="Resource_eva_def"]
 script = ExtResource("5_eva1")
-base_value = 3.0
-per_level = 6
+base_value = 2.0
+per_level = 2.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_eva_sbf"]
 script = ExtResource("4_eva1")
-stat_type = 8
+stat_type = 17
 flat_bonus_formula = SubResource("Resource_eva_def")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 
@@ -36,7 +36,7 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 script = ExtResource("6_eva1")
 ability_id = "5101118971151051111109511-9043-1410149-105135-1410158678120214"
 ability_name = "Evasion"
-description = "Permanently increases Defense by $[stat_bonus]."
+description = "Permanently increases your Evasion by $[stat_bonus]%, reducing the chance that incoming attacks land."
 ability_icon = ExtResource("1_eva1")
 max_level = 5
 ability_type = 1

--- a/resources/Abilities/Staff/A_Arcane_Resonance.tres
+++ b/resources/Abilities/Staff/A_Arcane_Resonance.tres
@@ -17,14 +17,14 @@ script = ExtResource("2_af1")
 
 [sub_resource type="Resource" id="Resource_af_critdmg"]
 script = ExtResource("5_af1")
-base_value = 3.0
-per_level = 4
+base_value = 2.0
+per_level = 4.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_af_sbf"]
 script = ExtResource("4_af1")
-stat_type = 8
-flat_bonus_formula = SubResource("Resource_af_critdmg")
+stat_type = 13
+percent_bonus_formula = SubResource("Resource_af_critdmg")
 metadata/_custom_type_script = "uid://bx4thfjsjclbw"
 
 [sub_resource type="Resource" id="Resource_af_scaling"]
@@ -35,8 +35,8 @@ metadata/_custom_type_script = "uid://csg6jvyvm5q1n"
 [resource]
 script = ExtResource("6_af1")
 ability_id = "1251510411081061-9043-1410149-105135-1410158678120291"
-ability_name = "Stoneskin"
-description = "Permanently increases Defense by $[stat_bonus] — arcane wards harden the body."
+ability_name = "Arcane Resonance"
+description = "Permanently increases your Magic Attack by $[stat_bonus]% — arcane currents amplify every spell."
 ability_icon = ExtResource("1_af1")
 max_level = 5
 ability_type = 1

--- a/resources/Player/Disciplines/bow.tres
+++ b/resources/Player/Disciplines/bow.tres
@@ -17,7 +17,7 @@
 [ext_resource type="Resource" uid="uid://bowbarbedshot01x" path="res://resources/Abilities/Bow/A_Barbed_Shot.tres" id="15_avqjs"]
 [ext_resource type="Resource" uid="uid://bowlethality01x" path="res://resources/Abilities/Bow/A_Lethality.tres" id="16_avqjs"]
 [ext_resource type="Resource" uid="uid://bowdeepres01x" path="res://resources/Abilities/Bow/A_Tailwind.tres" id="17_avqjs"]
-[ext_resource type="Resource" uid="uid://bowironhide01x" path="res://resources/Abilities/Bow/A_Iron_Hide.tres" id="18_avqjs"]
+[ext_resource type="Resource" uid="uid://bowironhide01x" path="res://resources/Abilities/Bow/A_Marksmans_Focus.tres" id="18_avqjs"]
 
 [resource]
 script = ExtResource("1_eu6w6")

--- a/resources/Player/Disciplines/staff.tres
+++ b/resources/Player/Disciplines/staff.tres
@@ -16,7 +16,7 @@
 [ext_resource type="Resource" uid="uid://stfvitalbloom1" path="res://resources/Abilities/Staff/A_Mana_Flow.tres" id="14_vita"]
 [ext_resource type="Resource" uid="uid://stfwellspring1" path="res://resources/Abilities/Staff/A_Deep_Wellspring.tres" id="15_well"]
 [ext_resource type="Resource" uid="uid://stfkeenmind01" path="res://resources/Abilities/Staff/A_Overload.tres" id="16_keen"]
-[ext_resource type="Resource" uid="uid://stfarcanefury1" path="res://resources/Abilities/Staff/A_Stoneskin.tres" id="17_fury"]
+[ext_resource type="Resource" uid="uid://stfarcanefury1" path="res://resources/Abilities/Staff/A_Arcane_Resonance.tres" id="17_fury"]
 [ext_resource type="Resource" uid="uid://stfspellward1" path="res://resources/Abilities/Staff/A_Spell_Ward.tres" id="18_spwd"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_pq730"]

--- a/scripts/Buffs/BL_ShadowPartner.gd
+++ b/scripts/Buffs/BL_ShadowPartner.gd
@@ -130,7 +130,16 @@ func _on_owner_dealt_damage(target: Node, damage_values: Array, crit_values: Arr
 	var tgt_stats = target.get("stats_component")
 	if tgt_stats != null and is_instance_valid(tgt_stats) and tgt_stats.stats.has(Constants.StatType.EVASIONCHANCE):
 		tgt_evasion = float(tgt_stats.stats[Constants.StatType.EVASIONCHANCE].total_value)
-	var hit_chance: float = clampf(95.0 + (level_diff * 3.0) + dex_acc + stat_acc - tgt_evasion, 5.0, 100.0)
+	# PR 13 weapon-underlevel penalty — same shape as combat.gd. Phantoms use the
+	# player's wielded weapon, so an underleveled weapon also bites their hit-chance.
+	var weapon_underlevel: int = 0
+	var equip_comp = _owner_ref.get_node_or_null("Components/Equipment")
+	if equip_comp and equip_comp.active_weapon_data:
+		var wep_lvl: int = int(equip_comp.active_weapon_data.item_level)
+		if wep_lvl > 0:
+			weapon_underlevel = maxi(0, target_level - wep_lvl)
+	var weapon_penalty: float = weapon_underlevel * CombatComponent.WEAPON_UNDERLEVEL_PENALTY
+	var hit_chance: float = clampf(95.0 + (level_diff * 3.0) + dex_acc + stat_acc - tgt_evasion - weapon_penalty, 5.0, 100.0)
 
 	var shadow_damages: Array = []
 	var shadow_crits: Array = []

--- a/scripts/Buffs/BL_ShadowPartner.gd
+++ b/scripts/Buffs/BL_ShadowPartner.gd
@@ -115,7 +115,22 @@ func _on_owner_dealt_damage(target: Node, damage_values: Array, crit_values: Arr
 	var attacker_level: int = _owner_ref.level_component.level
 	var target_level: int = target.monster_level
 	var level_diff: int = attacker_level - target_level
-	var hit_chance: float = clampf(95.0 + (level_diff * 2.0), 5.0, 100.0)
+	# PR 13: mirror combat.gd hit-chance — level scalar 3, DEX accuracy +
+	# ACCURACY stat + target EVASIONCHANCE subtractor. Without this, Shadow
+	# Partner's phantom hits would have higher hit% than the player's own
+	# strikes against high-evasion targets, and lower hit% than the player's
+	# strikes when the player has accuracy investment.
+	var dex_acc: float = 0.0
+	var stat_acc: float = 0.0
+	if stats_comp.stats.has(Constants.StatType.DEXTERITY):
+		dex_acc = stats_comp.stats[Constants.StatType.DEXTERITY].total_value * StatsComponent.DEX_TO_ACCURACY
+	if stats_comp.stats.has(Constants.StatType.ACCURACY):
+		stat_acc = float(stats_comp.stats[Constants.StatType.ACCURACY].total_value)
+	var tgt_evasion: float = 0.0
+	var tgt_stats = target.get("stats_component")
+	if tgt_stats != null and is_instance_valid(tgt_stats) and tgt_stats.stats.has(Constants.StatType.EVASIONCHANCE):
+		tgt_evasion = float(tgt_stats.stats[Constants.StatType.EVASIONCHANCE].total_value)
+	var hit_chance: float = clampf(95.0 + (level_diff * 3.0) + dex_acc + stat_acc - tgt_evasion, 5.0, 100.0)
 
 	var shadow_damages: Array = []
 	var shadow_crits: Array = []

--- a/scripts/Components/CLAUDE.md
+++ b/scripts/Components/CLAUDE.md
@@ -47,10 +47,21 @@ Player (MultiplayerPlayerV2)
     │                               `attribute_points` JSONB); synced via
     │                               sync_attributes RPC.
     ├── Combat     combat.gd      - hitboxes, damage calc, crit. PR 13 hit-
-    │                               chance formula: clamp(95 + level_diff*3 +
-    │                               (DEX * 0.05) + ACCURACY - target.EVASION,
-    │                               5, 100). Level-diff scalar raised 2→3 so
-    │                               above-level fights demand accuracy invest.
+    │                               chance formula:
+    │                                 clamp(95
+    │                                   + (char_lvl - mob_lvl) * 3
+    │                                   + DEX * DEX_TO_ACCURACY
+    │                                   + attacker.ACCURACY
+    │                                   - target.EVASION
+    │                                   - max(0, mob_lvl - weapon_lvl) * 2,
+    │                                   5, 100)
+    │                               Level-diff scalar raised 2→3 so above-level
+    │                               fights demand accuracy invest. Weapon
+    │                               underlevel: -2% per level the wielded weapon
+    │                               is below the target (MapleStory-style — the
+    │                               gear-upgrade loop matters; equal-or-overlevel
+    │                               weapon = 0 penalty). Equipment access for
+    │                               weapon_lvl via _equipment_component.
     │                               BL_ShadowPartner.gd mirrors the formula
     │                               (caught diverged in PR 12 audit).
     ├── Ability    ability.gd     - learn/level/use abilities, cooldowns, passives.

--- a/scripts/Components/CLAUDE.md
+++ b/scripts/Components/CLAUDE.md
@@ -36,10 +36,23 @@ Player (MultiplayerPlayerV2)
     │                               leaving default/split builds (primary ~297 < knee)
     │                               untouched. Accounting tracks RAW spent, not
     │                               effective. CON is StatType idx 15
-    │                               (appended). Round-trips via save_attributes /
-    │                               load_attributes (backend `attribute_points`
-    │                               JSONB); synced via sync_attributes RPC.
-    ├── Combat     combat.gd      - hitboxes, damage calc, crit
+    │                               (appended). PR 13 appended ACCURACY (idx 16)
+    │                               and EVASIONCHANCE (idx 17) — both new stat
+    │                               types are read in combat.gd's hit-chance
+    │                               formula (attacker ACCURACY adds, target
+    │                               EVASIONCHANCE subtracts). Bow's Marksman's
+    │                               Focus grants ACCURACY; dagger's Evasion
+    │                               grants EVASIONCHANCE. Round-trips via
+    │                               save_attributes / load_attributes (backend
+    │                               `attribute_points` JSONB); synced via
+    │                               sync_attributes RPC.
+    ├── Combat     combat.gd      - hitboxes, damage calc, crit. PR 13 hit-
+    │                               chance formula: clamp(95 + level_diff*3 +
+    │                               (DEX * 0.05) + ACCURACY - target.EVASION,
+    │                               5, 100). Level-diff scalar raised 2→3 so
+    │                               above-level fights demand accuracy invest.
+    │                               BL_ShadowPartner.gd mirrors the formula
+    │                               (caught diverged in PR 12 audit).
     ├── Ability    ability.gd     - learn/level/use abilities, cooldowns, passives.
     │                               Ability points are PER-DISCIPLINE (PR 4 — see
     │                               available_points_per_discipline dict). Points

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -14,6 +14,15 @@ signal dealt_damage(target: Node, damage_values: Array, crit_values: Array)
 ## dead. 0.5 = half. Tunable. A dedicated caster is ~unaffected (low STR/DEX).
 const SPELLBLADE_PHYS_RATE: float = 0.5
 
+## PR 13 — hidden weapon-level weight on hit chance (MapleStory-style). Per
+## level that the wielded weapon is BELOW the target monster's level, this
+## % is subtracted from hit chance. Equal- or over-level weapon = 0 penalty
+## (overlevel gives no bonus — level requirements gate equipping anyway).
+## At 2.0, a 20-level weapon gap is -40% hit chance, which is meant to be
+## noticeable but recoverable with accuracy investment (Marksman's Focus L5
+## = +10%, gear can stack more). Tune together with the level_diff scalar.
+const WEAPON_UNDERLEVEL_PENALTY: float = 2.0
+
 # Attack type tracking
 enum AttackMode {NONE, BASIC, ABILITY}
 var _current_attack_mode: AttackMode = AttackMode.NONE
@@ -405,18 +414,18 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 
 	# --- Hit Chance Calculation ---
 	var level_diff = attacker_level - target_level
-	# Base 95% chance to hit at even level. Lose 3% chance for each level the
-	# monster is above you (PR 13 — raised 2 → 3 so above-level fights actually
-	# demand accuracy investment; before, the level penalty was too soft for
-	# DEX/ACCURACY to feel meaningful).
-	#
-	# Accuracy sources stack additively into the hit-chance:
-	#   - DEX  -> + DEX_TO_ACCURACY % per point (PR 7 utility — invisible total)
-	#   - ACCURACY stat -> + flat_bonus_value (PR 13 — bow passive, equipment)
-	# Target-side reducer:
-	#   - EVASIONCHANCE stat on target -> -flat_bonus_value (PR 13 — dagger passive)
-	# Floor 5%, ceil 100% (so a fully-evasive target still has a 5% chance to
-	# be hit; a fully-blind attacker still hits 5% of the time).
+	# Base 95% at even character level vs the monster.
+	#   character-level diff:     × 3% per level above/below (PR 13).
+	#   DEX:                      + DEX_TO_ACCURACY % per point (PR 7 attribute utility).
+	#   ACCURACY stat:            + flat_bonus_value (PR 13 — bow passive, equipment).
+	#   target EVASIONCHANCE:     - flat_bonus_value (PR 13 — dagger passive).
+	#   weapon-level underlevel:  × WEAPON_UNDERLEVEL_PENALTY per level the wielded
+	#                             weapon is BELOW the monster (PR 13 follow-up,
+	#                             MapleStory-style). Equal or over-level weapon = 0.
+	#                             Makes the gear-upgrade loop matter for accuracy
+	#                             specifically — a lvl 10 weapon vs lvl 30 mob loses
+	#                             ~40% hit chance on top of whatever damage gap exists.
+	# Floor 5%, ceil 100%.
 	var dex_accuracy: float = 0.0
 	var stat_accuracy: float = 0.0
 	if _stats_component:
@@ -428,7 +437,17 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 	var target_stats = target_enemy.get("stats_component")
 	if target_stats != null and is_instance_valid(target_stats) and target_stats.stats.has(Constants.StatType.EVASIONCHANCE):
 		target_evasion = float(target_stats.stats[Constants.StatType.EVASIONCHANCE].total_value)
-	var hit_chance = clamp(95.0 + (level_diff * 3.0) + dex_accuracy + stat_accuracy - target_evasion, 5.0, 100.0)
+	# Weapon-level underlevel penalty. Looks at the currently-active wielded weapon
+	# (so swapping to a higher-level off-hand mid-fight matters). NPCs / enemies
+	# with no equipment component skip the penalty (their attacks aren't expected
+	# to scale off "their weapon level" — that's a player-side gear concern).
+	var weapon_underlevel: int = 0
+	if _equipment_component and _equipment_component.active_weapon_data:
+		var weapon_level: int = int(_equipment_component.active_weapon_data.item_level)
+		if weapon_level > 0:
+			weapon_underlevel = maxi(0, target_level - weapon_level)
+	var weapon_penalty: float = weapon_underlevel * WEAPON_UNDERLEVEL_PENALTY
+	var hit_chance = clamp(95.0 + (level_diff * 3.0) + dex_accuracy + stat_accuracy - target_evasion - weapon_penalty, 5.0, 100.0)
 	
 	var max_hits = 1
 	if ability and level_stats:

--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -405,13 +405,30 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 
 	# --- Hit Chance Calculation ---
 	var level_diff = attacker_level - target_level
-	# Base 95% chance to hit. Lose 2% chance for each level the monster is above you.
-	# PR 7: DEX adds accuracy (StatsComponent.DEX_TO_ACCURACY % per point) — mainly
-	# matters vs higher-level enemies where the base chance dips below the cap.
+	# Base 95% chance to hit at even level. Lose 3% chance for each level the
+	# monster is above you (PR 13 — raised 2 → 3 so above-level fights actually
+	# demand accuracy investment; before, the level penalty was too soft for
+	# DEX/ACCURACY to feel meaningful).
+	#
+	# Accuracy sources stack additively into the hit-chance:
+	#   - DEX  -> + DEX_TO_ACCURACY % per point (PR 7 utility — invisible total)
+	#   - ACCURACY stat -> + flat_bonus_value (PR 13 — bow passive, equipment)
+	# Target-side reducer:
+	#   - EVASIONCHANCE stat on target -> -flat_bonus_value (PR 13 — dagger passive)
+	# Floor 5%, ceil 100% (so a fully-evasive target still has a 5% chance to
+	# be hit; a fully-blind attacker still hits 5% of the time).
 	var dex_accuracy: float = 0.0
+	var stat_accuracy: float = 0.0
 	if _stats_component:
-		dex_accuracy = _stats_component.stats.get(Constants.StatType.DEXTERITY).total_value * StatsComponent.DEX_TO_ACCURACY
-	var hit_chance = clamp(95.0 + (level_diff * 2.0) + dex_accuracy, 5.0, 100.0)
+		if _stats_component.stats.has(Constants.StatType.DEXTERITY):
+			dex_accuracy = _stats_component.stats[Constants.StatType.DEXTERITY].total_value * StatsComponent.DEX_TO_ACCURACY
+		if _stats_component.stats.has(Constants.StatType.ACCURACY):
+			stat_accuracy = float(_stats_component.stats[Constants.StatType.ACCURACY].total_value)
+	var target_evasion: float = 0.0
+	var target_stats = target_enemy.get("stats_component")
+	if target_stats != null and is_instance_valid(target_stats) and target_stats.stats.has(Constants.StatType.EVASIONCHANCE):
+		target_evasion = float(target_stats.stats[Constants.StatType.EVASIONCHANCE].total_value)
+	var hit_chance = clamp(95.0 + (level_diff * 3.0) + dex_accuracy + stat_accuracy - target_evasion, 5.0, 100.0)
 	
 	var max_hits = 1
 	if ability and level_stats:

--- a/scripts/Components/stats.gd
+++ b/scripts/Components/stats.gd
@@ -79,6 +79,8 @@ const BASE_KNOCKBACK_RESIST: int = 80
 	Constants.StatType.MAGICATTACK: StatData.new(Constants.StatType.MAGICATTACK, 0),
 	Constants.StatType.KNOCKBACKRESIST: StatData.new(Constants.StatType.KNOCKBACKRESIST, BASE_KNOCKBACK_RESIST),
 	Constants.StatType.CONSTITUTION: StatData.new(Constants.StatType.CONSTITUTION, 4),
+	Constants.StatType.ACCURACY: StatData.new(Constants.StatType.ACCURACY, 0),
+	Constants.StatType.EVASIONCHANCE: StatData.new(Constants.StatType.EVASIONCHANCE, 0),
 
 }
 

--- a/scripts/Core/Enums/constants.gd
+++ b/scripts/Core/Enums/constants.gd
@@ -50,6 +50,8 @@ enum StatType {
 	MAGICATTACK,
 	KNOCKBACKRESIST,
 	CONSTITUTION, # PR 7 — appended (idx 15, NEVER insert): attribute → Max HP + HP regen
+	ACCURACY,     # PR 13 — appended (idx 16, NEVER insert): +% hit chance, additive in combat.gd
+	EVASIONCHANCE, # PR 13 — appended (idx 17, NEVER insert): -% hit chance on incoming attacks
 }
 
 enum EquipmentType {

--- a/scripts/UI/equipment_compare_tooltip.gd
+++ b/scripts/UI/equipment_compare_tooltip.gd
@@ -44,6 +44,9 @@ const STAT_NAMES := {
 	Constants.StatType.WEAPONATTACK: "Weapon Attack",
 	Constants.StatType.MAGICATTACK: "Magic Attack",
 	Constants.StatType.KNOCKBACKRESIST: "Knockback Resist",
+	Constants.StatType.CONSTITUTION: "Constitution",
+	Constants.StatType.ACCURACY: "Accuracy",
+	Constants.StatType.EVASIONCHANCE: "Evasion",
 }
 
 


### PR DESCRIPTION
Per the passive review breakdown — Sword should be the only +Defense passive. Bow, Staff, and Dagger get distinct stat identities. **Updated with weapon-level weighting on accuracy** per the MapleStory-style gear-gates-content feel.

## Passive changes

| Discipline | Was | Now |
|---|---|---|
| **Bow** | Iron Hide (+27 DEF at L5) | **Marksman's Focus** (+10% Accuracy at L5) |
| **Dagger** | Evasion (+27 DEF) — name didn't match mechanic | **Evasion** (+10% Evasion Chance at L5) |
| **Staff** | Stoneskin (+19 DEF) | **Arcane Resonance** (+18% Magic Attack at L5) |

## New StatTypes (appended at idx 16/17)

- `ACCURACY`      (idx 16) — additive into attacker hit-chance
- `EVASIONCHANCE` (idx 17) — subtracted from incoming hit-chance

Initialized at 0 in `StatsComponent.stats`. STAT_NAMES map in the equipment tooltip gets friendly labels for both (and a missing `Constitution` entry from PR 7 that I caught too).

## New combat hit-chance formula

```
hit_chance = clamp(
    95
    + (char_level - mob_level) * 3                  # was *2 — above-level fights now bite
    + DEX * DEX_TO_ACCURACY                         # PR 7 attribute utility
    + attacker.ACCURACY                             # PR 13 — bow passive, gear
    - target.EVASIONCHANCE                          # PR 13 — dagger passive
    - max(0, mob_level - weapon_level) * 2,         # PR 13 — weapon-underlevel penalty
    5, 100
)
```

Three knobs working together:
1. **Level-diff scalar 2→3** — above-level monsters dodge more, so accuracy investment matters.
2. **ACCURACY / EVASIONCHANCE stats** — give bow + dagger their distinctive build axes.
3. **Weapon underlevel penalty** — gear-progression gating ("you can't kill a lvl 30 mob with a lvl 10 weapon").

### Worked examples (lvl 30 char with various weapons + targets)

| char | weapon | mob | base | char penalty | wep penalty | hit |
|---:|---:|---:|---:|---:|---:|---:|
| 30 | 30 | 30 | 95 | 0 | 0 | **95%** |
| 30 | 20 | 30 | 95 | 0 | -20 | **75%** |
| 30 | 10 | 30 | 95 | 0 | -40 | **55%** |
| 30 | 30 | 40 | 95 | -30 | 0 | **65%** |
| 30 | 20 | 40 | 95 | -30 | -40 | **25%** |
| 30 | 10 | 40 | 95 | -30 | -60 | **5% (floor)** |

Marksman's Focus L5 = +10% recovers some of that; gear can stack more. A 10-level weapon gap is recoverable with accuracy investment, a 20+ level gap is meant to feel terrible.

## Bug fix piggybacked

`BL_ShadowPartner.gd` had a diverged copy of the hit-chance formula (caught in the PR 12 audit) that lacked the DEX accuracy term. PR 13 mirrors the full new formula there — including weapon-underlevel penalty, since phantom hits are powered by the player's wielded weapon.

## Null safety

Combat reads of ACCURACY/EVASIONCHANCE/weapon_level are `has()` guarded. Enemies use a slimmed `curve_stats` dict (no DEX/ACC/EVA) and no equipment component, so:
- **Player attacks enemy**: player ACCURACY + weapon-level penalty applies, enemy EVASION = 0
- **Enemy attacks player**: enemy DEX/ACCURACY = 0, no weapon-level term (enemy has no equipment_component), player EVASION subtracts

Existing fights unchanged unless we explicitly grant enemies new stats later.

## File renames

| Old | New |
|---|---|
| `A_Iron_Hide.tres` | `A_Marksmans_Focus.tres` |
| `A_Stoneskin.tres` | `A_Arcane_Resonance.tres` |
| `A_Evasion.tres` | (kept — name now matches mechanic) |

Discipline .tres path references rewritten. UIDs preserved so saves keep working.

## Tests

79/81 — same 2 pre-existing failures.

## Followups (not in this PR)

- Balance simulator (`addons/balance_simulator/simulator_dock.gd:753`) still uses the old `95 + level_diff*2` formula without DEX or weapon underlevel — should be mirrored.
- Enemy stat curves could optionally include EVASIONCHANCE for specific "dodge" enemies.
- `WEAPON_UNDERLEVEL_PENALTY = 2.0` is a first-pass tuning value; verify in playtest that 10-level gaps feel like the right amount of bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)