### PR TITLE
Combat: active dodge (server-authoritative i-frames)

### DIFF
--- a/docs/adr/0006-active-dodge-iframes.md
+++ b/docs/adr/0006-active-dodge-iframes.md
@@ -1,0 +1,113 @@
+# 6. Active dodge — server-authoritative i-frames + cooldown on the roll
+
+Date: 2026-06-02
+
+## Status
+
+Accepted
+
+## Context
+
+The game had no **active defensive verb**. Survival was purely stat-checked:
+you out-leveled, out-geared, or out-healed incoming damage, but there was no
+moment-to-moment input that let a skilled player *avoid* a hit they saw coming.
+The design (no dedicated tank role; roles are emergent from weapon identity)
+needs a universal "get out of the way" answer that every discipline shares —
+a GW2-style dodge.
+
+A roll already existed in code: `scripts/Player/StateMachine/slide.gd` is a
+quick directional lunge with jump/attack cancels. But in the weapon-identity
+overhaul branch it had decayed into orphaned WIP — its controller plumbing
+(`do_slide`, `slide_timer`, `slide_speed_boost`, `start_slide_effects`/
+`end_slide_effects`, `coming_from_slide`) referenced members that no longer
+existed on `MultiplayerPlayerV2`, the `slide` state node and a `SlideTimer` were
+absent from `player.tscn`, and nothing in the input path ever set `do_slide`. So
+the roll was un-enterable and had **no i-frames and no cooldown** — it was pure
+movement, not a defensive verb.
+
+The decision was to **deepen the existing roll into an active dodge** rather than
+build a new state: reconnect the roll, and layer invulnerability + a cooldown
+onto it so it becomes the counter-play to telegraphed damage.
+
+The crux is *authority*. Movement in this codebase is server-simulated: the
+StateMachine only changes state on the server (`state_machine.change_state` guards
+`is_server`) and broadcasts the state **name** to remote peers for animation;
+position replicates via `MultiplayerSynchronizer`. Critically, **damage is applied
+by the server** in `health.gd take_damage`. So if invulnerability were a
+client-side decision ("I'm rolling, therefore I'm immune"), a hacked client could
+simply hold the roll state and ignore all damage. Immunity has to be decided where
+damage is decided: on the server.
+
+## Decision
+
+Make the dodge's **invulnerability and cooldown server-authoritative**; the client
+only sends *intent* and (visually) sees the roll motion.
+
+- **A pure, testable gate.** The i-frame/cooldown logic lives in a standalone
+  `DodgeGate` (`scripts/Player/dodge_gate.gd`, a clock-injectable `RefCounted`)
+  holding two server-clock anchors: `_invulnerable_until_ms` and
+  `_cooldown_until_ms`. `IFRAME_SECONDS = 0.35` (aligned to the roll's
+  `SlideTimer` duration so immunity matches the readable roll motion) and
+  `DODGE_COOLDOWN = 1.2`. `try_start_dodge(now)` is the **single** writer of both
+  windows — immunity can never decouple from the cooldown that authorized it.
+  Being a plain object with an injected clock, the whole gate is unit-tested
+  headless (`test/player/test_dodge_gate.gd`) without a scene, peer, or the
+  StateMachine (none reachable in the harness).
+
+- **The flow.** The owning client presses the dodge key →
+  `multiplayer_input.gd` sends `player_input(..., "dodge")` →
+  `PlayerManager.player_input` (server, guarded) calls the player node's
+  `request_dodge()`. `request_dodge` is the authoritative gate: it rejects if
+  dead / mid-weapon-swap / not on floor, then asks `_dodge_gate.try_start_dodge`.
+  **Only on success** does it arm the i-frame window, enter the roll state on the
+  server (which broadcasts to peers), and `confirm_dodge.rpc()` so all peers
+  (host included) can play a brief cosmetic flash. If on cooldown it does nothing
+  — a client may still visually roll but gains **no immunity** (the server never
+  armed the window). That negative case is the security property.
+
+- **The damage check.** At the top of `health.gd take_damage`, in server context,
+  if the target is a player and `owner.is_invulnerable()` (which forwards to the
+  gate), the hit is ignored entirely — no HP loss, no damage number, no combat
+  invuln start, no SFX. The check is skipped for the `ignore_invuln` channel
+  (DoTs / true damage that must always land), so dodge i-frames gate only normal
+  hits.
+
+- **Reuses the existing `Slide` input action** (already bound to **Shift** in
+  `project.godot`) — no new action, no clobbering. `Slide` existed but no code
+  read it; the dodge wiring gives it a purpose. Only the owning client emits the
+  intent (the input synchronizer runs only for the authority peer).
+
+- **Bot-safe.** `is_invulnerable()` returns false for any entity whose gate was
+  never armed (bots never call `request_dodge`), so bots in the roll state or
+  passed to the damage check just take damage normally. No bot dodge AI (out of
+  scope).
+
+## Consequences
+
+- **Correct under a hostile client, at the cost of one RPC round-trip.** A client
+  can't grant itself i-frames; immunity is real only after the server arms it.
+  The trade-off vs. pure client-side i-frames (simpler, but cheatable) is ~one
+  round-trip of latency before immunity is "real". Acceptable: the roll's motion
+  is the readable tell, and the design's telegraphed boss specials wind up over
+  hundreds of milliseconds, so a dodge initiated on the telegraph still lands its
+  immunity inside the danger window.
+
+- **This is the counter-play to the (designed) boss-telegraph feature.** Telegraphs
+  give the *signal*; the dodge is the *answer*. Together they convert
+  "stat-checked survival" into "readable, dodgeable danger" — the no-tank design
+  resolution. The telegraph feature itself is not yet built (it lives in the GDD);
+  this PR ships the defensive half.
+
+- **The roll is functional again.** `player.tscn` gains a `SlideTimer` and a
+  `slide` StateMachine node (wired to idle/move/fall/jump/attack); the controller
+  regains the slide plumbing the overhaul branch had orphaned. The dodge enters
+  the roll directly via `change_state` from a grounded interruptible state, so the
+  source states didn't need new `slide_state` exports.
+
+- **Deliberate no-op collision swap.** `start_slide_effects`/`end_slide_effects`
+  exist (slide.gd's contract) but don't shrink the collision shape — the overhaul's
+  standing shape is a tiny circle where a slide-shrink adds little and risks
+  getting stuck. A real shape swap can drop in later without touching this design.
+
+- **Gate reset on respawn.** `respawn()` calls `_dodge_gate.reset()` so a stale
+  i-frame/cooldown anchor can't carry across a life.

--- a/scenes/Player/player.tscn
+++ b/scenes/Player/player.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=98 format=3 uid="uid://bdtdpx0d05sy3"]
+[gd_scene load_steps=99 format=3 uid="uid://bdtdpx0d05sy3"]
 
 [ext_resource type="Script" uid="uid://yibpus3whwuj" path="res://scripts/Player/multiplayer_controller_v2.gd" id="1_an8q1"]
 [ext_resource type="Script" uid="uid://cy1j38lpy671e" path="res://scripts/Player/multiplayer_input.gd" id="2_hxkm2"]
