### PR TITLE
Refactor: one ChatManager.notify_peer seam + component verb methods

### DIFF
--- a/scripts/Components/player_inventory.gd
+++ b/scripts/Components/player_inventory.gd
@@ -85,6 +85,14 @@ func add_item(item_id: String):
 	inventory_component.add_item(item_id)
 
 
+## Grants `amount` coins to this player. Goes through the `monies_amount`
+## setter, so the clamp to [0, MAX_MONIES_AMOUNT], the label refresh, and the
+## save-notify side effect all run exactly as a direct `monies_amount += amount`
+## would. A public verb so callers don't reach through the field.
+func grant_coins(amount: int) -> void:
+	monies_amount += amount
+
+
 func add_item_instance(item_data: ItemData):
 	if multiplayer.is_server():
 		inventory_component.server_add_item_instance(item_data.to_dictionary())

--- a/scripts/Managers/ChatManager.gd
+++ b/scripts/Managers/ChatManager.gd
@@ -173,6 +173,51 @@ func add_system_message(text: String, color: Color = Color.WHITE) -> void:
 	message_received.emit(text, color)
 
 
+## Which client-side surface a server->peer notification lands on.
+enum NotifySurface { CHAT, LOG }
+
+
+## Canonical server->one-player notification seam. Routes a single message to a
+## specific peer's CHAT (system message) or LOG (scrolling log) surface,
+## reproducing the host-local-vs-rpc_id branch and the bot-peer skip in ONE
+## place. Other managers (QuestManager, TradeManager, PetManager) delegate here
+## so the routing rules live once.
+##
+## Must be called server-side. Bots have no client, so they are skipped.
+func notify_peer(peer_id: int, text: String, color: Color = Color.WHITE, surface: NotifySurface = NotifySurface.CHAT) -> void:
+	if peer_id == 0:
+		return
+	# Bots have no client/UI — nothing to deliver to.
+	if BotManager.is_bot(peer_id):
+		return
+	if peer_id == multiplayer.get_unique_id():
+		# Host is also a client — deliver locally.
+		_notify_peer_local(text, color, surface)
+	else:
+		match surface:
+			NotifySurface.LOG:
+				_notify_peer_log_rpc.rpc_id(peer_id, text, color)
+			_:
+				add_system_message.rpc_id(peer_id, text, color)
+
+
+## Local (host) side of notify_peer — emit on the chosen surface directly.
+func _notify_peer_local(text: String, color: Color, surface: NotifySurface) -> void:
+	match surface:
+		NotifySurface.LOG:
+			LogManager.add_scrolling_log(text, color)
+		_:
+			add_system_message(text, color)
+
+
+## Server -> Client: deliver a notification to the LOG (scrolling log) surface.
+@rpc("authority", "call_remote", "reliable")
+func _notify_peer_log_rpc(text: String, color: Color) -> void:
+	if multiplayer.is_server():
+		return
+	LogManager.add_scrolling_log(text, color)
+
+
 ## Client -> Server: quest command passthrough
 @rpc("any_peer", "call_local", "reliable")
 func _request_quest_command(args: String) -> void:

--- a/scripts/Managers/party_manager.gd
+++ b/scripts/Managers/party_manager.gd
@@ -228,12 +228,7 @@ func rpc_send_invite(invitee_name: String):
 	if sender_id == 0:
 		sender_id = multiplayer.get_unique_id()
 	
-	var invitee_id = PlayerManager.get_player_id_from_name(invitee_name)
-	if invitee_id == -1:
-		for bot_id in BotManager.active_bots:
-			if BotManager.active_bots[bot_id].username.to_lower() == invitee_name.to_lower():
-				invitee_id = bot_id
-				break
+	var invitee_id = PlayerManager.resolve_by_name(invitee_name)
 	if invitee_id == -1:
 		#print("Server: Player not found by name: ", invitee_name)
 		return
@@ -433,37 +428,6 @@ func _client_clear_my_party_status():
 func _on_player_disconnected(player_id: int):
 	if _player_party_map.has(player_id):
 		leave_party(player_id)
