### PR TITLE
Second Wind upgrades + rename 24 stale upgrade names

### DIFF
--- a/resources/Abilities/Bow/Upgrades/U_DR_Boundless.tres
+++ b/resources/Abilities/Bow/Upgrades/U_DR_Boundless.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dr_t3_boundless"
-upgrade_name = "Boundless"
-description = "Increases Tailwind's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Hurricane"
+description = "Increases Tailwind's bonus damage at max Momentum by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Bow/Upgrades/U_DR_Capacity.tres
+++ b/resources/Abilities/Bow/Upgrades/U_DR_Capacity.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dr_t1_capacity"
-upgrade_name = "Capacity"
-description = "Increases Tailwind's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Crosswind"
+description = "Increases Tailwind's bonus damage at max Momentum by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Bow/Upgrades/U_DR_Wellspring.tres
+++ b/resources/Abilities/Bow/Upgrades/U_DR_Wellspring.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dr_t2_wellspring"
-upgrade_name = "Wellspring"
-description = "Increases Tailwind's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Headwind"
+description = "Increases Tailwind's bonus damage at max Momentum by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Bow/Upgrades/U_FF_LightningReflexes.tres
+++ b/resources/Abilities/Bow/Upgrades/U_FF_LightningReflexes.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ff_t3_lightning_reflexes"
-upgrade_name = "Lightning Reflexes"
-description = "Increases Execution's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Reaper's Mark"
+description = "Increases Execution's bonus damage vs low-HP targets by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Bow/Upgrades/U_FF_Nimble.tres
+++ b/resources/Abilities/Bow/Upgrades/U_FF_Nimble.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ff_t1_nimble"
-upgrade_name = "Nimble"
-description = "Increases Execution's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Coup de Grace"
+description = "Increases Execution's bonus damage vs low-HP targets by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Bow/Upgrades/U_FF_Quick.tres
+++ b/resources/Abilities/Bow/Upgrades/U_FF_Quick.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ff_t2_quick"
-upgrade_name = "Quick"
-description = "Increases Execution's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Killing Blow"
+description = "Increases Execution's bonus damage vs low-HP targets by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Bow/Upgrades/U_IH_Calloused.tres
+++ b/resources/Abilities/Bow/Upgrades/U_IH_Calloused.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ih_t2_calloused"
-upgrade_name = "Calloused"
-description = "Increases Iron Hide's Defense bonus by +3."
+upgrade_name = "Sharpshooter's Eye"
+description = "Increases Marksman's Focus's Accuracy bonus by +3%."
 tier = 2
 effect_key = "passive_stat_flat_bonus"
 magnitude = 3.0

--- a/resources/Abilities/Bow/Upgrades/U_IH_Ironclad.tres
+++ b/resources/Abilities/Bow/Upgrades/U_IH_Ironclad.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ih_t3_ironclad"
-upgrade_name = "Ironclad"
-description = "Increases Iron Hide's Defense bonus by +3."
+upgrade_name = "Dead-Eye"
+description = "Increases Marksman's Focus's Accuracy bonus by +3%."
 point_cost = 2
 tier = 3
 effect_key = "passive_stat_flat_bonus"

--- a/resources/Abilities/Bow/Upgrades/U_IH_Thick.tres
+++ b/resources/Abilities/Bow/Upgrades/U_IH_Thick.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "ih_t1_thick"
-upgrade_name = "Thick Skin"
-description = "Increases Iron Hide's Defense bonus by +2."
+upgrade_name = "Steady Hand"
+description = "Increases Marksman's Focus's Accuracy bonus by +2%."
 effect_key = "passive_stat_flat_bonus"
 magnitude = 2.0