@@ -40,6 +40,7 @@
 [ext_resource type="Script" uid="uid://bfh8yeyv2wu0g" path="res://scripts/Player/StateMachine/death.gd" id="22_eiysd"]
 [ext_resource type="Script" uid="uid://bvunkdne8wduc" path="res://scripts/Player/StateMachine/hit.gd" id="23_03slv"]
 [ext_resource type="Script" uid="uid://tnuxo6lbsuxq" path="res://scripts/Player/StateMachine/climb.gd" id="23_climb_gd"]
+[ext_resource type="Script" uid="uid://dawpj0867b6xh" path="res://scripts/Player/StateMachine/slide.gd" id="24_slide_gd"]
 [ext_resource type="PackedScene" uid="uid://1ufb4svp8iwu" path="res://scenes/UI/quest_window.tscn" id="26_quest"]
 [ext_resource type="FontVariation" uid="uid://bpwl38ly8lvyj" path="res://assets/fonts/DamageNumbersFontVariation.tres" id="27_7iww4"]
 [ext_resource type="SpriteFrames" uid="uid://c05dyrlp5i5bj" path="res://resources/Player/SpriteFrames/Swordsman.tres" id="27_e8txv"]
@@ -1069,6 +1070,10 @@ one_shot = true
 wait_time = 0.8
 one_shot = true
 
+[node name="SlideTimer" type="Timer" parent="."]
+wait_time = 0.35
+one_shot = true
+
 [node name="StateMachine" type="Node" parent="." node_paths=PackedStringArray("starting_state", "state_label")]
 script = ExtResource("33_gb22u")
 starting_state = NodePath("idle")
@@ -1135,6 +1140,16 @@ script = ExtResource("23_climb_gd")
 idle_state = NodePath("../idle")
 fall_state = NodePath("../fall")
 animation_name = "idle"
