### PR TITLE
Arcane Resonance upgrades: switch to percent + arcane theme

### DIFF
--- a/resources/Abilities/Staff/Upgrades/U_AF_Annihilating.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AF_Annihilating.tres
@@ -5,9 +5,9 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "af_t3_annihilating"
-upgrade_name = "Annihilating"
-description = "Increases Stoneskin's Defense bonus by an additional +4."
+upgrade_name = "Overcharged"
+description = "Increases Arcane Resonance's Magic Attack bonus by an additional +4%."
 point_cost = 2
 tier = 3
-effect_key = "passive_stat_flat_bonus"
+effect_key = "passive_stat_percent_bonus"
 magnitude = 4.0

--- a/resources/Abilities/Staff/Upgrades/U_AF_Cruel.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AF_Cruel.tres
@@ -5,8 +5,8 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "af_t2_cruel"
-upgrade_name = "Cruel"
-description = "Increases Stoneskin's Defense bonus by an additional +2."
+upgrade_name = "Resonant"
+description = "Increases Arcane Resonance's Magic Attack bonus by an additional +2%."
 tier = 2
-effect_key = "passive_stat_flat_bonus"
+effect_key = "passive_stat_percent_bonus"
 magnitude = 2.0

--- a/resources/Abilities/Staff/Upgrades/U_AF_Vicious.tres
+++ b/resources/Abilities/Staff/Upgrades/U_AF_Vicious.tres
@@ -5,7 +5,7 @@
 [resource]
 script = ExtResource("1_aud")
 upgrade_id = "af_t1_vicious"
-upgrade_name = "Vicious"
-description = "Increases Stoneskin's Defense bonus by +2."
-effect_key = "passive_stat_flat_bonus"
+upgrade_name = "Attuned"
+description = "Increases Arcane Resonance's Magic Attack bonus by +2%."
+effect_key = "passive_stat_percent_bonus"
 magnitude = 2.0


### PR DESCRIPTION
Last followup from the passives review.

The 3 Arcane Resonance upgrade .tres files had two compounding issues:

## 1. Wrong effect_key

Base stat uses `percent_bonus_formula` (adds +% MATK). Upgrades used `passive_stat_flat_bonus` which adds FLAT. So the upgrades were either silently no-op for the % bonus, or adding flat +2 / +2 / +4 MATK instead of the +2% / +2% / +4% the description implied. **Fixed to `passive_stat_percent_bonus`** — they now stack correctly on the base passive's percentage.

## 2. Stale Stoneskin descriptions

All three descriptions still said `Increases Stoneskin's Defense bonus by +X` — leftover from before PR 13 repointed the passive to +%MATK. Rewrote to `Increases Arcane Resonance's Magic Attack bonus by +X%`.

## 3. Stale names

Vicious / Cruel / Annihilating were carried from the original `Arcane Fury` identity and don't fit arcane-caster theme. Renamed:

| Tier | Old | New | Magnitude |
|---|---|---|---|
| 1 | Vicious | **Attuned** | +2% MATK |
| 2 | Cruel | **Resonant** | +2% MATK |
| 3 | Annihilating | **Overcharged** | +4% MATK |

upgrade_id / tier / point_cost / magnitude all unchanged so save data keeps resolving.

## Tests

79/81 (same 2 pre-existing failures).