### PR TITLE
Refactor: consolidate player-persistence local-file fallback into one helper

### DIFF
--- a/scripts/Managers/save_manager.gd
+++ b/scripts/Managers/save_manager.gd
@@ -36,7 +36,12 @@ const VALID_CATEGORIES: PackedStringArray = [
 	"stats", "inventory", "abilities", "buffs", "pets", "quests"
 ]
 
-var _api_url: String = ""  # Will be loaded from UserConfig
+# Computed so a runtime change via UserConfig.set_backend_api_url(...) takes
+# effect immediately on the next request. Previously this was cached at _ready,
+# so switching the backend URL in-game left SaveManager pointed at the old one
+# (NetworkManager/PlayerManager already resolve theirs on demand).
+var _api_url: String:
+	get: return UserConfig.get_backend_api_url() + "/player"
 
 # ── Per-player tracking ───────────────────────────────────────────────────
 ## Registered players: username -> { node, dirty_categories, timer }
@@ -66,9 +71,6 @@ class SaveJob extends RefCounted:
 
 
 func _ready() -> void:
-	# Load API URL from config (supports environment variable override)
-	_api_url = UserConfig.get_backend_api_url() + "/player"
-
 	# SaveManager only does work on the server
 	if not _is_server():
 		return
@@ -405,38 +407,8 @@ func _release_slot(slot: int, job: SaveJob, success: bool, err: String) -> void:
 # ═══════════════════════════════════════════════════════════════════════════
 
 func _save_to_file(data: Dictionary) -> void:
-	var uname: String = data.get("username", "")
-	if uname.is_empty():
-		push_error("SaveManager: Cannot save to file — no username in data.")
-		return
-
-	var file_path: String = "res://saves/player_%s.json" % uname
-
-	# Create saves directory if it doesn't exist
-	var dir = DirAccess.open("res://")
-	if dir:
-		if not dir.dir_exists("saves"):
-			dir.make_dir("saves")
-
-	var existing_data: Dictionary = {}
-
-	if FileAccess.file_exists(file_path):
-		var file_read := FileAccess.open(file_path, FileAccess.READ)
-		if file_read:
-			var parsed = JSON.parse_string(file_read.get_as_text())
-			file_read.close()
-			if parsed is Dictionary:
-				existing_data = parsed
-
-	# Merge new data into existing (overwrite matching keys)
-	existing_data.merge(data, true)
-
-	var file_write := FileAccess.open(file_path, FileAccess.WRITE)
-	if file_write:
-		file_write.store_string(JSON.stringify(existing_data))
-		file_write.close()
-	else:
-		push_error("SaveManager: Failed to open file for writing: %s" % file_path)
+	# Shared read-merge-write fallback (canonical res://saves path).
+	PlayerPersistence.write_save_file_merged(data)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/Networking/CLAUDE.md
+++ b/scripts/Networking/CLAUDE.md
@@ -12,7 +12,8 @@ these scripts are autoloads (see the root `CLAUDE.md` autoload table).
 | `player_manager.gd` | Spawns/despawns player & bot characters; `get_player_node(id)` lookup |
 | `channel_manager.gd` | Switches server channels (ports) without a full restart |
 | `network_utils.gd` | IP/port validation and scene-path helpers |
-| `network_manager.gd` | HTTP bridge to the Flask backend (login, character CRUD, save/load) |
+| `network_manager.gd` | HTTP bridge to the Flask backend (login, character CRUD, character load) |
+| `player_persistence.gd` | `PlayerPersistence` — shared local-file fallback (canonical `res://saves` path + read-merge-write) used by the three HTTP autoloads |
 | `PartyData.gd` | Plain data class for a party (members, leader, invites) |
 
 ## Server-authoritative model
@@ -58,5 +59,12 @@ to disconnect signals before `queue_free()`.
 
 ## Backend bridge
 
-`network_manager.gd` is the only script that talks HTTP to Flask, via `HTTPRequest`
-against `http://localhost:5000`. Endpoints and payloads: [backend/CLAUDE.md](../../backend/CLAUDE.md).
+Three autoloads talk HTTP to Flask via `HTTPRequest` (against `http://localhost:5000`):
+`network_manager.gd` (account / character CRUD, login), `player_manager.gd`
+(character *load* on spawn), and `save_manager.gd` (debounced *saves*). They each
+own their own `HTTPRequest` lifecycle and retry, but share one local-file fallback:
+`player_persistence.gd` (`PlayerPersistence`) owns the canonical `res://saves`
+path and the read-merge-write helpers, so the offline fallback behaves identically
+across all three. The backend URL is resolved on demand from `UserConfig` in every
+HTTP caller, so a runtime `set_backend_api_url()` takes effect without a restart.
+Endpoints and payloads: [backend/CLAUDE.md](../../backend/CLAUDE.md).

