### PR TITLE
Cleanup: remove dead autoloads, unused helpers, and orphaned getters

### DIFF
--- a/scripts/Managers/game_manager.gd
+++ b/scripts/Managers/game_manager.gd
@@ -1,7 +1,0 @@
-extends Node
-
-var score = 0
-
-func add_point():
-	score += 1
-	print(score)

--- a/scripts/Managers/game_manager.gd.uid
+++ b/scripts/Managers/game_manager.gd.uid
@@ -1,1 +1,0 @@
-uid://b7t1yw1uohpqm

--- a/scripts/Managers/map_manager.gd
+++ b/scripts/Managers/map_manager.gd
@@ -1073,13 +1073,3 @@ func get_player_map_node(player_id: int) -> Node:
 	if map_id and active_maps.has(map_id):
 		return active_maps[map_id].scene_instance
 	return null
-
-func _find_all_nodes_of_type(root: Node, type_name: String) -> Array:
-	var nodes = []
-	if root.is_class(type_name):
-		nodes.append(root)
-	
-	for child in root.get_children():
-		nodes.append_array(_find_all_nodes_of_type(child, type_name))
-		
-	return nodes

--- a/scripts/Managers/multiplayer_manager.gd
+++ b/scripts/Managers/multiplayer_manager.gd
@@ -236,25 +236,6 @@ func _ping_response():
 			_ping_display.add_theme_color_override("font_color", Color.RED)
 
 # === UTILITY METHODS ===
-# These methods are deprecated - kept for backward compatibility with main_menu
-func _setup_menu_container():
-	# Try to get menu_container if it exists (for backward compatibility)
-	var scene = get_tree().get_current_scene()
-	if scene.has_node("%MenuContainer"):
-		menu_container = scene.get_node("%MenuContainer")
-		if menu_container and menu_container.has_method("get_node") and menu_container.has_node("connection_status_label"):
-			menu_container.connection_status_label.text = ""
-
-func _update_ui_for_host():
-	if not menu_container or not is_instance_valid(menu_container):
-		#print("MultiplayerManager: No menu container, skipping UI update")
-		return
-	menu_container.hide()
-	if menu_container.has_method("setup_PID_label"):
-		menu_container.setup_PID_label(true, multiplayer.get_unique_id())
-	if menu_container.has_node("connection_panel"):
-		menu_container.connection_panel.show()
-
 func _update_ui_for_client():
 	if not menu_container or not is_instance_valid(menu_container):
 		#print("MultiplayerManager: No menu container, skipping UI update")

--- a/scripts/Networking/channel_manager.gd
+++ b/scripts/Networking/channel_manager.gd
@@ -21,13 +21,6 @@ func switch_channel(new_port: int):
 func is_switching() -> bool:
 	return _is_switching
 
-func get_switch_progress() -> Dictionary:
-	return {
-		"switching": _is_switching,
-		"start_time": _switch_start_time,
-		"elapsed": Time.get_time_dict_from_system().hour * 3600 + Time.get_time_dict_from_system().minute * 60 + Time.get_time_dict_from_system().second - _switch_start_time if _is_switching else 0.0
-	}
-
 func _can_switch_channels(new_port: int) -> bool:
 	"""Check if channel switching is possible"""
 	if multiplayer.is_server():
@@ -191,31 +184,3 @@ func _handle_switch_failure():
 	
 	# Return to login screen
 	get_tree().change_scene_to_file("res://scenes/UI/LoginScreen.tscn")
-
-# === UTILITY FUNCTIONS ===
-func get_available_channels() -> Array:
-	"""Get list of potentially available channels (for UI)"""
-	var base_port = ClientManager.current_server_port
-	if base_port == 0:
-		base_port = 8080
-	
-	var channels = []
-	for i in range(-2, 3): # Show 5 channels around current
-		var port = base_port + i
-		if port > 0 and port <= 65535 and port != ClientManager.current_server_port:
-			channels.append({
-				"port": port,
-				"name": "Channel %d" % port,
-				"current": false
-			})
-	
-	return channels
-
-func quick_test_channel(port: int) -> bool:
-	"""Quick test if a channel is reachable (non-blocking, for UI)"""
-	if port == ClientManager.current_server_port:
-		return true
-	
-	# This would need to be implemented as a very quick, non-blocking test
-	# For now, return true to indicate "potentially available"
-	return NetworkUtils.is_valid_port(port)

--- a/scripts/Networking/client_manager.gd
+++ b/scripts/Networking/client_manager.gd
@@ -39,31 +39,6 @@ func cleanup():
 	_disconnect()
 	multiplayer.multiplayer_peer = null
 
-func get_connection_info() -> Dictionary:
-	return {
-		"ip": current_server_ip,
-		"port": current_server_port,
-		"connected": _is_connected(),
-		"connection_time": _connection_attempt_time
-	}
-
-func _is_connected() -> bool:
-	return _client_peer != null and _client_peer.get_connection_status() == MultiplayerPeer.CONNECTION_CONNECTED
-
-func get_connection_status() -> String:
-	if not _client_peer:
-		return "Not Connected"
-	
-	match _client_peer.get_connection_status():
-		MultiplayerPeer.CONNECTION_DISCONNECTED:
-			return "Disconnected"
-		MultiplayerPeer.CONNECTION_CONNECTING:
-			return "Connecting"
-		MultiplayerPeer.CONNECTION_CONNECTED:
-			return "Connected"
-		_:
-			return "Unknown"
-
 # Called by multiplayer manager when connection signals are received
 func _on_connection_succeeded():
 	#print("Client connection succeeded to %s:%d" % [current_server_ip, current_server_port])

