### PR TITLE
Tune Arcane Resonance L5 +10% -> +6% Magic Attack

### DIFF
--- a/resources/Abilities/Staff/A_Arcane_Resonance.tres
+++ b/resources/Abilities/Staff/A_Arcane_Resonance.tres
@@ -18,7 +18,7 @@ script = ExtResource("2_af1")
 [sub_resource type="Resource" id="Resource_af_critdmg"]
 script = ExtResource("5_af1")
 base_value = 2.0
-per_level = 2.0
+per_level = 1.0
 metadata/_custom_type_script = "uid://dnsex6fyou07d"
 
 [sub_resource type="Resource" id="Resource_af_sbf"]


### PR DESCRIPTION
User flagged that Staff might be outscaling other weapons via Arcane Resonance — confirmed by effective-DPS analysis.

## The math

Flat % damage and crit-based % aren't equivalent at the same raw number. Flat % applies to **every hit including non-crits**; crit-based only contributes on crit hits. Per the principle in [[feedback-size-passives-by-effective-dps]], compare via effective DPS:

| Passive (L5) | Mechanic | Raw % | Effective DPS |
|---|---|---:|---:|
| Keen Eye (Bow) | +crit chance | 10% | +7.7% |
| Lethality (Bow) | +crit damage | 18% | +5.4% |
| Killer Instinct (Dagger) | +crit chance | 11% | +8.5% |
| Cutthroat (Dagger) | +crit damage | 20% | +6.0% |
| **Arcane Resonance BEFORE** | **+Magic Attack %** | **10%** | **+10.0%** |
| **Arcane Resonance NOW** | **+Magic Attack %** | **6%** | **+6.0%** |

## Per-pt efficiency for the damage passive lineup

| Weapon | Build | Total DPS | Pts | Per-pt |
|---|---|---:|---:|---:|
| Bow | Keen Eye + Lethality | +13.1% | 10 | 1.31% |
| Dagger | Killer Instinct + Cutthroat | +14.5% | 10 | 1.45% |
| Staff BEFORE | Arcane Resonance alone | +10.0% | 5 | **2.00%** ← out of band |
| Staff NOW | Arcane Resonance alone | +6.0% | 5 | 1.20% |

Staff now sits in the same band as bow/dagger — slightly lower per-pt, accounting for the fact that staff's bonus is unconditional (a small premium for reliability is fair).

## Change

\`A_Arcane_Resonance.tres\` percent_bonus_formula: \`per_level 2.0 -> 1.0\`
- L1: +2% Magic Attack (unchanged)
- L5: +6% Magic Attack (was +10%)

## Tests

79/81 (same 2 pre-existing failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)