### PR TITLE
Fix 3 followups + Arcane Resonance rebalance

### DIFF
--- a/addons/balance_simulator/simulator_dock.gd
+++ b/addons/balance_simulator/simulator_dock.gd
@@ -19,11 +19,16 @@ const COMBAT_COLUMNS := ["Lv", "Stat", "Min", "Max", "Avg", "Hit%", "ExpAvg"]
 
 # Combat formula constants, mirrored from CombatComponent so the simulator
 # matches the game's damage calculation exactly.
-const HIT_CHANCE_PER_LEVEL_DIFF := 2.0
+# PR 14: raised HIT_CHANCE_PER_LEVEL_DIFF 2 -> 3 (combat.gd PR 13) and added
+# DEX_TO_ACCURACY + WEAPON_UNDERLEVEL_PENALTY constants so the Hit% column
+# reflects the new accuracy/evasion/weapon-level math.
+const HIT_CHANCE_PER_LEVEL_DIFF := 3.0
 const LEVEL_MOD_PER_LEVEL_DIFF := 0.05
 const LEVEL_MOD_MIN := 0.5
 const LEVEL_MOD_MAX := 1.5
 const DEFENSE_DENOM := 500.0
+const DEX_TO_ACCURACY := 0.05
+const WEAPON_UNDERLEVEL_PENALTY := 2.0
 
 var _editor_interface: EditorInterface = null
 
@@ -542,8 +547,11 @@ func _build_combat_section() -> void:
 	# Defaults: a fresh level-1 character — base WeaponDisciplineData stats (4 each),
 	# no equipment, no crit. Adjust upward to test gear / progression.
 	_add_spinbox(player_grid, "player_level",     "Level",      1,     999,     1, 1)
+	_add_spinbox(player_grid, "weapon_level",     "Wpn Level",  0,     999,     1, 1)
 	_add_spinbox(player_grid, "primary_stat",     "Primary",    0,    9999,     4, 1)
 	_add_spinbox(player_grid, "secondary_stat",   "Secondary",  0,    9999,     4, 1)
+	_add_spinbox(player_grid, "dex",              "DEX",        0,    9999,     0, 1)
+	_add_spinbox(player_grid, "accuracy",         "Accuracy %", 0.0, 200.0,   0.0, 1.0)
 	_add_spinbox(player_grid, "weapon_attack",    "WeaponAtk",  0,   99999,     0, 1)
 	_add_spinbox(player_grid, "magic_attack",     "MagicAtk",   0,   99999,     0, 1)
 	_add_spinbox(player_grid, "weapon_multiplier","Wpn Mult",   0.1,   3.0,   1.5, 0.05)
@@ -561,8 +569,9 @@ func _build_combat_section() -> void:
 	target_body.add_child(target_grid)
 
 	# Defaults: a level-1 enemy with no defense — the lowest-end matchup.
-	_add_spinbox(target_grid, "target_level",   "Level",   1,     999,     1, 1)
-	_add_spinbox(target_grid, "target_defense", "Defense", 0,  999999,     0, 1)
+	_add_spinbox(target_grid, "target_level",    "Level",    1,    999,    1, 1)
+	_add_spinbox(target_grid, "target_defense",  "Defense",  0, 999999,    0, 1)
+	_add_spinbox(target_grid, "target_evasion",  "Evasion %", 0.0, 100.0,  0.0, 1.0)
 
 	# A bit of context inside the target panel so the difference is obvious at
 	# a glance — these are the only two enemy-side inputs the combat formula
@@ -741,6 +750,10 @@ func _recompute_combat() -> void:
 	var crit_chance: float = _loadout_widgets.crit_chance.value
 	var crit_damage_pct: float = _loadout_widgets.crit_damage.value
 	var target_defense: int = int(_loadout_widgets.target_defense.value)