--- a/resources/Abilities/Dagger/Upgrades/U_DPK_Bottomless.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_DPK_Bottomless.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dpk_t3_bottomless"
-upgrade_name = "Bottomless"
-description = "Increases Opportunist's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Assassinate"
+description = "Increases Opportunist's stealth damage bonus by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Dagger/Upgrades/U_DPK_Deep.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_DPK_Deep.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dpk_t1_deep"
-upgrade_name = "Deep"
-description = "Increases Opportunist's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Backstab"
+description = "Increases Opportunist's stealth damage bonus by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Dagger/Upgrades/U_DPK_Hidden.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_DPK_Hidden.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "dpk_t2_hidden"
-upgrade_name = "Hidden Reserves"
-description = "Increases Opportunist's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Ambush"
+description = "Increases Opportunist's stealth damage bonus by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Dagger/Upgrades/U_LUK_Blessed.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_LUK_Blessed.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "luk_t3_blessed"
-upgrade_name = "Blessed"
-description = "Increases Composure's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Cold-Blooded"
+description = "Increases Composure's high-HP damage bonus by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Dagger/Upgrades/U_LUK_Fortunate.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_LUK_Fortunate.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "luk_t2_fortunate"
-upgrade_name = "Fortunate"
-description = "Increases Composure's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Unfazed"
+description = "Increases Composure's high-HP damage bonus by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Dagger/Upgrades/U_LUK_Lucky.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_LUK_Lucky.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "luk_t1_lucky"
-upgrade_name = "Lucky"
-description = "Increases Composure's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Steady"
+description = "Increases Composure's high-HP damage bonus by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Dagger/Upgrades/U_VIG_Hardy.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VIG_Hardy.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "vig_t1_hardy"
-upgrade_name = "Hardy"
-description = "Increases Cutthroat's critical hit chance bonus by +1%."
+upgrade_name = "Razor's Edge"
+description = "Increases Cutthroat's Critical Damage bonus by +1%."
 effect_key = "passive_stat_flat_bonus"
 magnitude = 1.0

--- a/resources/Abilities/Dagger/Upgrades/U_VIG_Robust.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VIG_Robust.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "vig_t2_robust"
-upgrade_name = "Robust"
-description = "Increases Cutthroat's critical hit chance bonus by +2%."
+upgrade_name = "Killing Stroke"
+description = "Increases Cutthroat's Critical Damage bonus by +2%."
 tier = 2
 effect_key = "passive_stat_flat_bonus"
 magnitude = 2.0

--- a/resources/Abilities/Dagger/Upgrades/U_VIG_Stalwart.tres
+++ b/resources/Abilities/Dagger/Upgrades/U_VIG_Stalwart.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "vig_t3_stalwart"
-upgrade_name = "Stalwart"
-description = "Increases Cutthroat's critical hit chance bonus by +2%."
+upgrade_name = "Death Strike"
+description = "Increases Cutthroat's Critical Damage bonus by +2%."
 point_cost = 2
 tier = 3
 effect_key = "passive_stat_flat_bonus"

--- a/resources/Abilities/Staff/Upgrades/U_AM_Erudite.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AM_Erudite.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "am_t2_erudite"
-upgrade_name = "Erudite"
-description = "Increases Killing Spree's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Adrenaline Surge"
+description = "Increases Killing Spree's post-kill damage bonus by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Staff/Upgrades/U_AM_Sage.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AM_Sage.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "am_t3_sage"
-upgrade_name = "Sage's Insight"
-description = "Increases Killing Spree's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Frenzy"
+description = "Increases Killing Spree's post-kill damage bonus by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Staff/Upgrades/U_AM_Studious.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AM_Studious.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "am_t1_studious"
-upgrade_name = "Studious"
-description = "Increases Killing Spree's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Momentum"
+description = "Increases Killing Spree's post-kill damage bonus by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Staff/Upgrades/U_KM_Focused.tres
+++ b/resources/Abilities/Staff/Upgrades/U_KM_Focused.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "km_t1_focused"
-upgrade_name = "Focused"
-description = "Increases Overload's bonus damage by +3% (while its condition is met)."
+upgrade_name = "Charged"
+description = "Increases Overload's high-mana damage bonus by +3%."
 effect_key = "conditional_damage_bonus"
 magnitude = 0.03

--- a/resources/Abilities/Staff/Upgrades/U_KM_Incisive.tres
+++ b/resources/Abilities/Staff/Upgrades/U_KM_Incisive.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "km_t2_incisive"
-upgrade_name = "Incisive"
-description = "Increases Overload's bonus damage by +5% (while its condition is met)."
+upgrade_name = "Surging"
+description = "Increases Overload's high-mana damage bonus by +5%."
 tier = 2
 effect_key = "conditional_damage_bonus"
 magnitude = 0.05