-
-# Placeholder for Quest System integration
-func add_quest_to_party(party_id: int, quest_id: String):
-	if not multiplayer.is_server():
-		return
-
-	if not _parties.has(party_id):
-		#print("Party %d does not exist." % party_id)
-		return
-
-	var party: PartyData = _parties[party_id]
-	if not party.has("active_quests"): # PartyData does not directly have active_quests. Need to add this to PartyData or handle differently.
-		party["active_quests"] = [] # This line will cause an error on PartyData
-	if not quest_id in party["active_quests"]:
-		party["active_quests"].append(quest_id)
-		_send_party_data_to_members(party_id)
-		#print("Quest %s added to party %d." % [quest_id, party_id])
-
-func remove_quest_from_party(party_id: int, quest_id: String):
-	if not multiplayer.is_server():
-		return
-
-	if not _parties.has(party_id):
-		#print("Party %d does not exist." % party_id)
-		return
-
-	var party: PartyData = _parties[party_id]
-	if party.has("active_quests") and quest_id in party["active_quests"]:
-		party["active_quests"].erase(quest_id)
-		_send_party_data_to_members(party_id)
-		#print("Quest %s removed from party %d." % [quest_id, party_id])
 
 func notify_player_data_changed(player_id: int):
 	if not multiplayer.is_server():