+move_speed = 100.0
+
+[node name="slide" type="Node" parent="StateMachine" node_paths=PackedStringArray("idle_state", "move_state", "fall_state", "jump_state", "attack_state")]
+script = ExtResource("24_slide_gd")
+idle_state = NodePath("../idle")
+move_state = NodePath("../move")
+fall_state = NodePath("../fall")
+jump_state = NodePath("../jump")
+attack_state = NodePath("../attack")
+animation_name = "move"
 move_speed = 100.0
 
 [connection signal="button_down" from="CanvasLayer/PlayerHUD/MobileButtons/LeftButton" to="InputSynchronizer" method="_on_left_button_button_down"]

--- a/scripts/Components/health.gd
+++ b/scripts/Components/health.gd
@@ -166,8 +166,18 @@ func _on_regen_timer_timeout() -> void:
 	
 @rpc("any_peer", "call_local", "reliable")
 func take_damage(amount: int, source: Node = null, ignore_invuln: bool = false, is_crit: bool = false, show_number: bool = true) -> void:
-	
+
 	var is_player = (owner is MultiplayerPlayerV2)
+
+	# ACTIVE DODGE i-frames (server-authoritative). If the SERVER says this player is
+	# mid-dodge, the hit is fully ignored — no HP loss, no damage number, no combat
+	# invuln start, no SFX. Authority lives on the player's _dodge_gate (armed only by
+	# request_dodge on the server), so a hacked client that merely enters the roll
+	# state can't grant itself immunity. Only gates real dodge i-frames, NOT the
+	# `ignore_invuln` channel reserved for DoTs/true damage that must always land.
+	if multiplayer.is_server() and is_player and not ignore_invuln:
+		if owner.has_method("is_invulnerable") and owner.is_invulnerable():
+			return
 
 	# Compute the post-reduction amount UP FRONT so the floating damage number
 	# matches the HP actually lost. Server-authoritative player passives (Vanguard's

--- a/scripts/Enemy/enemy_base.gd
+++ b/scripts/Enemy/enemy_base.gd
@@ -807,6 +807,11 @@ func damage_on_overlap(body: Node):
 	if body.has_meta("is_invisible") and body.get_meta("is_invisible"):
 		return
 
+	# Mid-dodge i-frames: the player rolls cleanly THROUGH the enemy — no damage,
+	# no hit roll, and (the bit the take_damage guard missed) no knockback shove.
+	if body.has_method("is_invulnerable") and body.is_invulnerable():
+		return
+
 	if body.has_node("Components/Health"):
 		var health: HealthComponent = body.get_node("Components/Health")
 		var player_stats: StatsComponent = body.get_node("Components/Stats")

--- a/scripts/Managers/user_config.gd
+++ b/scripts/Managers/user_config.gd
@@ -10,6 +10,9 @@ const DEFAULT_API_URL = "http://127.0.0.1:5000/api"
 var custom_keybinds: Dictionary = {}
 var default_hotbar_actions: Array[String] = []
 var _all_managed_actions: Array[String] = []
+## Set when load backfills a newly-added managed action from its InputMap default,
+## so the resolved binding gets persisted back to the config file.
+var _keybinds_need_resave: bool = false
 
 # Sound settings
 var master_volume_db: float = 1
@@ -31,7 +34,7 @@ func _init():
 	# Combine all actions to be managed
 	_all_managed_actions = default_hotbar_actions.duplicate() # Start with hotbar actions
 	_all_managed_actions.append_array([
-		"Jump", "Attack", "Move Left", "Move Right", "Move Down", "Pickup",
+		"Jump", "Attack", "Move Left", "Move Right", "Move Down", "Slide", "Pickup",
 		"OpenStatsWindow", "OpenInventoryWindow", "OpenEquipmentWindow", "OpenAbilityWindow"
 	])
 
@@ -114,11 +117,26 @@ func _load_keybinds_from_config(config: ConfigFile):
 				custom_keybinds[action_name] = key_events
 				#print("Loaded custom keybinds for '%s': %s" % [action_name, get_keybind_text(action_name, -1)])
 			else:
-				# If action not in config, prefill with unset events
-				var key_events: Array[int] = [_create_unset_key_event(), _create_unset_key_event()]
+				# Action not in an existing config (e.g. a newly-added managed action
+				# like "Slide"/Dodge on an older save). Backfill from its project.godot
+				# InputMap DEFAULT so the player keeps a working default binding instead
+				# of an unbound key — then persist it.
+				var key_events: Array[int] = []
+				for event in InputMap.action_get_events(action_name):
+					if event is InputEventKey:
+						key_events.append(event.physical_keycode)
+						if key_events.size() >= 2:
+							break
+				while key_events.size() < 2:
+					key_events.append(_create_unset_key_event())
 				custom_keybinds[action_name] = key_events