--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -126,27 +126,7 @@ func get_characters():
 				var dev_char_name = "Dev" + class_name_str
 				var dev_file_path = saves_path.path_join("player_%s.json" % dev_char_name)
 				if not FileAccess.file_exists(dev_file_path):
-					var is_advanced = class_enum >= Constants.ClassType.CRUSADER
-					var starting_level = 30 if is_advanced else 1
-					var save_data = {
-							"username": dev_char_name,
-							"level": starting_level,
-							"experience": 0,
-							"character_class": class_enum,
-							"current_health": 100,
-							"max_health": 100,
-							"current_mana": 100,
-							"max_mana": 100,
-							"monies": 0,
-							"inventory": {},
-							"equipment": {},
-							# PR 4: per-discipline ability-point pools. New chars get the
-						# full level-1->starting-level allotment in their starting
-						# discipline's pool; the other three start at zero.
-						"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_enum, starting_level)},
-							"buffs": {},
-							"quests": {}
-						}
+					var save_data = _default_new_character_save(dev_char_name, class_enum)
 					var file = FileAccess.open(dev_file_path, FileAccess.WRITE)
 					if file:
 						file.store_string(JSON.stringify(save_data, "\t"))
@@ -232,26 +212,7 @@ func create_character(char_name, class_id):
 			#print("Create character: FileAccess.open failed, error: ", FileAccess.get_open_error())
 			character_creation_failed.emit("Failed to create save file")
 			return
-		var is_advanced = class_id >= Constants.ClassType.CRUSADER
-		var starting_level = 30 if is_advanced else 1
-		var save_data = {
-			"username": char_name,
-			"level": starting_level,
-			"experience": 0,
-			"character_class": class_id,
-			"current_health": 100,
-			"max_health": 100,
-			"current_mana": 100,
-			"max_mana": 100,
-			"monies": 0,
-			"inventory": {},
-			"equipment": {},
-			# PR 4: per-discipline ability-point pools. See dev-mode site for
-			# the helper that fills the starting discipline and zeros the rest.
-			"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_id, starting_level)},
-			"buffs": {},
-			"quests": {}
-		}
+		var save_data = _default_new_character_save(char_name, class_id)
 		file.store_string(JSON.stringify(save_data, "\t"))
 		file.close()
 		character_created.emit(char_name)
@@ -354,6 +315,35 @@ func _on_delete_character_completed(result, response_code, _headers, body, http,
 	http.queue_free()
 
 
+## Builds the default save blob for a brand-new character. Used by both the
+## local create-character path and the dev-mode per-class seeding in
+## get_characters() — previously two byte-for-byte copies that drifted apart.
+## Advanced (tier-2) classes start at level 30; everyone else at level 1.
+func _default_new_character_save(char_name: String, class_id: int) -> Dictionary:
+	var is_advanced := class_id >= Constants.ClassType.CRUSADER
+	var starting_level := 30 if is_advanced else 1
+	return {
+		"username": char_name,
+		"level": starting_level,
+		"experience": 0,
+		"character_class": class_id,
+		"current_health": 100,
+		"max_health": 100,
+		"current_mana": 100,
+		"max_mana": 100,
+		"monies": 0,
+		"inventory": {},
+		"equipment": {},
+		# PR 4: per-discipline ability-point pools. All four tier-1 pools start
+		# at zero — the starting point comes from
+		# AbilityComponent.bootstrap_fresh_character_if_needed bumping the chosen
+		# discipline to mastery 1 (which grants 1 point via mastery_level_changed).
+		"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_id, starting_level)},
+		"buffs": {},
+		"quests": {}
+	}
+
+
 ## PR 8 (2026-05-31): seeds an empty per-discipline ability-point pool dict
 ## for a newly-created character. All four tier-1 pools start at zero — the
 ## starting point comes from AbilityComponent.bootstrap_fresh_character_if_needed
@@ -369,20 +359,3 @@ func _starter_ability_point_pools(_class_id: int, _starting_level: int) -> Dicti
 		"staff": 0,
 		"dagger": 0,
 	}
