### PR TITLE
Refactor: shared resolve_intent() + player/bot name directory on PlayerManager

### DIFF
--- a/scripts/Managers/party_manager.gd
+++ b/scripts/Managers/party_manager.gd
@@ -228,12 +228,7 @@ func rpc_send_invite(invitee_name: String):
 	if sender_id == 0:
 		sender_id = multiplayer.get_unique_id()
 	
-	var invitee_id = PlayerManager.get_player_id_from_name(invitee_name)
-	if invitee_id == -1:
-		for bot_id in BotManager.active_bots:
-			if BotManager.active_bots[bot_id].username.to_lower() == invitee_name.to_lower():
-				invitee_id = bot_id
-				break
+	var invitee_id = PlayerManager.resolve_by_name(invitee_name)
 	if invitee_id == -1:
 		#print("Server: Player not found by name: ", invitee_name)
 		return
@@ -433,37 +428,6 @@ func _client_clear_my_party_status():
 func _on_player_disconnected(player_id: int):
 	if _player_party_map.has(player_id):
 		leave_party(player_id)
-
-# Placeholder for Quest System integration
-func add_quest_to_party(party_id: int, quest_id: String):
-	if not multiplayer.is_server():
-		return
-
-	if not _parties.has(party_id):
-		#print("Party %d does not exist." % party_id)
-		return
-
-	var party: PartyData = _parties[party_id]
-	if not party.has("active_quests"): # PartyData does not directly have active_quests. Need to add this to PartyData or handle differently.
-		party["active_quests"] = [] # This line will cause an error on PartyData
-	if not quest_id in party["active_quests"]:
-		party["active_quests"].append(quest_id)
-		_send_party_data_to_members(party_id)
-		#print("Quest %s added to party %d." % [quest_id, party_id])
-
-func remove_quest_from_party(party_id: int, quest_id: String):
-	if not multiplayer.is_server():
-		return
-
-	if not _parties.has(party_id):
-		#print("Party %d does not exist." % party_id)
-		return
-
-	var party: PartyData = _parties[party_id]
-	if party.has("active_quests") and quest_id in party["active_quests"]:
-		party["active_quests"].erase(quest_id)
-		_send_party_data_to_members(party_id)
-		#print("Quest %s removed from party %d." % [quest_id, party_id])
 
 func notify_player_data_changed(player_id: int):
 	if not multiplayer.is_server():