-				push_warning("Action '%s' not found in config. Prefilling with [Unset]." % action_name)
+				_keybinds_need_resave = true
+				push_warning("Action '%s' not in config — backfilled from InputMap default." % action_name)
 		KeybindManager.apply_keybinds_to_input_map()
+		# Persist any defaults we just backfilled for newly-added managed actions.
+		if _keybinds_need_resave:
+			_keybinds_need_resave = false
+			save_config()
 	else:
 		# If the Keybinds section doesn't exist, prefill with defaults and save
 		push_warning("Keybinds section not found in config file. Prefilling with default keybinds.")

--- a/scripts/Networking/player_manager.gd
+++ b/scripts/Networking/player_manager.gd
@@ -565,6 +565,13 @@ func player_input(input_type: String, data: Variant = null):
 		"jump": player_node.do_jump = true
 		"drop": player_node.do_drop = true
 		"attack": player_node.do_attack = true
+		"dodge":
+			# ACTIVE DODGE intent. Route to the player node's request_dodge, which is
+			# the server-authoritative gate: it validates the dodge cooldown and (if
+			# off cooldown) arms the i-frame window + enters the roll. The client only
+			# sends intent; immunity is decided here on the server.
+			if player_node.has_method("request_dodge"):
+				player_node.request_dodge()
 		"pickup": player_node.do_pickup = data
 		"portal": player_node.do_portal_interact = true
 		"staff_cycle_element":

--- a/scripts/Player/dodge_gate.gd
+++ b/scripts/Player/dodge_gate.gd
@@ -1,0 +1,79 @@
+class_name DodgeGate
+extends RefCounted
+
+## Server-authoritative gate for the ACTIVE DODGE (the deepened roll).
+##
+## The roll/slide state gives the player a quick evasive lunge. On its own that's
+## just movement — anyone (including a hacked client) can enter the state. The
+## *invulnerability* and the *cooldown* that make the dodge a real defensive verb
+## live HERE, and this object is only ever mutated on the SERVER (see
+## MultiplayerPlayerV2.request_dodge / health.gd take_damage). A client cannot grant
+## itself i-frames: the server is the sole writer of `_invulnerable_until_ms` and
+## `_cooldown_until_ms`, so entering the roll without the server's blessing yields
+## the motion but no immunity.
+##
+## Why a standalone RefCounted instead of inline fields on the player:
+## - It is PURE and clock-injectable, so the cooldown/i-frame logic is unit-testable
+##   headless without a scene, a multiplayer peer, or the StateMachine (which is
+##   unreachable in the test harness). The player node owns one instance and
+##   delegates; health.gd asks the player `is_invulnerable()`, which forwards here.
+##
+## Clock: anchored on Time.get_ticks_msec() (the engine monotonic clock, same one
+## ShadowmeldComponent's enter-cooldown uses) — NOT wall-clock. The `now_ms`
+## parameter on every method lets tests feed a deterministic clock; production
+## callers pass Time.get_ticks_msec().
+
+## Invulnerability window granted by one successful dodge. Roughly the roll's
+## active duration so immunity lines up with the readable roll motion.
+const IFRAME_SECONDS: float = 0.35
+
+## Minimum time between dodges. Server-enforced so dodge can't be spammed for free
+## perma-immunity.
+const DODGE_COOLDOWN: float = 1.2
+
+## Server clock anchor (ms): the player is invulnerable while now < this. 0 = never
+## dodged / not currently invulnerable. Server-owned.
+var _invulnerable_until_ms: int = 0
+
+## Server clock anchor (ms): a new dodge is rejected while now < this. 0 = ready.
+## Server-owned.
+var _cooldown_until_ms: int = 0
+
+
+## True iff a dodge is allowed to start at `now_ms` (off cooldown). Pure read.
+func is_off_cooldown(now_ms: int) -> bool:
+	return now_ms >= _cooldown_until_ms
+
+
+## Attempt to start a dodge at `now_ms`. SERVER-ONLY semantics (the caller must
+## already be on the server). Returns true and arms the i-frame + cooldown windows
+## if off cooldown; returns false and changes nothing if still on cooldown. This is
+## the single place both windows are set, so immunity can NEVER outlast/decouple
+## from the cooldown gate that authorized it.
+func try_start_dodge(now_ms: int) -> bool:
+	if not is_off_cooldown(now_ms):
+		return false
+	_invulnerable_until_ms = now_ms + int(round(IFRAME_SECONDS * 1000.0))
+	_cooldown_until_ms = now_ms + int(round(DODGE_COOLDOWN * 1000.0))
+	return true
+
+
+## True while the i-frame window is open at `now_ms`. health.gd take_damage reads
+## this (via the player's is_invulnerable forwarder) to no-op incoming damage.
+func is_invulnerable(now_ms: int) -> bool:
+	return now_ms < _invulnerable_until_ms
+
+
+## Remaining cooldown in seconds at `now_ms` (0 when ready). For an optional UI
+## countdown / dimmed dodge indicator.
+func cooldown_remaining(now_ms: int) -> float:
+	if now_ms >= _cooldown_until_ms:
+		return 0.0
+	return float(_cooldown_until_ms - now_ms) / 1000.0
+
+
+## Clear both windows (e.g. on death / respawn) so a stale i-frame anchor can't
+## carry across a life. Safe to call any time.
+func reset() -> void:
+	_invulnerable_until_ms = 0
+	_cooldown_until_ms = 0