+	var target_evasion: float = float(_loadout_widgets.target_evasion.value)
+	var weapon_level: int = int(_loadout_widgets.weapon_level.value)
+	var dex: int = int(_loadout_widgets.dex.value)
+	var accuracy: float = float(_loadout_widgets.accuracy.value)
 
 	# Damage stat for THIS ability (Layer-1 value; CombatComponent uses this in
 	# _calculate_max_range for ability damage).
@@ -748,9 +761,18 @@ func _recompute_combat() -> void:
 	var attack_power: int = magic_attack if dmg_stat == _ConstantsScript.StatType.MAGICATTACK \
 		else weapon_attack
 
-	# Mirror the combat formula at each level.
+	# Mirror the combat formula at each level (CombatComponent._execute_hit, PR 13/14):
+	#   95 + char_diff*3 + DEX*0.05 + ACCURACY - target.EVASION
+	#      - max(0, target_lvl - weapon_lvl) * WEAPON_UNDERLEVEL_PENALTY
+	# floor 5, ceil 100.
 	var level_diff: int = player_level - target_level
-	var hit_chance: float = clampf(95.0 + (level_diff * HIT_CHANCE_PER_LEVEL_DIFF), 5.0, 100.0)
+	var dex_acc: float = float(dex) * DEX_TO_ACCURACY
+	var weapon_underlevel: int = maxi(0, target_level - weapon_level) if weapon_level > 0 else 0
+	var weapon_penalty: float = float(weapon_underlevel) * WEAPON_UNDERLEVEL_PENALTY
+	var hit_chance: float = clampf(
+		95.0 + (level_diff * HIT_CHANCE_PER_LEVEL_DIFF) + dex_acc + accuracy - target_evasion - weapon_penalty,
+		5.0, 100.0
+	)
 	var level_mod: float = clampf(1.0 + (level_diff * LEVEL_MOD_PER_LEVEL_DIFF), LEVEL_MOD_MIN, LEVEL_MOD_MAX)
 	var defense_mult: float = 1.0 - (float(target_defense) / (target_defense + DEFENSE_DENOM))
 	# Average crit multiplier = mid of randf_range(1.2, 1.5) + critDamage%/100.

--- a/resources/Abilities/Staff/A_Arcane_Resonance.tres
+++ b/resources/Abilities/Staff/A_Arcane_Resonance.tres
@@ -18,7 +18,7 @@ script = ExtResource("2_af1")
 [sub_resource type="Resource" id="Resource_af_critdmg"]
 script = ExtResource("5_af1")
 base_value = 2.0
-per_level = 4.0
+per_level = 2.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_af_sbf"]

--- a/scripts/Abilities/AL_Bloodthirst.gd
+++ b/scripts/Abilities/AL_Bloodthirst.gd
@@ -10,17 +10,18 @@ extends Node
 ## learned passive abilities and calls on_kill on those whose
 ## active_behavior.logic_script defines the method.
 
-## PR 6 follow-up: original 1% + 1%/lvl (10% at L10) was way too generous
-## per playtest — a maxed Bloodthirst made the character functionally
-## unkillable in a kill-chain. Tuned down to ~3.2% at L10, modeled after
-## MapleStory Demon Avenger's HP-recovery trickle (small per-kill, real
-## but not build-defining sustain).
+## PR 14 (2026-05-31): heal % now reads from A_Bloodthirst.tres's
+## damage_percent_formula directly, so future .tres tunings auto-propagate
+## without touching this script. The hardcoded BASE/PER_LEVEL constants
+## had drifted: PR 9 doubled .tres per_level (0.3 → 0.6) when max_level
+## halved (10 → 5), but this script's PER_LEVEL_HEAL_PCT stayed 0.3 —
+## Bloodthirst silently undertuned at L5 (1.7% instead of intended 2.9%).
+## Reading from the formula makes that whole class of bug impossible.
 ##
+## With the current .tres formula (base 0.5, per_level 0.6, max_level 5):
 ##   L1:   0.5% Max HP per kill
