### PR TITLE
Hotfix: combat.gd duplicate target_stats parse error

### DIFF
--- a/scripts/Components/combat.gd
+++ b/scripts/Components/combat.gd
@@ -434,9 +434,9 @@ func _execute_hit(target_enemy: Node, ability: AbilityData, level_stats: Ability
 		if _stats_component.stats.has(Constants.StatType.ACCURACY):
 			stat_accuracy = float(_stats_component.stats[Constants.StatType.ACCURACY].total_value)
 	var target_evasion: float = 0.0
-	var target_stats = target_enemy.get("stats_component")
-	if target_stats != null and is_instance_valid(target_stats) and target_stats.stats.has(Constants.StatType.EVASIONCHANCE):
-		target_evasion = float(target_stats.stats[Constants.StatType.EVASIONCHANCE].total_value)
+	var target_stats_for_evasion = target_enemy.get("stats_component")
+	if target_stats_for_evasion != null and is_instance_valid(target_stats_for_evasion) and target_stats_for_evasion.stats.has(Constants.StatType.EVASIONCHANCE):
+		target_evasion = float(target_stats_for_evasion.stats[Constants.StatType.EVASIONCHANCE].total_value)
 	# Weapon-level underlevel penalty. Looks at the currently-active wielded weapon
 	# (so swapping to a higher-level off-hand mid-fight matters). NPCs / enemies
 	# with no equipment component skip the penalty (their attacks aren't expected


### PR DESCRIPTION
PR 13 introduced a function-scoped `var target_stats` in `_execute_hit`'s hit-chance section that collided with two pre-existing block-scoped `var target_stats` declarations later in the same function. Renamed to `target_stats_for_evasion`.

**Why this shipped silently:** the headless test suite never loads `combat.gd` directly (it only exercises ability/scaling logic), so the parse error stayed invisible — the "CombatComponent could not parse" warnings I dismissed as cold-cache through PRs 13–15 were the real bug. Test harness gap to add to followups.

`godot --check-only` now passes with no combat.gd errors.