--- a/resources/Abilities/Staff/Upgrades/U_KM_Prescient.tres
+++ b/resources/Abilities/Staff/Upgrades/U_KM_Prescient.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "km_t3_prescient"
-upgrade_name = "Prescient"
-description = "Increases Overload's bonus damage by +7% (while its condition is met)."
+upgrade_name = "Overflowing"
+description = "Increases Overload's high-mana damage bonus by +7%."
 point_cost = 2
 tier = 3
 effect_key = "conditional_damage_bonus"

--- a/resources/Abilities/Sword/A_Second_Wind.tres
+++ b/resources/Abilities/Sword/A_Second_Wind.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="AbilityData" load_steps=12 format=3 uid="uid://mgj21bo08vcx"]
+[gd_resource type="Resource" script_class="AbilityData" load_steps=15 format=3 uid="uid://mgj21bo08vcx"]
 
 [ext_resource type="Texture2D" uid="uid://cc18m1wu0h2vl" path="res://assets/sprites/Abilities/sharp_eyes.png" id="1_bi1"]
 [ext_resource type="Script" uid="uid://1raaatfhww5y" path="res://scripts/Resources/AbilitySystem/ActiveBehaviorData.gd" id="2_bi1"]
@@ -7,6 +7,9 @@
 [ext_resource type="Script" uid="uid://dnsex6fyou07d" path="res://scripts/Resources/AbilitySystem/AbilityScalingFormula.gd" id="5_bi1"]
 [ext_resource type="Script" uid="uid://b8y62rc8nb40j" path="res://scripts/Resources/AbilitySystem/AbilityData.gd" id="6_bi1"]
 [ext_resource type="Script" uid="uid://baupgr1sword3" path="res://scripts/Resources/AbilitySystem/AbilityUpgradeData.gd" id="8_aud"]
+[ext_resource type="Resource" uid="uid://swt1recover0001" path="res://resources/Abilities/Sword/Upgrades/U_SW_Recovery.tres" id="9_swrc"]
+[ext_resource type="Resource" uid="uid://swt2secheart002" path="res://resources/Abilities/Sword/Upgrades/U_SW_SecondHeart.tres" id="10_swsh"]
+[ext_resource type="Resource" uid="uid://swt3inexhaust03" path="res://resources/Abilities/Sword/Upgrades/U_SW_Inexhaustible.tres" id="11_swin"]
 
 [sub_resource type="Resource" id="Resource_bi_behav"]
 resource_local_to_scene = true
@@ -41,6 +44,7 @@ required_class = Array[int]([0])
 required_weapon_types = Array[int]([0])
 tree_path = 0
 tree_depth = 6
+upgrades = Array[ExtResource("8_aud")]([ExtResource("9_swrc"), ExtResource("10_swsh"), ExtResource("11_swin")])
 active_behavior = SubResource("Resource_bi_behav")
 scaling_data = SubResource("Resource_bi_scaling")
 metadata/_custom_type_script = "uid://b8y62rc8nb40j"

--- a/resources/Abilities/Sword/Upgrades/U_SW_Inexhaustible.tres
+++ b/resources/Abilities/Sword/Upgrades/U_SW_Inexhaustible.tres
@@ -1,0 +1,13 @@
+[gd_resource type="Resource" script_class="AbilityUpgradeData" load_steps=2 format=3 uid="uid://swt3inexhaust03"]
+
+[ext_resource type="Script" uid="uid://baupgr1sword3" path="res://scripts/Resources/AbilitySystem/AbilityUpgradeData.gd" id="1_aud"]
+
+[resource]
+script = ExtResource("1_aud")
+upgrade_id = "sw_t3_inexhaustible"
+upgrade_name = "Inexhaustible"
+description = "Increases Second Wind's HP regeneration bonus by +2."
+effect_key = "passive_stat_flat_bonus"
+magnitude = 2.0
+tier = 3
+point_cost = 2