-##   L5:   1.7% Max HP per kill
-##   L10:  3.2% Max HP per kill   (was 10%)
-const BASE_HEAL_PCT: float = 0.5
-const PER_LEVEL_HEAL_PCT: float = 0.3
+##   L3:   1.7% Max HP per kill
+##   L5:   2.9% Max HP per kill
 
 
 func on_kill(_owner_node: Node, _target: Node, _ability_level: int, _ability_id: String = "") -> void:
@@ -33,7 +34,14 @@ func on_kill(_owner_node: Node, _target: Node, _ability_level: int, _ability_id:
 	if health_comp.is_dead:
 		return
 
-	var heal_pct: float = BASE_HEAL_PCT + PER_LEVEL_HEAL_PCT * float(_ability_level - 1)
+	# Read per-level heal % from the .tres formula (single source of truth).
+	# Fallback to a small fixed value if the ability data can't be resolved.
+	var heal_pct: float = 0.5
+	if _ability_id != "":
+		var ability: AbilityData = ResourceManager.get_ability_data(_ability_id)
+		if ability and ability.damage_percent_formula:
+			heal_pct = ability.damage_percent_formula.calculate(_ability_level)
+
 	# PR 6 upgrades: "heal_pct_bonus" (+flat % per kill) and "vampiric_basic"
 	# is handled elsewhere; here we only add the per-kill heal bonus.
 	var ability_comp = _owner_node.get("ability_component")


### PR DESCRIPTION
Three followups from the PR 13 thread + the Arcane Resonance rebalance the user flagged.

## 1. Arcane Resonance rebalance (staff)

Was: \`base 2, per_level 4\` → L5 = **+18% Magic Attack** (direct +18% DPS)

Comparison with peer offensive passives at L5:
- Keen Eye (bow): +10% crit chance — ~10% effective DPS
- Lethality (bow): +18% crit damage — ~5% eff DPS at 30% crit
- Cutthroat (dagger): +20% crit damage — ~6% eff DPS

Staff's +18% direct outpaces all of them. Tuned to **\`base 2, per_level 2\` → L5: +10% Magic Attack** — sits in the same DPS band as Keen Eye.

## 2. Bloodthirst AL hardcode → read from .tres formula

The class of bug: \`AL_Bloodthirst.gd\` had \`PER_LEVEL_HEAL_PCT = 0.3\` hardcoded for the old max_level=20 era. PR 9 doubled the .tres per_level to 0.6 when max_level halved to 5 — but this script never got the memo. Bloodthirst silently undertuned at L5 (gave 1.7% instead of intended 2.9%).

**Fix:** read \`ability.damage_percent_formula.calculate(level)\` directly. Now future .tres tunings auto-propagate. This is the structural fix for [[feedback-audit-al-scripts-when-changing-max-level]] — eliminate the hardcode rather than just sync it.

## 3. Balance simulator hit-chance formula

Mirrors combat.gd PR 13/14:

- \`HIT_CHANCE_PER_LEVEL_DIFF\` 2 → 3
- Added consts: \`DEX_TO_ACCURACY = 0.05\`, \`WEAPON_UNDERLEVEL_PENALTY = 2.0\`
- New loadout inputs: **Wpn Level, DEX, Accuracy %** (player side); **Evasion %** (target side)
- Hit% column now reflects:
  \`95 + char_diff*3 + DEX*0.05 + ACC - target.EVA - max(0, target_lvl - wpn_lvl) * 2\`

You can now sim "lvl 30 char with lvl 10 weapon vs lvl 30 mob" and see the 55% hit% directly in the table.

## On the 3rd followup ("BL_ShadowPartner playtest")

That one wasn't a code fix — BL_ShadowPartner.gd already mirrors combat.gd's full formula (PRs 13/14). The note was to verify the FEEL in playtest. Left as a playtest TODO; nothing to code-change.

## Tests

79/81 (same 2 pre-existing failures from earlier in the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)