--- a/scripts/Managers/pet_manager.gd
+++ b/scripts/Managers/pet_manager.gd
@@ -281,13 +281,10 @@ func hatch_pet_server(username: String, pet_data_id: String, default_name: Strin
 func request_summon_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	if find_pet(username, pet_uuid).is_empty():
@@ -309,13 +306,10 @@ func request_summon_pet_server(pet_uuid: String) -> void:
 func request_unsummon_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	if find_pet(username, pet_uuid).is_empty():
@@ -331,13 +325,11 @@ func request_unsummon_pet_server(pet_uuid: String) -> void:
 func request_release_pet_server(pet_uuid: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var player = resolved.node
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -391,13 +383,10 @@ func _return_one_pet_slot(slot_data: Dictionary, inv) -> void:
 func request_rename_pet_server(pet_uuid: String, new_name: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -667,13 +656,11 @@ func _pet_event_visual_rpc(pet_uuid: String, event_type: String) -> void:
 func request_feed_pet_server(pet_uuid: String, inventory_slot_index: int) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var username: String = player.username
+	var player = resolved.node
+	var username: String = resolved.username
 	if not _rosters.has(username):
 		return
 	var record := find_pet(username, pet_uuid)
@@ -1016,14 +1003,11 @@ func request_autopot_server(pet_uuid: String, slot_type: String) -> void:
 func request_set_autopot_threshold_server(pet_uuid: String, slot_type: String, threshold: float) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Configuring thresholds doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
-	var owner_username: String = player.username
+	var owner_username: String = resolved.username
 	var record := find_pet(owner_username, pet_uuid)
 	if record.is_empty():
 		return
@@ -1050,12 +1034,14 @@ func request_transfer_to_pet_slot_server(pet_uuid: String, slot_key: String, sou
 	if not multiplayer.is_server():
 		print("[PetMgr.transfer_to] not server — early return")
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
+		print("[PetMgr.transfer_to] REJECT: player or inventory_component invalid")
+		return
+	var caller: int = resolved.peer_id
+	var player = resolved.node
 	print("[PetMgr.transfer_to] caller=%d" % caller)
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player) or not is_instance_valid(player.inventory_component):
+	if not is_instance_valid(player.inventory_component):
 		print("[PetMgr.transfer_to] REJECT: player or inventory_component invalid")
 		return
 	var owner_username: String = player.username
@@ -1123,12 +1109,12 @@ func request_transfer_to_pet_slot_server(pet_uuid: String, slot_key: String, sou
 func request_transfer_from_pet_slot_server(pet_uuid: String, slot_key: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Unequipping a pet item doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player) or not is_instance_valid(player.inventory_component):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
+		return
+	var player = resolved.node
+	if not is_instance_valid(player.inventory_component):
 		return
 	var owner_username: String = player.username
 	var record := find_pet(owner_username, pet_uuid)
@@ -1266,13 +1252,11 @@ func _tick_autobuff() -> void:
 func request_set_active_buff_ability_server(pet_uuid: String, ability_id: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var caller := multiplayer.get_remote_sender_id()
-	if caller == 0:
-		caller = 1
 	# Setting the active buff ability doesn't require the pet to be currently summoned.
-	var player := PlayerManager.get_player_node(caller)
-	if not is_instance_valid(player):
+	var resolved := PlayerManager.resolve_intent()
+	if resolved.is_empty():
 		return
+	var player = resolved.node
 	var owner_username: String = player.username
 	var record := find_pet(owner_username, pet_uuid)
 	if record.is_empty():

--- a/scripts/Managers/pet_manager.gd
+++ b/scripts/Managers/pet_manager.gd
@@ -1229,7 +1229,7 @@ func _tick_autobuff() -> void:
 			continue
 
 		# Validate the owner actually has this ability learned.
-		if int(owner_player.ability_component._ability_levels.get(ability_id, 0)) <= 0:
+		if owner_player.ability_component.get_ability_level(ability_id) <= 0:
 			continue
 
 		# Skip if owner already has plenty of the buff remaining (avoids wasting
@@ -1267,7 +1267,7 @@ func request_set_active_buff_ability_server(pet_uuid: String, ability_id: String
 	if not ability_id.is_empty():
 		if not is_instance_valid(player.ability_component):
 			return
-		if int(player.ability_component._ability_levels.get(ability_id, 0)) <= 0:
+		if player.ability_component.get_ability_level(ability_id) <= 0:
 			return
 		var ability: AbilityData = ResourceManager.get_ability_data(ability_id)
 		if not ability or not ability.applies_buff:
@@ -1304,20 +1304,9 @@ func notify_book_use_failed(username: String, reason: String) -> void:
 
 
 func _show_message_to_owner(peer: int, message: String) -> void:
-	if peer == 0:
-		return
-	if peer == 1:
-		# Host has the LogManager locally.
-		LogManager.add_scrolling_log(message, Color.GOLD)
-		return
-	_log_to_client_rpc.rpc_id(peer, message)
-
-
-@rpc("authority", "call_remote", "reliable")
-func _log_to_client_rpc(message: String) -> void:
-	if multiplayer.is_server():
-		return
-	LogManager.add_scrolling_log(message, Color.GOLD)
+	# Delegates to the canonical server->peer seam; pet messages land on the
+	# scrolling LOG surface (a different UI surface than chat) in GOLD.
+	ChatManager.notify_peer(peer, message, Color.GOLD, ChatManager.NotifySurface.LOG)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -487,7 +487,7 @@ func _complete_quest(username: String, quest_id: String) -> void:
 
 	# Grant coins via inventory
 	if quest.reward_coins > 0 and is_instance_valid(player_node.inventory_component):
-		player_node.player_inventory.monies_amount += quest.reward_coins
+		player_node.player_inventory.grant_coins(quest.reward_coins)
 
 	# Grant items. InventoryComponent.add_item takes an item id/name string and
 	# resolves + duplicates internally via ResourceManager.get_item_data.
@@ -645,12 +645,8 @@ func _save_quest_data(username: String) -> void:
 # ═══════════════════════════════════════════════════════════════════════════
 
 func _send_message(peer_id: int, text: String, color: Color) -> void:
-	_client_receive_quest_message.rpc_id(peer_id, text, color)
-
-
-@rpc("authority", "call_local", "reliable")
-func _client_receive_quest_message(text: String, color: Color) -> void:
-	ChatManager.add_system_message(text, color)
+	# Delegates to the canonical server->peer seam; quest messages land on CHAT.
+	ChatManager.notify_peer(peer_id, text, color, ChatManager.NotifySurface.CHAT)
 
 
 ## Server-triggered, client-rendered: spawn a QuestRewardPopup on the local

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -358,8 +358,8 @@ func record_level_up(username: String, new_level: int) -> void:
 func start_onboarding(username: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var pid: int = PlayerManager.get_player_id_from_name(username)
-	if pid == -1 or BotManager.is_bot(pid):
+	var pid: int = PlayerManager.resolve_player_only(username)
+	if pid == -1:
 		return
 	var player_node: MultiplayerPlayerV2 = PlayerManager.get_player_node(pid)
 	if not is_instance_valid(player_node):

--- a/scripts/Managers/save_manager.gd
+++ b/scripts/Managers/save_manager.gd
@@ -36,7 +36,12 @@ const VALID_CATEGORIES: PackedStringArray = [
 	"stats", "inventory", "abilities", "buffs", "pets", "quests"
 ]
 
-var _api_url: String = ""  # Will be loaded from UserConfig
+# Computed so a runtime change via UserConfig.set_backend_api_url(...) takes
+# effect immediately on the next request. Previously this was cached at _ready,
+# so switching the backend URL in-game left SaveManager pointed at the old one
+# (NetworkManager/PlayerManager already resolve theirs on demand).
+var _api_url: String:
+	get: return UserConfig.get_backend_api_url() + "/player"
 
 # ── Per-player tracking ───────────────────────────────────────────────────
 ## Registered players: username -> { node, dirty_categories, timer }
@@ -66,9 +71,6 @@ class SaveJob extends RefCounted:
 
 
 func _ready() -> void:
-	# Load API URL from config (supports environment variable override)
-	_api_url = UserConfig.get_backend_api_url() + "/player"
-
 	# SaveManager only does work on the server
 	if not _is_server():
 		return
@@ -405,38 +407,8 @@ func _release_slot(slot: int, job: SaveJob, success: bool, err: String) -> void:
 # ═══════════════════════════════════════════════════════════════════════════
 
 func _save_to_file(data: Dictionary) -> void:
-	var uname: String = data.get("username", "")
-	if uname.is_empty():
-		push_error("SaveManager: Cannot save to file — no username in data.")
-		return
-
-	var file_path: String = "res://saves/player_%s.json" % uname
-
-	# Create saves directory if it doesn't exist
-	var dir = DirAccess.open("res://")
-	if dir:
-		if not dir.dir_exists("saves"):
-			dir.make_dir("saves")
-
-	var existing_data: Dictionary = {}
-
-	if FileAccess.file_exists(file_path):
-		var file_read := FileAccess.open(file_path, FileAccess.READ)
-		if file_read:
-			var parsed = JSON.parse_string(file_read.get_as_text())
-			file_read.close()
-			if parsed is Dictionary:
-				existing_data = parsed
-
-	# Merge new data into existing (overwrite matching keys)
-	existing_data.merge(data, true)
-
-	var file_write := FileAccess.open(file_path, FileAccess.WRITE)
-	if file_write:
-		file_write.store_string(JSON.stringify(existing_data))
-		file_write.close()
-	else:
-		push_error("SaveManager: Failed to open file for writing: %s" % file_path)
+	# Shared read-merge-write fallback (canonical res://saves path).
+	PlayerPersistence.write_save_file_merged(data)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/Networking/CLAUDE.md
+++ b/scripts/Networking/CLAUDE.md
@@ -12,7 +12,8 @@ these scripts are autoloads (see the root `CLAUDE.md` autoload table).
 | `player_manager.gd` | Spawns/despawns player & bot characters; `get_player_node(id)` lookup |
 | `channel_manager.gd` | Switches server channels (ports) without a full restart |
 | `network_utils.gd` | IP/port validation and scene-path helpers |
-| `network_manager.gd` | HTTP bridge to the Flask backend (login, character CRUD, save/load) |
+| `network_manager.gd` | HTTP bridge to the Flask backend (login, character CRUD, character load) |
+| `player_persistence.gd` | `PlayerPersistence` — shared local-file fallback (canonical `res://saves` path + read-merge-write) used by the three HTTP autoloads |
 | `PartyData.gd` | Plain data class for a party (members, leader, invites) |
 
 ## Server-authoritative model
@@ -58,5 +59,12 @@ to disconnect signals before `queue_free()`.
 
 ## Backend bridge
 
-`network_manager.gd` is the only script that talks HTTP to Flask, via `HTTPRequest`
-against `http://localhost:5000`. Endpoints and payloads: [backend/CLAUDE.md](../../backend/CLAUDE.md).
+Three autoloads talk HTTP to Flask via `HTTPRequest` (against `http://localhost:5000`):
+`network_manager.gd` (account / character CRUD, login), `player_manager.gd`
+(character *load* on spawn), and `save_manager.gd` (debounced *saves*). They each
+own their own `HTTPRequest` lifecycle and retry, but share one local-file fallback:
+`player_persistence.gd` (`PlayerPersistence`) owns the canonical `res://saves`
+path and the read-merge-write helpers, so the offline fallback behaves identically
+across all three. The backend URL is resolved on demand from `UserConfig` in every
+HTTP caller, so a runtime `set_backend_api_url()` takes effect without a restart.
+Endpoints and payloads: [backend/CLAUDE.md](../../backend/CLAUDE.md).

--- a/scripts/Networking/network_manager.gd
+++ b/scripts/Networking/network_manager.gd
@@ -126,27 +126,7 @@ func get_characters():
 				var dev_char_name = "Dev" + class_name_str
 				var dev_file_path = saves_path.path_join("player_%s.json" % dev_char_name)
 				if not FileAccess.file_exists(dev_file_path):
-					var is_advanced = class_enum >= Constants.ClassType.CRUSADER
-					var starting_level = 30 if is_advanced else 1
-					var save_data = {
-							"username": dev_char_name,
-							"level": starting_level,
-							"experience": 0,
-							"character_class": class_enum,
-							"current_health": 100,
-							"max_health": 100,
-							"current_mana": 100,
-							"max_mana": 100,
-							"monies": 0,
-							"inventory": {},
-							"equipment": {},
-							# PR 4: per-discipline ability-point pools. New chars get the
-						# full level-1->starting-level allotment in their starting
-						# discipline's pool; the other three start at zero.
-						"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_enum, starting_level)},
-							"buffs": {},
-							"quests": {}
-						}
+					var save_data = _default_new_character_save(dev_char_name, class_enum)
 					var file = FileAccess.open(dev_file_path, FileAccess.WRITE)
 					if file:
 						file.store_string(JSON.stringify(save_data, "\t"))
@@ -232,26 +212,7 @@ func create_character(char_name, class_id):
 			#print("Create character: FileAccess.open failed, error: ", FileAccess.get_open_error())
 			character_creation_failed.emit("Failed to create save file")
 			return
-		var is_advanced = class_id >= Constants.ClassType.CRUSADER
-		var starting_level = 30 if is_advanced else 1
-		var save_data = {
-			"username": char_name,
-			"level": starting_level,
-			"experience": 0,
-			"character_class": class_id,
-			"current_health": 100,
-			"max_health": 100,
-			"current_mana": 100,
-			"max_mana": 100,
-			"monies": 0,
-			"inventory": {},
-			"equipment": {},
-			# PR 4: per-discipline ability-point pools. See dev-mode site for
-			# the helper that fills the starting discipline and zeros the rest.
-			"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_id, starting_level)},
-			"buffs": {},
-			"quests": {}
-		}
+		var save_data = _default_new_character_save(char_name, class_id)
 		file.store_string(JSON.stringify(save_data, "\t"))
 		file.close()
 		character_created.emit(char_name)
@@ -354,6 +315,35 @@ func _on_delete_character_completed(result, response_code, _headers, body, http,
 	http.queue_free()
 
 
+## Builds the default save blob for a brand-new character. Used by both the
+## local create-character path and the dev-mode per-class seeding in
+## get_characters() — previously two byte-for-byte copies that drifted apart.
+## Advanced (tier-2) classes start at level 30; everyone else at level 1.
+func _default_new_character_save(char_name: String, class_id: int) -> Dictionary:
+	var is_advanced := class_id >= Constants.ClassType.CRUSADER
+	var starting_level := 30 if is_advanced else 1
+	return {
+		"username": char_name,
+		"level": starting_level,
+		"experience": 0,
+		"character_class": class_id,
+		"current_health": 100,
+		"max_health": 100,
+		"current_mana": 100,
+		"max_mana": 100,
+		"monies": 0,
+		"inventory": {},
+		"equipment": {},
+		# PR 4: per-discipline ability-point pools. All four tier-1 pools start
+		# at zero — the starting point comes from
+		# AbilityComponent.bootstrap_fresh_character_if_needed bumping the chosen
+		# discipline to mastery 1 (which grants 1 point via mastery_level_changed).
+		"abilities": {"available_points_per_discipline": _starter_ability_point_pools(class_id, starting_level)},
+		"buffs": {},
+		"quests": {}
+	}
+
+
 ## PR 8 (2026-05-31): seeds an empty per-discipline ability-point pool dict
 ## for a newly-created character. All four tier-1 pools start at zero — the
 ## starting point comes from AbilityComponent.bootstrap_fresh_character_if_needed
@@ -369,20 +359,3 @@ func _starter_ability_point_pools(_class_id: int, _starting_level: int) -> Dicti
 		"staff": 0,
 		"dagger": 0,
 	}
-
-
-## PR 4: maps a `Constants.ClassType` int (tier-1 starting OR tier-2
-## advancement) to the lowercase discipline key. Mirrors the helper in
-## `AbilityComponent` (kept duplicated here so this autoload doesn't have
-## to reach into a sibling node before the player exists).
-func _class_id_to_discipline_key(class_id: int) -> String:
-	match class_id:
-		Constants.ClassType.SWORD, Constants.ClassType.CRUSADER:
-			return "sword"
-		Constants.ClassType.BOW, Constants.ClassType.RANGER:
-			return "bow"
-		Constants.ClassType.STAFF, Constants.ClassType.ARCHMAGE:
-			return "staff"
-		Constants.ClassType.DAGGER, Constants.ClassType.ASSASSIN:
-			return "dagger"
-	return ""

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -641,6 +641,57 @@ func get_player_id_from_name(username: String) -> int:
 	return -1
 
 
+## Resolves the calling peer of a client-intent RPC to its player node + name.
+## MUST be called from inside the RPC handler body — it reads
+## `multiplayer.get_remote_sender_id()`, which only returns the real sender
+## while the RPC stack is live (same constraint as TradeManager._sender()).
+##
+## Folds the copy-pasted server-intent prelude into one place: the sender-id
+## read, the host `0 → 1` normalization (a host call has sender id 0 and is
+## the server, peer 1), the player-node lookup, the validity guard, and the
+## username read. Returns an empty Dictionary `{}` when the caller has no
+## valid player node, so callers guard with `if resolved.is_empty(): return`.
+## On success returns `{ "peer_id": int, "node": MultiplayerPlayerV2,
+## "username": String }`.
+func resolve_intent() -> Dictionary:
+	var caller := multiplayer.get_remote_sender_id()
+	if caller == 0:
+		caller = 1
+	var node := get_player_node(caller)
+	if not is_instance_valid(node):
+		return {}
+	return {
+		"peer_id": caller,
+		"node": node,
+		"username": node.username,
+	}
+
+
+## Resolves a name (case-insensitive for bots, exact for players) to a peer id,
+## consulting BotManager for bots. Returns -1 if no player OR bot matches.
+## Used by party/trade name-based intents that accept either a player or a bot.
+func resolve_by_name(name: String) -> int:
+	var pid := get_player_id_from_name(name)
+	if pid != -1:
+		return pid
+	# Delegate the bot name/id lookup to BotManager rather than re-scanning
+	# active_bots here. _find_bot_by_name_or_id returns 0 when not found.
+	var bot_id := BotManager._find_bot_by_name_or_id(name)
+	if bot_id != 0:
+		return bot_id
+	return -1
+
+
+## Player-ONLY name resolution (excludes bots). Returns the peer id, or -1.
+## QuestManager uses this — quests are never granted to bots. `active_players`
+## holds bots too (negative ids), so filter them out explicitly.
+func resolve_player_only(name: String) -> int:
+	var pid := get_player_id_from_name(name)
+	if pid != -1 and BotManager.is_bot(pid):
+		return -1
+	return pid
+
+
 ## Stores a player's live state, captured at map-change time, so the imminent
 ## respawn can restore it without a save-backend round-trip. Called by
 ## MapManager.request_map_change just before the old character node is freed.

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -459,20 +459,15 @@ func _initialize_spawned_player(id: int, character_type: int, username: String, 
 
 
 func _load_player_data_from_file(username: String) -> Dictionary:
-	var file_path = "res://saves/player_%s.json" % username
-	if FileAccess.file_exists(file_path):
-		var file = FileAccess.open(file_path, FileAccess.READ)
-		var data = JSON.parse_string(file.get_as_text())
-		file.close()
-		if data:
-			data["party_id"] = data.get("party_id", -1)
-			data["last_map"] = data.get("last_map", "")
-			# weapon_mastery (PR 2) — legacy saves without the key load with
-			# an empty dict so the component picks up four zero-state
-			# disciplines on _ensure_default_disciplines.
-			data["weapon_mastery"] = data.get("weapon_mastery", {})
-			return data
-	return {}
+	var data := PlayerPersistence.read_save_file(username)
+	if not data.is_empty():
+		data["party_id"] = data.get("party_id", -1)
+		data["last_map"] = data.get("last_map", "")
+		# weapon_mastery (PR 2) — legacy saves without the key load with
+		# an empty dict so the component picks up four zero-state
+		# disciplines on _ensure_default_disciplines.
+		data["weapon_mastery"] = data.get("weapon_mastery", {})
+	return data
 
 
 func _load_player_data_async(username: String) -> Dictionary:
@@ -549,92 +544,12 @@ func _load_player_data_async(username: String) -> Dictionary:
 
 
 func _save_player_data_to_file(data: Dictionary):
-	"""Save player data to file (Fallback) - Merges partial updates"""
-	var username = data.get("username", "")
-	if username.is_empty():
-		return
-	
-	var file_path = "player_%s.json" % username
-	var existing_data = {}
-	
-	# Read existing data first to merge
-	if FileAccess.file_exists(file_path):
-		var file_read = FileAccess.open(file_path, FileAccess.READ)
-		if file_read:
-			existing_data = JSON.parse_string(file_read.get_as_text())
-			file_read.close()
-			if existing_data == null: existing_data = {}
-	
-	# Merge new data into existing data
-	existing_data.merge(data, true) # true = overwrite existing keys
-	
-	var file = FileAccess.open(file_path, FileAccess.WRITE)
-	if file:
-		file.store_string(JSON.stringify(existing_data))
-		file.close()
-		#print("PlayerManager: Saved to local file for ", username)
-
-
-func _save_player_data_async(data: Dictionary) -> void:
-	var username = data.get("username", "")
-	if username.is_empty():
-		return
-
-	if NetworkManager.use_local_save:
-		#print("PlayerManager: Local Save enabled. Saving to file for ", username)
-		_save_player_data_to_file(data)
-		return
-
-	#print("PlayerManager: Attempting to save data for %s to API..." % username)
-
-	var request = HTTPRequest.new()
-	add_child(request)
-	request.timeout = 5.0
-
-	var payload = {
-		"username": username,
-		"data": data
-	}
-
-	var json = JSON.stringify(payload)
-	var headers = ["Content-Type: application/json"]
-	var error = request.request(_api_url + "/save", headers, HTTPClient.METHOD_POST, json)
-
-	if error != OK:
-		#print("PlayerManager: HTTP save request failed to start for %s. Error: %d" % [username, error])
-		request.queue_free()
-		#print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable)" % username)
-		_save_player_data_to_file(data)
-		return
-
-	var result = await request.request_completed
-	var response_code = result[1]
-
-	if response_code == 200:
-		#print("PlayerManager: Saved %s via API" % username)
-		request.queue_free()
-		return
-
-	# First attempt failed — retry once after 1 second
-	#print("PlayerManager: API save failed for %s (code: %d), retrying..." % [username, response_code])
-	await get_tree().create_timer(1.0).timeout
-
-	error = request.request(_api_url + "/save", headers, HTTPClient.METHOD_POST, json)
-	if error != OK:
-		request.queue_free()
-		#print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable)" % username)
-		_save_player_data_to_file(data)
-		return
-
-	result = await request.request_completed
-	response_code = result[1]
-	request.queue_free()
-
-	if response_code == 200:
-		print("PlayerManager: Retry succeeded for %s" % username)
-	else:
-		print("PlayerManager: WARNING - Saved %s to LOCAL FILE (API unavailable after retry, code: %d)" % [username, response_code])
-		_save_player_data_to_file(data)
+	"""Save player data to file (fallback) — read-merge-write to the canonical
+	res://saves path. Delegates to the shared PlayerPersistence helper so the
+	path and merge semantics match NetworkManager / SaveManager exactly. (This
+	previously wrote a bare `player_%s.json` to the process CWD — a stray,
+	wrong-directory save that never lined up with the real saves folder.)"""
+	PlayerPersistence.write_save_file_merged(data)
 
 
 func _get_quick_save_data(player_id: int) -> Dictionary:

--- a/scripts/Networking/player_persistence.gd
+++ b/scripts/Networking/player_persistence.gd
@@ -1,0 +1,70 @@
+class_name PlayerPersistence
+extends RefCounted
+## Shared local-file persistence for player save data.
+##
+## Three autoloads (NetworkManager, PlayerManager, SaveManager) used to each
+## carry their own copy of the local read-merge-write fallback, with the save
+## directory / filename pattern hard-coded three different ways — including one
+## bare `"player_%s.json"` that wrote to the process CWD instead of the saves
+## folder. This consolidates the path convention and the read/merge/write logic
+## into one place so the fallback behaves identically everywhere.
+##
+## Network HTTP itself stays in the individual autoloads (each owns its own
+## HTTPRequest lifecycle and retry semantics); only the file fallback and the
+## canonical path live here.
+
+## Canonical saves directory (res:// so it works the same in editor and export).
+const SAVE_DIR: String = "res://saves"
+
+
+## The one true on-disk path for a character's save file.
+static func save_path(username: String) -> String:
+	return SAVE_DIR.path_join("player_%s.json" % username)
+
+
+## Reads a character's save file. Returns the parsed Dictionary, or {} if the
+## file is missing / unreadable / not a Dictionary. Callers layer their own
+## default-field fill-ins on top of the returned dict.
+static func read_save_file(username: String) -> Dictionary:
+	if username.is_empty():
+		return {}
+	var file_path := save_path(username)
+	if not FileAccess.file_exists(file_path):
+		return {}
+	var file := FileAccess.open(file_path, FileAccess.READ)
+	if file == null:
+		return {}
+	var parsed = JSON.parse_string(file.get_as_text())
+	file.close()
+	if parsed is Dictionary:
+		return parsed
+	return {}
+
+
+## Read-merge-write fallback used when the backend is unavailable. Merges the
+## supplied (possibly partial) data over whatever is already on disk so a
+## category-scoped save doesn't clobber untouched fields. `data` must carry a
+## non-empty "username". Ensures the saves directory exists first.
+static func write_save_file_merged(data: Dictionary) -> void:
+	var username: String = data.get("username", "")
+	if username.is_empty():
+		push_error("PlayerPersistence: Cannot save to file — no username in data.")
+		return
+
+	# Ensure the saves directory exists.
+	var dir := DirAccess.open("res://")
+	if dir and not dir.dir_exists("saves"):
+		dir.make_dir("saves")
+
+	var file_path := save_path(username)
+	var existing_data: Dictionary = read_save_file(username)
+
+	# Merge new data into existing (overwrite matching keys).
+	existing_data.merge(data, true)
+
+	var file_write := FileAccess.open(file_path, FileAccess.WRITE)
+	if file_write:
+		file_write.store_string(JSON.stringify(existing_data))
+		file_write.close()
+	else:
+		push_error("PlayerPersistence: Failed to open file for writing: %s" % file_path)

--- a/scripts/Networking/player_persistence.gd.uid
+++ b/scripts/Networking/player_persistence.gd.uid
@@ -1,0 +1,1 @@
+uid://dic0oa6tamf7o

--- a/scripts/Trading/trade_manager.gd
+++ b/scripts/Trading/trade_manager.gd
@@ -667,13 +667,9 @@ func _get_player_name(player_id: int) -> String:
 
 
 ## Sends a system message to a player — directly if it is the host, else by RPC.
+## Delegates to the canonical server->peer seam (CHAT surface).
 func _notify_player(player_id: int, message: String, color: Color) -> void:
-	if BotManager.is_bot(player_id):
-		return
-	if player_id == multiplayer.get_unique_id():
-		ChatManager.add_system_message(message, color)
-	else:
-		ChatManager.add_system_message.rpc_id(player_id, message, color)
+	ChatManager.notify_peer(player_id, message, color, ChatManager.NotifySurface.CHAT)
 
 
 #=============================================================================

--- a/scripts/Trading/trade_manager.gd
+++ b/scripts/Trading/trade_manager.gd
@@ -706,12 +706,7 @@ func _sender() -> int:
 func rpc_request_trade(target_name: String) -> void:
 	if not multiplayer.is_server():
 		return
-	var target_id := PlayerManager.get_player_id_from_name(target_name)
-	if target_id == -1:
-		for bot_id in BotManager.active_bots:
-			if BotManager.active_bots[bot_id].username.to_lower() == target_name.to_lower():
-				target_id = bot_id
-				break
+	var target_id := PlayerManager.resolve_by_name(target_name)
 	if target_id == -1:
 		_notify_player(_sender(), "No player named '%s' found." % target_name, Color.ORANGE)
 		return


### PR DESCRIPTION
Stacks on #182 (which stacks on #180) — review/merge in order.

## Problem
- **Candidate C:** three managers each rolled their own server→one-peer message helper with subtly different routing — `quest_manager._send_message` (always rpc_id, relies on call_local), `trade_manager._notify_player` (bot-skip + host-local-vs-rpc_id), `pet_manager._show_message_to_owner` (host-local-vs-rpc_id, but to a *different* UI surface — LogManager scrolling log). (The 4th helper on job_advancement_manager was already gone — that manager was deleted upstream.)
- **Candidate E:** managers reached through the player node into component internals — `pet_manager` read the **private** `ability_component._ability_levels`, and `quest_manager` mutated `player_inventory.monies_amount` directly.

## Change
- New canonical seam **`ChatManager.notify_peer(peer_id, text, color, surface)`** with `NotifySurface.{CHAT, LOG}`. CHAT → `add_system_message`; LOG → `LogManager.add_scrolling_log` (new `_notify_peer_log_rpc`). The bot-peer skip and host-local-vs-rpc_id branch live here once.
  - `quest_manager._send_message` → `notify_peer(..., CHAT)`
  - `trade_manager._notify_player` → `notify_peer(..., CHAT)`
  - `pet_manager._show_message_to_owner` → `notify_peer(..., Color.GOLD, LOG)` (LOG surface preserved)
  - Removed now-dead `_client_receive_quest_message` and `_log_to_client_rpc`.
- **`PlayerInventory.grant_coins(amount)`** — wraps the `monies_amount` setter (clamp + label + save-notify all unchanged); `quest_manager` grants coins through it.
- **`AbilityComponent.get_ability_level`** already existed upstream; `pet_manager` now uses it (2 sites) instead of `_ability_levels.get(...)`.

Server authority unchanged — coin/ability reads & grants still run server-side; only *how* they're reached is narrowed.

## Deferred
- `bot_manager._gather_bot_snapshot` → `MultiplayerPlayerV2.get_status_snapshot()`: snapshot is **not** a pure player-node read (mixes `BotBrain.current_action` owned by BotManager + `MapManager` lookups), so it can't be made byte-for-byte equivalent without leaking those deps into the player node. Left as-is.
- `trade_manager` TradeWindow UI reparenting: no UI test coverage — a regression couldn't be caught by the harness. Left as-is.

## Verification
- Editor import: clean.
- Headless harness: **84/84 passed, HARNESS_EXIT=0** (incl. AbilityComponent suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)