--- a/resources/Abilities/Sword/Upgrades/U_SW_Recovery.tres
+++ b/resources/Abilities/Sword/Upgrades/U_SW_Recovery.tres
@@ -1,0 +1,11 @@
+[gd_resource type="Resource" script_class="AbilityUpgradeData" load_steps=2 format=3 uid="uid://swt1recover0001"]
+
+[ext_resource type="Script" uid="uid://baupgr1sword3" path="res://scripts/Resources/AbilitySystem/AbilityUpgradeData.gd" id="1_aud"]
+
+[resource]
+script = ExtResource("1_aud")
+upgrade_id = "sw_t1_recovery"
+upgrade_name = "Recovery"
+description = "Increases Second Wind's HP regeneration bonus by +1."
+effect_key = "passive_stat_flat_bonus"
+magnitude = 1.0

--- a/resources/Abilities/Sword/Upgrades/U_SW_SecondHeart.tres
+++ b/resources/Abilities/Sword/Upgrades/U_SW_SecondHeart.tres
@@ -1,0 +1,12 @@
+[gd_resource type="Resource" script_class="AbilityUpgradeData" load_steps=2 format=3 uid="uid://swt2secheart002"]
+
+[ext_resource type="Script" uid="uid://baupgr1sword3" path="res://scripts/Resources/AbilitySystem/AbilityUpgradeData.gd" id="1_aud"]
+
+[resource]
+script = ExtResource("1_aud")
+upgrade_id = "sw_t2_second_heart"
+upgrade_name = "Second Heart"
+description = "Increases Second Wind's HP regeneration bonus by +1."
+effect_key = "passive_stat_flat_bonus"
+magnitude = 1.0
+tier = 2


### PR DESCRIPTION
Two cleanups from the passives review report.

## 1. Second Wind upgrade chain (sword)

Was the only passive in the entire set without T1/T2/T3 upgrades. Added 3 themed upgrades matching the staff Mana Flow regen-passive pattern (same magnitudes: 1/1/2 flat regen):

| Tier | Name | Cost | Effect | Magnitude |
|---|---|---|---|---|
| 1 | Recovery | 1 | passive_stat_flat_bonus | +1 HP regen |
| 2 | Second Heart | 1 | passive_stat_flat_bonus | +1 HP regen |
| 3 | Inexhaustible | 2 | passive_stat_flat_bonus | +2 HP regen |

Wired into `A_Second_Wind.tres`'s `upgrades` array.

## 2. 24 stale upgrade name renames

PR 12 renamed parent abilities but didn't sweep the upgrade .tres files — players were seeing upgrade names from the OLD passive identities. **upgrade_ids / effect_keys / magnitudes / tiers / costs unchanged** so save data keeps resolving correctly.

| Passive | Old → New |
|---|---|
| **Bow** Marksman's Focus (was Iron Hide) | Thick Skin / Calloused / Ironclad → Steady Hand / Sharpshooter's Eye / Dead-Eye |
| **Bow** Tailwind (was Deep Reserves) | Capacity / Wellspring / Boundless → Crosswind / Headwind / Hurricane |
| **Bow** Execution (was Fleet Fingers) | Nimble / Quick / Lightning Reflexes → Coup de Grâce / Killing Blow / Reaper's Mark |
| **Staff** Killing Spree (was Arcane Mind) | Studious / Erudite / Sage's Insight → Momentum / Adrenaline Surge / Frenzy |
| **Staff** Overload (was Keen Mind) | Focused / Incisive / Prescient → Charged / Surging / Overflowing |
| **Dagger** Cutthroat (was Vigor) | Hardy / Robust / Stalwart → Razor's Edge / Killing Stroke / Death Strike |
| **Dagger** Opportunist (was Deep Pockets) | Deep / Hidden Reserves / Bottomless → Backstab / Ambush / Assassinate |
| **Dagger** Composure (was Larcenous Luck) | Lucky / Fortunate / Blessed → Steady / Unfazed / Cold-Blooded |

## Tests

79/81 (same 2 pre-existing failures). Re-import shows no parse errors.