--- a/scripts/Player/dodge_gate.gd.uid
+++ b/scripts/Player/dodge_gate.gd.uid
@@ -1,0 +1,1 @@
+uid://g5mf3ytj06fk

--- a/scripts/Player/multiplayer_controller_v2.gd
+++ b/scripts/Player/multiplayer_controller_v2.gd
@@ -78,6 +78,22 @@ var do_pickup: bool = false
 var do_portal_interact: bool = false
 var current_portal: Portal = null
 
+## ACTIVE DODGE (the deepened roll). do_slide is the server-side one-shot intent
+## flag the slide state consumes on enter (set by request_dodge, the dodge intent
+## RPC). slide_speed_boost is the roll lunge speed; coming_from_slide lets the next
+## state preserve a little exit momentum. These plumb the existing
+## scripts/Player/StateMachine/slide.gd, which the overhaul branch had left
+## referencing members that didn't exist on the controller yet.
+var do_slide: bool = false
+const slide_speed_boost: float = 260.0
+var coming_from_slide: bool = false
+
+## i-frame/cooldown gate for the dodge. SERVER-ONLY mutation (request_dodge). The
+## logic lives in scripts/Player/dodge_gate.gd so it's unit-testable headless; the
+## player just holds the instance and forwards is_invulnerable() for health.gd.
+var _dodge_gate: DodgeGate = DodgeGate.new()
+@onready var slide_timer: Timer = $SlideTimer
+
 ## The enemy this character most recently DAMAGED + when (ticks ms). Players have
 ## no explicit target lock (they swing in a direction), so this is the proxy for
 ## "what I'm fighting" — party bots read it via get_recent_combat_target() to
@@ -384,6 +400,92 @@ func _check_drop_through_complete() -> void:
 		_drop_through_active = false
 		if is_instance_valid(drop_timer):
 			drop_timer.stop()