-
-
-## PR 4: maps a `Constants.ClassType` int (tier-1 starting OR tier-2
-## advancement) to the lowercase discipline key. Mirrors the helper in
-## `AbilityComponent` (kept duplicated here so this autoload doesn't have
-## to reach into a sibling node before the player exists).
-func _class_id_to_discipline_key(class_id: int) -> String:
-	match class_id:
-		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
-			return "sword"
-		Constants.ClassType.BOW, Constants.ClassType.RANGER:
-			return "bow"
-		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
-			return "staff"
-		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
-			return "dagger"
-	return ""

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -459,20 +459,15 @@ func _initialize_spawned_player(id: int, character_type: int, username: String, 
 
 
 func _load_player_data_from_file(username: String) -> Dictionary:
-	var file_path = "res://saves/player_%s.json" % username
-	if FileAccess.file_exists(file_path):
-		var file = FileAccess.open(file_path, FileAccess.READ)
-		var data = JSON.parse_string(file.get_as_text())
-		file.close()
-		if data:
-			data["party_id"] = data.get("party_id", -1)
-			data["last_map"] = data.get("last_map", "")
-			# weapon_mastery (PR 2) — legacy saves without the key load with
-			# an empty dict so the component picks up four zero-state
-			# disciplines on _ensure_default_disciplines.
-			data["weapon_mastery"] = data.get("weapon_mastery", {})
-			return data
-	return {}
+	var data := PlayerPersistence.read_save_file(username)
+	if not data.is_empty():
+		data["party_id"] = data.get("party_id", -1)
+		data["last_map"] = data.get("last_map", "")
+		# weapon_mastery (PR 2) — legacy saves without the key load with
+		# an empty dict so the component picks up four zero-state
+		# disciplines on _ensure_default_disciplines.
+		data["weapon_mastery"] = data.get("weapon_mastery", {})
+	return data
 
 
 func _load_player_data_async(username: String) -> Dictionary:
@@ -549,92 +544,12 @@ func _load_player_data_async(username: String) -> Dictionary:
 
 
 func _save_player_data_to_file(data: Dictionary):
-	"""Save player data to file (Fallback) - Merges partial updates"""
-	var username = data.get("username", "")
-	if username.is_empty():
-		return
-	
-	var file_path = "player_%s.json" % username
-	var existing_data = {}
-	
-	# Read existing data first to merge
-	if FileAccess.file_exists(file_path):
-		var file_read = FileAccess.open(file_path, FileAccess.READ)
-		if file_read:
-			existing_data = JSON.parse_string(file_read.get_as_text())
-			file_read.close()
-			if existing_data == null: existing_data = {}
-	
-	# Merge new data into existing data
-	existing_data.merge(data, true) # true = overwrite existing keys
-	
-	var file = FileAccess.open(file_path, FileAccess.WRITE)
-	if file:
-		file.store_string(JSON.stringify(existing_data))
-		file.close()
-		#print("PlayerManager: Saved to local file for ", username)
-
-
-func _save_player_data_async(data: Dictionary) -> void:
-	var username = data.get("username", "")
-	if username.is_empty():
-		return
-
-	if NetworkManager.use_local_save:
-		#print("PlayerManager: Local Save enabled. Saving to file for ", username)
-		_save_player_data_to_file(data)
-		return
-
-	#print("PlayerManager: Attempting to save data for %s to API..." % username)
-
-	var request = HTTPRequest.new()
-	add_child(request)
-	request.timeout = 5.0
-
-	var payload = {
-		"username": username,
-		"data": data
-	}
-
-	var json = JSON.stringify(payload)
-	var headers = ["Content-Type: application/json"]
-	var error = request.request(_api_url + "/save", headers, HTTPClient.METHOD_POST, json)
-
-	if error != OK:
-		#print("PlayerManager: HTTP save request failed to start for %s. Error: %d" % [username, error])
-		request.queue_free()
-		#print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable)" % username)
-		_save_player_data_to_file(data)
-		return
-
-	var result = await request.request_completed
-	var response_code = result[1]
-
-	if response_code == 200:
-		#print("PlayerManager: Saved %s via API" % username)
-		request.queue_free()
-		return
-
-	# First attempt failed — retry once after 1 second
-	#print("PlayerManager: API save failed for %s (code: %d), retrying..." % [username, response_code])
-	await get_tree().create_timer(1.0).timeout
-
-	error = request.request(_api_url + "/save", headers, HTTPClient.METHOD_POST, json)
-	if error != OK:
-		request.queue_free()
-		#print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable)" % username)
-		_save_player_data_to_file(data)
-		return
-
-	result = await request.request_completed
-	response_code = result[1]
-	request.queue_free()
-
-	if response_code == 200:
-		print("PlayerManager: Retry succeeded for %s" % username)
-	else:
-		print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable after retry, code: %d)" % [username, response_code])
-		_save_player_data_to_file(data)
+	"""Save player data to file (fallback) — read-merge-write to the canonical
+	res://saves path. Delegates to the shared PlayerPersistence helper so the
+	path and merge semantics match NetworkManager / SaveManager exactly. (This
+	previously wrote a bare `player_%s.json` to the process CWD — a stray,
+	wrong-directory save that never lined up with the real saves folder.)"""
+	PlayerPersistence.write_save_file_merged(data)
 
 
 func _get_quick_save_data(player_id: int) -> Dictionary:

--- a/scripts/Networking/player_persistence.gd
+++ b/scripts/Networking/player_persistence.gd
@@ -1,0 +1,70 @@
+class_name PlayerPersistence
+extends RefCounted
+## Shared local-file persistence for player save data.
+##
+## Three autoloads (NetworkManager, PlayerManager, SaveManager) used to each
+## carry their own copy of the local read-merge-write fallback, with the save
+## directory / filename pattern hard-coded three different ways — including one
+## bare `"player_%s.json"` that wrote to the process CWD instead of the saves
+## folder. This consolidates the path convention and the read/merge/write logic
+## into one place so the fallback behaves identically everywhere.
+##
+## Network HTTP itself stays in the individual autoloads (each owns its own
+## HTTPRequest lifecycle and retry semantics); only the file fallback and the
+## canonical path live here.
+
+## Canonical saves directory (res:// so it works the same in editor and export).
+const SAVE_DIR: String = "res://saves"
+
+
+## The one true on-disk path for a character's save file.
+static func save_path(username: String) -> String:
+	return SAVE_DIR.path_join("player_%s.json" % username)
+
+
+## Reads a character's save file. Returns the parsed Dictionary, or {} if the
+## file is missing / unreadable / not a Dictionary. Callers layer their own
+## default-field fill-ins on top of the returned dict.
+static func read_save_file(username: String) -> Dictionary:
+	if username.is_empty():
+		return {}
+	var file_path := save_path(username)
+	if not FileAccess.file_exists(file_path):
+		return {}
+	var file := FileAccess.open(file_path, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	if parsed is Dictionary:
+		return parsed
+	return {}
+
+
+## Read-merge-write fallback used when the backend is unavailable. Merges the
+## supplied (possibly partial) data over whatever is already on disk so a
+## category-scoped save doesn't clobber untouched fields. `data` must carry a
+## non-empty "username". Ensures the saves directory exists first.
+static func write_save_file_merged(data: Dictionary) -> void:
+	var username: String = data.get("username", "")
+	if username.is_empty():
+		push_error("PlayerPersistence: Cannot save to file — no username in data.")
+		return
+
+	# Ensure the saves directory exists.
+	var dir := DirAccess.open("res://")
+	if dir and not dir.dir_exists("saves"):
+		dir.make_dir("saves")
+
+	var file_path := save_path(username)
+	var existing_data: Dictionary = read_save_file(username)
+
+	# Merge new data into existing (overwrite matching keys).
+	existing_data.merge(data, true)
+
+	var file_write := FileAccess.open(file_path, FileAccess.WRITE)
+	if file_write:
+		file_write.store_string(JSON.stringify(existing_data))
+		file_write.close()
+	else:
+		push_error("PlayerPersistence: Failed to open file for writing: %s" % file_path)

--- a/scripts/Networking/player_persistence.gd.uid
+++ b/scripts/Networking/player_persistence.gd.uid
@@ -1,0 +1,1 @@
+uid://dic0oa6tamf7o


### PR DESCRIPTION
## Problem
The player-persistence local-file fallback (`read existing -> merge -> write`) and the canonical saves path were implemented **three times** across the HTTP autoloads, with the path/filename hard-coded three different ways — including one bare `"player_%s.json"` in `player_manager.gd` that wrote to the process CWD instead of `res://saves`. `player_manager.gd` also carried a dead `_save_player_data_async` (superseded by `SaveManager`, no callers) and `network_manager.gd` had two byte-for-byte-identical new-character save blobs plus a dead `_class_id_to_discipline_key`. `SaveManager` cached its backend URL at `_ready()`, so a runtime `UserConfig.set_backend_api_url()` left it stale (NetworkManager/PlayerManager already resolved theirs on demand). The networking `CLAUDE.md` falsely claimed `network_manager.gd` is the only script that talks HTTP.

## Change
- **New `scripts/Networking/player_persistence.gd` (`PlayerPersistence`)** — owns the canonical `res://saves` path (`save_path`) and the shared `read_save_file` / `write_save_file_merged` helpers.
- **`player_manager.gd`** — `_load_player_data_from_file` and `_save_player_data_to_file` delegate to `PlayerPersistence` (fixes the bare-path wrong-directory bug); removed dead `_save_player_data_async`.
- **`save_manager.gd`** — `_save_to_file` delegates to `PlayerPersistence`; `_api_url` is now a computed property so it can't go stale.
- **`network_manager.gd`** — de-duped the two new-character save blobs into `_default_new_character_save`; removed dead `_class_id_to_discipline_key`.
- **`scripts/Networking/CLAUDE.md`** — corrected the HTTP-ownership claim and added the new helper to the files table.

Behavior-preserving: save formats, payload shapes, endpoint URLs, retry counts/timing, and the `use_local_save` fallback are unchanged. The only intentional behavior change is the sanctioned bare-path bug fix (now writes to `res://saves`).

## Verification
Headless harness (`test/run_tests.gd`): **84 / 84 passed, HARNESS_EXIT=0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)