--- a/scripts/Networking/network_utils.gd
+++ b/scripts/Networking/network_utils.gd
@@ -65,50 +65,6 @@ func get_players_spawn_node(scene_tree: SceneTree) -> Node:
 		return scene.find_child("Players", true, false)
 	return null
 
-func get_node_safe(node: Node, path: String) -> Node:
-	if not node:
-		return null
-	return node.get_node_or_null(path)
-
-# === CLEANUP UTILITIES ===
-func clear_networked_entities(scene_tree: SceneTree) -> void:
-	var scene_root = scene_tree.get_current_scene()
-	if not scene_root:
-		return
-	
-	for entity in scene_root.get_tree().get_nodes_in_group("networked_entities"):
-		if is_instance_valid(entity):
-			entity.queue_free()
-
-func safe_disconnect_signal(signal_obj: Signal, callable_obj: Callable):
-	if signal_obj.is_connected(callable_obj):
-		signal_obj.disconnect(callable_obj)
-
-# === CONNECTION TESTING ===
-func test_tcp_connection(ip: String, port: int, timeout: float = 2.0) -> bool:
-	var tcp = StreamPeerTCP.new()
-	var error = tcp.connect_to_host(ip, port)
-	
-	if error != OK:
-		return false
-	
-	var time_waited = 0.0
-	while time_waited < timeout:
-		tcp.poll()
-		var status = tcp.get_status()
-		
-		if status == StreamPeerTCP.STATUS_CONNECTED:
-			tcp.disconnect_from_host()
-			return true
-		elif status == StreamPeerTCP.STATUS_ERROR:
-			return false
-		
-		await Engine.get_main_loop().process_frame
-		time_waited += get_process_delta_time()
-	
-	tcp.disconnect_from_host()
-	return false
-
 # === LOGGING UTILITIES ===
 func log_network_event(event_type: String, details: String = ""):
 	var timestamp = Time.get_datetime_string_from_system()
@@ -129,18 +85,3 @@ func is_valid_port(port: int) -> bool:
 
 func is_port_in_range(port: int, min_port: int, max_port: int) -> bool:
 	return port >= min_port and port <= max_port
-
-# === MULTIPLAYER UTILITIES ===
-func get_multiplayer_info() -> Dictionary:
-	return {
-		"is_server": multiplayer.is_server(),
-		"unique_id": multiplayer.get_unique_id(),
-		"has_peer": multiplayer.multiplayer_peer != null,
-		"connected": multiplayer.multiplayer_peer != null and multiplayer.multiplayer_peer.get_connection_status() == MultiplayerPeer.CONNECTION_CONNECTED
-	}
-
-func format_player_id(id: int) -> String:
-	if id == 1:
-		return "Host"
-	else:
-		return "Player_%d" % id

--- a/scripts/Networking/server_manager.gd
+++ b/scripts/Networking/server_manager.gd
@@ -62,22 +62,8 @@ func stop_server():
 	_current_port = 0
 	_is_dedicated = false
 
-func get_current_port() -> int:
-	return _current_port
-
 func is_server_running() -> bool:
 	return _server_peer != null and _current_port > 0
-
-func is_dedicated_server() -> bool:
-	return _is_dedicated
-
-func get_server_info() -> Dictionary:
-	return {
-		"running": is_server_running(),
-		"dedicated": _is_dedicated,
-		"port": _current_port,
-		"ip": NetworkUtils.get_public_ip_address() if is_server_running() else ""
-	}
 
 func _finalize_server_setup(port: int):
 	_current_port = port


### PR DESCRIPTION
## Problem

The networking/utility layer carried dead code: a placeholder autoload script, never-called "graveyard" helpers, deprecated UI methods, and getter/stub functions with zero callers. This is pure dead-code removal — every item was re-verified as genuinely unreferenced across all `.gd`, `.tscn`, and `project.godot` before removal. No behavior change to any live path.

## Removed

- **`scripts/Managers/game_manager.gd` (+ `.uid`)** — trivial placeholder (`score` / `add_point`), not registered as an autoload, zero references anywhere.
- **`map_manager.gd`** — `_find_all_nodes_of_type` (recursive walker, only self-recursive, no external callers).
- **`network_utils.gd`** — `get_node_safe`, `clear_networked_entities`, `safe_disconnect_signal`, `test_tcp_connection`, `get_multiplayer_info`, `format_player_id` (all definition-only, no call sites).
- **`multiplayer_manager.gd`** — deprecated UI methods `_setup_menu_container` and `_update_ui_for_host` (no callers). `_update_ui_for_client` kept — it is still called.
- **`channel_manager.gd`** — no-caller stubs `get_switch_progress`, `quick_test_channel`, and `get_available_channels`.
- **`server_manager.gd`** — no-caller getters `get_server_info`, `get_current_port`, `is_dedicated_server`.
- **`client_manager.gd`** — no-caller getters `get_connection_info`, `get_connection_status`, plus the now-orphaned private `_is_connected`.

### Kept (referenced or deliberately conservative)

- `music_manager.gd` — still referenced by `scenes/Gameplay/music.tscn` (itself orphaned, but the scene is out of this PR's scope).
- The inline `networked_entities` clear loop in `multiplayer_manager.gd` — its unguarded `queue_free()` differs from `NetworkUtils.clear_networked_entities`' `is_instance_valid` guard, so it was NOT rerouted (would change cleanup behavior).
- `server_manager.is_server_running()` and `network_utils.is_port_in_range()` — clean public predicates; left in place.

## Verification

- Godot headless `--editor` import: clean (no new errors referencing the edited files).
- Test harness (`res://test/run_tests.gd`): **HARNESS_EXIT=0**, 84 / 84 passed. (Pre-existing baseline noise — `uid://d1qhydj4bri7d` preload, EquipmentData/Slot class-resolution, ChatWindow.gd — is unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