+
+
+#=============================================================================
+# ACTIVE DODGE (server-authoritative i-frames + cooldown on the roll)
+#=============================================================================
+
+## True while the dodge i-frame window is open. Read by HealthComponent.take_damage
+## (via owner) to no-op incoming damage. ALWAYS server-authoritative: the window is
+## only ever armed by request_dodge on the server, so a client that enters the roll
+## state without the server's blessing gets no immunity. Bots (and any non-dodging
+## entity) just return false — the gate's anchors stay 0.
+func is_invulnerable() -> bool:
+	if _dodge_gate == null:
+		return false
+	return _dodge_gate.is_invulnerable(Time.get_ticks_msec())
+
+
+## CLIENT -> SERVER dodge intent. The owning client fires this when it presses the
+## dodge (Slide) key; the server validates and, if allowed, arms the i-frame +
+## cooldown windows and enters the roll authoritatively. Mirrors the guarded
+## any_peer -> server request pattern used across the codebase (e.g.
+## ShadowmeldComponent.toggle_shadowmeld via PlayerManager.player_input).
+@rpc("any_peer", "call_local", "reliable")
+func request_dodge() -> void:
+	if not multiplayer.is_server():
+		return
+	# Dead players can't dodge.
+	if is_instance_valid(health_component) and health_component.is_dead:
+		return
+	# Don't dodge mid weapon-swap flash (same gate as other inputs).
+	if _swap_input_locked:
+		return
+	# The roll is a grounded evade — require floor, matching the existing roll's
+	# jump-cancel "no airborne exploit" intent.
+	if not is_on_floor():
+		return
+	if _dodge_gate == null:
+		_dodge_gate = DodgeGate.new()
+	# Server is the SOLE writer of the i-frame + cooldown windows. If on cooldown,
+	# do nothing — the client may still visually roll but gains NO immunity.
+	if not _dodge_gate.try_start_dodge(Time.get_ticks_msec()):
+		return
+	# Blessed: drive the roll state on the server. do_slide is consumed on slide
+	# enter; the state change broadcasts to remote peers so they animate the roll.
+	do_slide = true
+	if is_instance_valid(state_machine) and state_machine.current_state:
+		# Only kick the roll from a grounded, interruptible state.
+		var sname: String = state_machine.current_state.name
+		if sname in ["idle", "move", "crouch", "fall"]:
+			var slide_state := state_machine.get_node_or_null("slide")
+			if slide_state:
+				state_machine.change_state(slide_state)
+	# Tell every peer the dodge was blessed (for an optional flash). call_local so
+	# the host (also a client) flashes too.
+	confirm_dodge.rpc()
+
+
+## SERVER -> ALL PEERS. The dodge was authorized server-side; peers may play a brief
+## i-frame flash. Purely cosmetic — authority over immunity stays on the server's
+## _dodge_gate. Bots have no client; the visual is a no-op for them.
+@rpc("authority", "call_local", "reliable")
+func confirm_dodge() -> void:
+	# Optional visual feedback hook. Kept intentionally light so it can't desync
+	# anything: a quick sprite flash if a sprite exists. Immunity itself is NOT
+	# decided here — only on the server's _dodge_gate.
+	if is_instance_valid(animated_sprite):
+		var tween := create_tween()
+		tween.tween_property(animated_sprite, "modulate:a", 0.5, 0.05)
+		tween.tween_property(animated_sprite, "modulate:a", 1.0, 0.3)
+
+
+## Roll begin: the existing slide state calls this on enter. The overhaul branch's
+## standing collision is a small circle; a slide-specific shrink adds little and
+## risks getting stuck, so the "collision-shape swap" is a deliberate no-op here —
+## the function exists so slide.gd's contract holds and a real swap can drop in
+## later. We DO (re)start the roll duration timer that slide.gd polls.
+func start_slide_effects() -> void:
+	if is_instance_valid(slide_timer):
+		slide_timer.start()
+
+
+## Roll end: counterpart to start_slide_effects. No-op shape restore (see above);
+## stop the timer if it's still running.
+func end_slide_effects() -> void:
+	if is_instance_valid(slide_timer) and not slide_timer.is_stopped():
+		slide_timer.stop()
 
 
 func cleanup_before_removal():
@@ -955,6 +1057,10 @@ func respawn() -> void:
 	do_attack = false
 	do_jump = false
 	do_drop = false
+	do_slide = false
+	# Clear any pending dodge i-frame/cooldown so immunity can't carry across a life.
+	if _dodge_gate != null:
+		_dodge_gate.reset()
 	# Reset drop-through state so a death mid-drop doesn't leave the next
 	# life with a stale target_y far above the respawn point.
 	_drop_through_active = false

--- a/scripts/Player/multiplayer_input.gd
+++ b/scripts/Player/multiplayer_input.gd
@@ -82,6 +82,14 @@ func _process(_delta: float) -> void:
 		else:
 			PlayerManager.player_input.rpc_id(1, "jump")
 
+	# ACTIVE DODGE: the existing "Slide" action (bound to Shift in project.godot)
+	# is the deliberate defensive button. just_pressed only — a single deliberate
+	# tap, not hold-to-spam (the server cooldown is the real gate regardless). Routes
+	# through player_input -> the player node's request_dodge RPC, which validates
+	# the server-side cooldown and arms the i-frame window authoritatively.
+	if Input.is_action_just_pressed("Slide"):
+		PlayerManager.player_input.rpc_id(1, "dodge")
+
 	# Basic attack: every-frame-while-held for ALL weapons. The bow's signature
 	# (Momentum) builds passively from landed hits — it needs NO special input
 	# path, so the bow uses the same plain attack as every other weapon.

--- a/scripts/UI/keybinds_menu.gd
+++ b/scripts/UI/keybinds_menu.gd
@@ -54,6 +54,7 @@ func _populate_keybinds():
 	_add_keybind_entry("Move Left", "Move Left")
 	_add_keybind_entry("Move Right", "Move Right")
 	_add_keybind_entry("Move Down", "Move Down")