--- a/scripts/Managers/pet_manager.gd
+++ b/scripts/Managers/pet_manager.gd
@@ -281,13 +281,10 @@ func hatch_pet_server(username: String, pet_data_id: String, default_name: Strin
 func request_summon_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	if find_pet(username, pet_uuid).is_empty():
@@ -309,13 +306,10 @@ func request_summon_pet_server(pet_uuid: String) -> void:
 func request_unsummon_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	if find_pet(username, pet_uuid).is_empty():
@@ -331,13 +325,11 @@ func request_unsummon_pet_server(pet_uuid: String) -> void:
 func request_release_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var player = resolved.node
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -391,13 +383,10 @@ func _return_one_pet_slot(slot_data: Dictionary, inv) -> void:
 func request_rename_pet_server(pet_uuid: String, new_name: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -667,13 +656,11 @@ func _pet_event_visual_rpc(pet_uuid: String, event_type: String) -> void:
 func request_feed_pet_server(pet_uuid: String, inventory_slot_index: int) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var player = resolved.node
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -1016,14 +1003,11 @@ func request_autopot_server(pet_uuid: String, slot_type: String) -> void:
 func request_set_autopot_threshold_server(pet_uuid: String, slot_type: String, threshold: float) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Configuring thresholds doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var owner_username: String = player.username
+	var owner_username: String = resolved.username
 	var record := find_pet(owner_username, pet_uuid)
 	if record.is_empty():
 		return
@@ -1050,12 +1034,14 @@ func request_transfer_to_pet_slot_server(pet_uuid: String, slot_key: String, sou
 	if not multiplayer.is_server():
 		print("[PetMgr.transfer_to] not server — early return")
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
+		print("[PetMgr.transfer_to] REJECT: player or inventory_component invalid")
+		return
+	var caller: int = resolved.peer_id
+	var player = resolved.node
 	print("[PetMgr.transfer_to] caller=%d" % caller)
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player) or not is_instance_valid(player.inventory_component):
+	if not is_instance_valid(player.inventory_component):
 		print("[PetMgr.transfer_to] REJECT: player or inventory_component invalid")
 		return
 	var owner_username: String = player.username
@@ -1123,12 +1109,12 @@ func request_transfer_to_pet_slot_server(pet_uuid: String, slot_key: String, sou
 func request_transfer_from_pet_slot_server(pet_uuid: String, slot_key: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Unequipping a pet item doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player) or not is_instance_valid(player.inventory_component):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
+		return
+	var player = resolved.node
+	if not is_instance_valid(player.inventory_component):
 		return
 	var owner_username: String = player.username
 	var record := find_pet(owner_username, pet_uuid)
@@ -1266,13 +1252,11 @@ func _tick_autobuff() -> void:
 func request_set_active_buff_ability_server(pet_uuid: String, ability_id: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Setting the active buff ability doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
+	var player = resolved.node
 	var owner_username: String = player.username
 	var record := find_pet(owner_username, pet_uuid)
 	if record.is_empty():

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -358,8 +358,8 @@ func record_level_up(username: String, new_level: int) -> void:
 func start_onboarding(username: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var pid: int = PlayerManager.get_player_id_from_name(username)
-	if pid == -1 or BotManager.is_bot(pid):
+	var pid: int = PlayerManager.resolve_player_only(username)
+	if pid == -1:
 		return
 	var player_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(pid)
 	if not is_instance_valid(player_node):

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -641,6 +641,57 @@ func get_player_id_from_name(username: String) -> int:
 	return -1
 
 
+## Resolves the calling peer of a client-intent RPC to its player node + name.
+## MUST be called from inside the RPC handler body — it reads
+## `multiplayer.get_remote_sender_id()`, which only returns the real sender
+## while the RPC stack is live (same constraint as TradeManager._sender()).
+##
+## Folds the copy-pasted server-intent prelude into one place: the sender-id
+## read, the host `0 → 1` normalization (a host call has sender id 0 and is
+## the server, peer 1), the player-node lookup, the validity guard, and the
+## username read. Returns an empty Dictionary `{}` when the caller has no
+## valid player node, so callers guard with `if resolved.is_empty(): return`.
+## On success returns `{ "peer_id": int, "node": MultiplayerPlayerV2,
+## "username": String }`.
+func resolve_intent() -> Dictionary:
+	var caller := multiplayer.get_remote_sender_id()
+	if caller == 0:
+		caller = 1
+	var node := get_player_node(caller)
+	if not is_instance_valid(node):
+		return {}
+	return {
+		"peer_id": caller,
+		"node": node,
+		"username": node.username,
+	}
+
+
+## Resolves a name (case-insensitive for bots, exact for players) to a peer id,
+## consulting BotManager for bots. Returns -1 if no player OR bot matches.
+## Used by party/trade name-based intents that accept either a player or a bot.
+func resolve_by_name(name: String) -> int:
+	var pid := get_player_id_from_name(name)
+	if pid != -1:
+		return pid
+	# Delegate the bot name/id lookup to BotManager rather than re-scanning
+	# active_bots here. _find_bot_by_name_or_id returns 0 when not found.
+	var bot_id := BotManager._find_bot_by_name_or_id(name)
+	if bot_id != 0:
+		return bot_id
+	return -1
+
+
+## Player-ONLY name resolution (excludes bots). Returns the peer id, or -1.
+## QuestManager uses this — quests are never granted to bots. `active_players`
+## holds bots too (negative ids), so filter them out explicitly.
+func resolve_player_only(name: String) -> int:
+	var pid := get_player_id_from_name(name)
+	if pid != -1 and BotManager.is_bot(pid):
+		return -1
+	return pid
+
+
 ## Stores a player's live state, captured at map-change time, so the imminent
 ## respawn can restore it without a save-backend round-trip. Called by
 ## MapManager.request_map_change just before the old character node is freed.

--- a/scripts/Trading/trade_manager.gd
+++ b/scripts/Trading/trade_manager.gd
@@ -706,12 +706,7 @@ func _sender() -> int:
 func rpc_request_trade(target_name: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var target_id := PlayerManager.get_player_id_from_name(target_name)
-	if target_id == -1:
-		for bot_id in BotManager.active_bots:
-			if BotManager.active_bots[bot_id].username.to_lower() == target_name.to_lower():
-				target_id = bot_id
-				break
+	var target_id := PlayerManager.resolve_by_name(target_name)
 	if target_id == -1:
 		_notify_player(_sender(), "No player named '%s' found." % target_name, Color.ORANGE)
 		return


### PR DESCRIPTION
> Stacks on #180 — review/merge that first. This PR's base is `arch-mgr/01-persistence`; the diff below is only PR2's changes.

## Problem
Two related duplications across the gameplay managers (arch review candidates B + D):

- **B — `any_peer` RPC caller-resolution prelude.** The "resolve sender → host 0→1 → get_player_node → validity guard → read username" block was copy-pasted across pet/party/quest/trade managers (≈9× in `pet_manager.gd` alone for the full username form). `trade_manager._sender()` already extracted the caller-id half, but local to one file.
- **D — player/bot name lookup leaking into BotManager's data structure.** `party_manager.gd` and `trade_manager.gd` each fell back to their own case-insensitive linear scan of `BotManager.active_bots` when `get_player_id_from_name` returned -1 — re-implementing logic that already lives in `BotManager._find_bot_by_name_or_id`.

## Change
New methods on `PlayerManager`:
- `resolve_intent() -> Dictionary` — returns `{peer_id, node, username}` or `{}` when invalid. Folds in exactly the sender read, host `0→1` normalization, node lookup, validity guard, and username read. Must be called from the RPC handler body (reads the same live multiplayer state as `_sender()`).
- `resolve_by_name(name) -> int` — player OR bot peer id, delegating the bot lookup to `BotManager._find_bot_by_name_or_id` (no re-scan of `active_bots`). -1 if none.
- `resolve_player_only(name) -> int` — bot-excluding variant for QuestManager.

Call sites converted:
- `pet_manager.gd`: 9 username preludes → `resolve_intent()`.
- `party_manager.gd`: `rpc_send_invite` bot scan → `resolve_by_name()`; removed dead `add_quest_to_party`/`remove_quest_from_party`.
- `trade_manager.gd`: `rpc_request_trade` bot scan → `resolve_by_name()`.
- `quest_manager.gd`: `start_onboarding` name→id→is_bot→node block → `resolve_player_only()`.

Deliberately left un-shared (semantics differ — noted in commit):
- `pet_manager.request_autoloot_server` / `request_autopot_server` — use only the `0→1` caller form (no username prelude) and reject on `_active_pets`/ownership *before* the node lookup; `resolve_intent`'s up-front validity gate would reorder validation.
- `trade_manager._sender()` — id-only, no node gate; feeds cancel/disconnect paths that must work with an already-freed node.

`bot_manager.gd` was inspected but needed no change — `_find_bot_by_name_or_id` already had the right shape.

Behavior-preserving: no RPC annotation, validation-order, or server-authority guard changes.

## Verification
- Editor import pass: clean.
- Headless test harness (`test/run_tests.gd`): **84/84 passed, HARNESS_EXIT=0**. The `uid://d1qhydj4bri7d` preload / `trade_manager.gd:0` / `EquipmentData`/`Slot` parse errors are pre-existing baseline noise (verified by stashing all changes and re-running: identical errors, exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)