+	_add_keybind_entry("Slide", "Dodge")
 	_add_keybind_entry("Pickup", "Pickup")
 	_add_keybind_entry("OpenStatsWindow", "Open Stats")
 	_add_keybind_entry("OpenInventoryWindow", "Open Inventory")

--- a/test/player/test_dodge_gate.gd
+++ b/test/player/test_dodge_gate.gd
@@ -1,0 +1,104 @@
+# Suite for the active-dodge server gate (scripts/Player/dodge_gate.gd).
+#
+# The gate is the server-authoritative i-frame + cooldown logic for the deepened
+# roll. It's a pure RefCounted with an injectable clock (now_ms), so we exercise
+# the full gate behaviour headless WITHOUT a scene, a multiplayer peer, or the
+# StateMachine (none of which are reachable in this harness). We also exercise the
+# health.gd-style "ignore damage while invulnerable" decision against the gate so
+# the take_damage no-op contract is covered without the full Health/RPC path.
+extends "res://test/test_case.gd"
+
+const DodgeGateScript = preload("res://scripts/Player/dodge_gate.gd")
+
+var gate
+
+func before_each() -> void:
+	gate = DodgeGateScript.new()
+
+
+# A dodge while off cooldown succeeds, arms invulnerability, and starts the cooldown.
+func test_dodge_off_cooldown_arms_iframes_and_cooldown() -> void:
+	var t0: int = 1000
+	var ok: bool = gate.try_start_dodge(t0)
+	assert_true(ok, "dodge off cooldown should succeed")
+	assert_true(gate.is_invulnerable(t0), "should be invulnerable immediately after a blessed dodge")
+	assert_false(gate.is_off_cooldown(t0), "cooldown should be running right after a dodge")
+
+
+# A second dodge during the cooldown window is rejected and grants no new immunity.
+func test_second_dodge_during_cooldown_is_rejected() -> void:
+	var t0: int = 1000
+	assert_true(gate.try_start_dodge(t0), "first dodge succeeds")
+
+	# Try again 200ms later — still well inside the 1.2s cooldown.
+	var t1: int = t0 + 200
+	var ok2: bool = gate.try_start_dodge(t1)
+	assert_false(ok2, "dodge during cooldown must be rejected")
+
+	# The i-frame window must NOT have been re-extended by the rejected attempt:
+	# the first dodge's 0.35s window expires 350ms after t0, i.e. before t0+400.
+	var after_first_iframe: int = t0 + 400
+	assert_false(gate.is_invulnerable(after_first_iframe),
+		"rejected dodge must not extend immunity past the original window")
+
+
+# is_invulnerable is true within the i-frame window and false after it.
+func test_invulnerable_within_window_then_false_after() -> void:
+	var t0: int = 5000
+	gate.try_start_dodge(t0)
+	# IFRAME_SECONDS = 0.35 -> 350ms window.
+	assert_true(gate.is_invulnerable(t0 + 100), "invulnerable mid-window")
+	assert_true(gate.is_invulnerable(t0 + 349), "invulnerable just before window ends")
+	assert_false(gate.is_invulnerable(t0 + 350), "no longer invulnerable at window end")
+	assert_false(gate.is_invulnerable(t0 + 1000), "not invulnerable long after")
+
+
+# After the full cooldown elapses, a fresh dodge is allowed again.
+func test_dodge_allowed_again_after_cooldown() -> void:
+	var t0: int = 0
+	assert_true(gate.try_start_dodge(t0), "first dodge")
+	# DODGE_COOLDOWN = 1.2s -> 1200ms.
+	assert_false(gate.is_off_cooldown(t0 + 1199), "still on cooldown at 1199ms")
+	assert_true(gate.is_off_cooldown(t0 + 1200), "off cooldown at exactly 1200ms")
+	assert_true(gate.try_start_dodge(t0 + 1200), "dodge succeeds again after cooldown")
+
+
+# Models health.gd take_damage's decision: damage is a no-op while invulnerable,
+# and applies normally otherwise. Mirrors the early-return the component does.
+func test_take_damage_noop_while_invulnerable() -> void:
+	var hp: int = 100
+	var t0: int = 2000
+	gate.try_start_dodge(t0)
+
+	# Incoming hit DURING the i-frame window -> ignored (no-op), like take_damage's
+	# `if owner.is_invulnerable(): return`.
+	var now_during: int = t0 + 100
+	if not gate.is_invulnerable(now_during):
+		hp -= 30
+	assert_eq(hp, 100, "damage must be ignored while invulnerable")
+
+	# Incoming hit AFTER the window -> applies.
+	var now_after: int = t0 + 500
+	if not gate.is_invulnerable(now_after):
+		hp -= 30
+	assert_eq(hp, 70, "damage must apply once the i-frame window has expired")
+
+
+# A fresh gate (e.g. a bot, or a player who never dodged) is never invulnerable and
+# is always off cooldown — the bot-safe / default path.
+func test_fresh_gate_is_inert() -> void:
+	assert_false(gate.is_invulnerable(0), "fresh gate not invulnerable at t=0")
+	assert_false(gate.is_invulnerable(999999), "fresh gate not invulnerable later")
+	assert_true(gate.is_off_cooldown(0), "fresh gate is off cooldown")
+	assert_eq(gate.cooldown_remaining(0), 0.0, "fresh gate has no cooldown remaining")
+
+
+# reset() clears both windows so immunity can't carry across a life/respawn.
+func test_reset_clears_windows() -> void:
+	var t0: int = 3000
+	gate.try_start_dodge(t0)
+	assert_true(gate.is_invulnerable(t0 + 50), "invulnerable before reset")
+	gate.reset()
+	assert_false(gate.is_invulnerable(t0 + 50), "not invulnerable after reset")
+	assert_true(gate.is_off_cooldown(t0 + 50), "off cooldown after reset")
+	assert_true(gate.try_start_dodge(t0 + 50), "can dodge immediately after reset")

--- a/test/player/test_dodge_gate.gd.uid
+++ b/test/player/test_dodge_gate.gd.uid
@@ -1,0 +1,1 @@
+uid://c1ia17nrso6s

--- a/test/run_tests.gd
+++ b/test/run_tests.gd
@@ -22,6 +22,7 @@ const SUITES: Array[String] = [
 	"res://test/boss/test_boss_phases.gd",
 	"res://test/boss/test_boss_attack_data.gd",
 	"res://test/ability/test_respec_economy.gd",
+	"res://test/player/test_dodge_gate.gd",
 ]
 
 var _ran := false


### PR DESCRIPTION
## Active dodge: server-authoritative i-frames + cooldown on the roll

Research item #8 (GW2 dodge) — the "survival is a verb" / no-tank answer. **Deepens the existing roll** (`slide.gd`) rather than adding a new system.

### What changed
- Found the roll was **non-functional WIP** (state script referenced controller members + scene nodes that didn't exist, and nothing triggered it). Reconnected it minimally + additively, then layered on the dodge.
- **Server-authoritative i-frames.** New `DodgeGate` (pure, clock-injectable) holds the i-frame + cooldown windows on the player root. Armed **only** by `request_dodge` on the server, so a hacked client that merely enters the roll state gets no immunity.
  - Client presses the existing **Slide** action (Shift; no `project.godot` change) → sends `"dodge"` intent through the existing `player_input` routing → server-side `request_dodge` validates (not dead / not swap-locked / on-floor / **off cooldown**), arms the window, enters the roll authoritatively, and `confirm_dodge` broadcasts a cosmetic flash.
  - `health.gd take_damage` early-returns (server context) while the player's `is_invulnerable()` window is open — and deliberately **does not** gate the `ignore_invuln` channel reserved for DoTs/true damage.
- Clock: `Time.get_ticks_msec()` (monotonic), matching `ShadowmeldComponent`'s cooldown pattern; the gate takes `now_ms` so tests inject a deterministic clock.
- Bot-safe: bots never dodge; `is_invulnerable()` is inert for them.

### Constants
`IFRAME_SECONDS = 0.35`, `DODGE_COOLDOWN = 1.2`.

### Validation
`run_tests.bat` → **91/91 pass** (incl. 7 new dodge-gate tests: off-cooldown arms i-frames+cooldown; in-cooldown rejected w/ no immunity extension; window true→false at the 350ms boundary; cooldown re-allows at 1200ms; take_damage no-op while invulnerable; fresh/bot gate inert; reset).

### Not verified / notes
- No live multiplayer smoke-test of the full press→RPC→roll→remote-animation→dodged-hit path.
- Slide uses the `"move"` animation (the 4 static sprites likely have no roll anim) and the collision-shape swap is a documented no-op (standing collision is already a tiny radius-4 circle) — both safe placeholders a real anim/shape can drop into later.

### Docs
`docs/adr/0006-active-dodge-iframes.md` (client predicts the motion, server owns immunity; one RPC round-trip before immunity is "real" is acceptable because the roll motion is the tell; counter-play to boss telegraphs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
