### PR TITLE
perf(ResourceManager): defer abilities/items scan off the login critical path

### DIFF
--- a/scripts/Managers/content_library.gd
+++ b/scripts/Managers/content_library.gd
@@ -1,0 +1,29 @@
+extends RefCounted
+
+# No class_name on purpose: a global class identifier isn't resolvable when the
+# game is launched headless via `--script` (the global-class cache isn't loaded),
+# which would break the autoloads that use this. Consumers `preload()` it by path
+# instead — see ResourceManager / QuestManager / PetManager.
+
+## Shared content scanner for the eager-loading autoloads (ResourceManager,
+## QuestManager, PetManager). Recursively walks `path`, loads every `.tres` /
+## `.res` it finds, and hands each loaded resource to `on_resource` as
+## `(resource: Resource, full_path: String)`. Type-guarding and indexing are the
+## caller's job (do them in the callback). This is the single home for the
+## recurse → list → load pattern that previously lived three times, once per
+## autoload.
+##
+## Safe to call from a worker thread (ResourceLoader.load is thread-safe in
+## Godot 4) — that is how ResourceManager runs it in the background for the heavy
+## abilities + items categories. A path that doesn't exist yields no resources.
+static func scan(path: String, on_resource: Callable) -> void:
+	var items: PackedStringArray = ResourceLoader.list_directory(path)
+	for item_name in items:
+		var full_path: String = path + item_name
+		if item_name.ends_with("/"):
+			# Subdirectory — descend.
+			scan(full_path, on_resource)
+		elif full_path.ends_with(".tres") or full_path.ends_with(".res"):
+			var res: Resource = ResourceLoader.load(full_path)
+			if res != null:
+				on_resource.call(res, full_path)

--- a/scripts/Managers/pet_manager.gd
+++ b/scripts/Managers/pet_manager.gd
@@ -1,4 +1,8 @@
 extends Node
+
+# Preloaded by path (not via class_name) so it resolves in headless --script runs.
+const ContentLibrary = preload("res://scripts/Managers/content_library.gd")
+
 ## PetManager — server-authoritative ownership of player pets.
 ##
 ## See docs/adr/0001-pet-system-architecture.md for the architectural rationale.
@@ -110,23 +114,10 @@ func _process(delta: float) -> void:
 
 
 func _load_pet_data_registry() -> void:
-	var dir := DirAccess.open(PET_DATA_FOLDER)
-	if not dir:
-		# Folder may not exist yet on fresh repos — that's fine, no pets yet.
-		return
-	dir.list_dir_begin()
-	while true:
-		var file := dir.get_next()
-		if file.is_empty():
-			break
-		if dir.current_is_dir():
-			continue
-		if not (file.ends_with(".tres") or file.ends_with(".res")):
-			continue
-		var path := PET_DATA_FOLDER + file
-		var res = load(path)
+	# A missing folder (fresh repo, no pets yet) just yields no resources.
+	ContentLibrary.scan(PET_DATA_FOLDER, func(res: Resource, _path: String) -> void:
 		if res is PetData:
-			_pet_data_cache[res.pet_id] = res
+			_pet_data_cache[res.pet_id] = res)
 
 
 func get_pet_data(pet_data_id: String) -> PetData:

--- a/scripts/Managers/quest_manager.gd
+++ b/scripts/Managers/quest_manager.gd
@@ -1,5 +1,8 @@
 extends Node
 
+# Preloaded by path (not via class_name) so it resolves in headless --script runs.
+const ContentLibrary = preload("res://scripts/Managers/content_library.gd")
+
 ## QuestManager — Server-authoritative quest tracking and progression.
 ##
 ## Quests are defined in code via _define_quests(). Player progress is tracked
@@ -73,7 +76,9 @@ func _ready() -> void:
 
 func _load_quests_from_resources() -> void:
 	var loaded: Array[QuestData] = []
-	_scan_quests_recursive(QUESTS_DIR, loaded)
+	ContentLibrary.scan(QUESTS_DIR, func(res: Resource, _path: String) -> void:
+		if res is QuestData:
+			loaded.append(res))
 	# Sort by `sort_order` so curated narrative order survives the move from
 	# `_define_quests()` (insertion order) to scanning files off disk
 	# (filesystem/alphabetical order). Dictionary preserves insertion order
@@ -89,21 +94,6 @@ func _load_quests_from_resources() -> void:
 				q.quest_id, q.resource_path, _quests[q.quest_id].resource_path
 			])
 		_quests[q.quest_id] = q
-
-
-## Walk QUESTS_DIR (and any subfolders) for QuestData .tres files. Mirrors
-## ResourceManager._load_resources_recursively but specialized to QuestData
-## so we get the type guard for free.
-func _scan_quests_recursive(path: String, into: Array[QuestData]) -> void:
-	var items: PackedStringArray = ResourceLoader.list_directory(path)
-	for item_name in items:
-		var full_path: String = path + item_name
-		if item_name.ends_with("/"):
-			_scan_quests_recursive(full_path, into)
-		elif full_path.ends_with(".tres") or full_path.ends_with(".res"):
-			var resource: Resource = ResourceLoader.load(full_path)
-			if resource is QuestData:
-				into.append(resource)
 
 
 # ═══════════════════════════════════════════════════════════════════════════

--- a/scripts/Managers/resource_manager.gd
+++ b/scripts/Managers/resource_manager.gd
@@ -1,6 +1,9 @@
 # ResourceManager.gd - Autoload script
 extends Node
 
+# Preloaded by path (not via class_name) so it resolves in headless --script runs.
+const ContentLibrary = preload("res://scripts/Managers/content_library.gd")
+
 # Emitted on the main thread once the deferred abilities + items scan has
 # finished and the indexes below are fully populated. Listeners that want to
 # react to readiness (rather than block on it) can connect to this; anything
@@ -102,8 +105,7 @@ func _load_item_data() -> void:
 			#print("Loaded item: %s from path: %s" % [resource.name, path])
 			#print("DEBUG: ResourceManager loaded item icon: ", resource.icon)
 			
-	# Call the generic loader
-	_load_resources_recursively(item_folder, process_item)
+	ContentLibrary.scan(item_folder, process_item)
 		
 
 func get_item_data(item_id: String) -> ItemData:
@@ -138,7 +140,7 @@ func _load_class_data() -> void:
 			class_data[resource.class_type] = resource
 			#print("Loaded discipline: %s from path: %s" % [resource._discipline_name, path])
 
-	_load_resources_recursively(class_folder, process_class)
+	ContentLibrary.scan(class_folder, process_class)
 
 
 func get_class_data(class_type: Constants.ClassType) -> WeaponDisciplineData:
@@ -221,10 +223,10 @@ func _load_ability_data() -> void:
 	var process_ability = func(resource, _path):
 		if resource is AbilityData:
 			ability_data[resource.ability_id] = resource 
-			ability_by_name[resource.ability_name] = resource 
+			ability_by_name[resource.ability_name] = resource
 			#print("Loaded ability: %s from path: %s" % [resource.ability_name, path])
 
-	_load_resources_recursively(ability_folder, process_ability)
+	ContentLibrary.scan(ability_folder, process_ability)
 
 
 func get_ability_data(ability_identifier: String) -> AbilityData:
@@ -259,8 +261,8 @@ func _load_buff_data() -> void:
 			buffs_by_name[resource.buff_name] = resource 
 			#print("Loaded buff: %s from path: %s" % [resource.buff_name, path])
 			
-	_load_resources_recursively(buff_folder, process_buff)
-		
+	ContentLibrary.scan(buff_folder, process_buff)
+
 func get_buff_data(buff_identifier: String) -> BuffData:
 	if buff_data.has(buff_identifier):
 		return buff_data[buff_identifier]
@@ -276,27 +278,3 @@ func get_buff_by_name(buff_name: String) -> BuffData:
 
 		
 #endregion
-
-
-func _load_resources_recursively(path: String, process_callable: Callable) -> void:
-	# Get all items (files and directories) in the current path
-	var items = ResourceLoader.list_directory(path)
-	
-	for item_name in items:
-		var full_path = path + item_name
-		
-		# Check if the item is a directory (it will end with "/")
-		if item_name.ends_with("/"):
-			# It's a directory! Call this function again for the subdirectory.
-			# This is the "recursive" step.
-			_load_resources_recursively(full_path, process_callable)
-			
-		# Check if it's a resource file we want to load
-		# This avoids trying to load ".import" files
-		elif full_path.ends_with(".tres") or full_path.ends_with(".res"):
-			# It's a file! Load it.
-			var resource = ResourceLoader.load(full_path)
-			
-			if resource:
-				# Call the provided 'Callable' and pass it the loaded resource
-				process_callable.call(resource, full_path)

--- a/scripts/Managers/resource_manager.gd
+++ b/scripts/Managers/resource_manager.gd
@@ -1,6 +1,12 @@
 # ResourceManager.gd - Autoload script
 extends Node
 
+# Emitted on the main thread once the deferred abilities + items scan has
+# finished and the indexes below are fully populated. Listeners that want to
+# react to readiness (rather than block on it) can connect to this; anything
+# that must read the data right now should call ensure_loaded() instead.
+signal content_ready
+
 # Dictionary to store weapon-discipline data by ClassType enum value.
 # (ClassType semantically means "weapon discipline" now — see Constants.gd.)
 var class_data: Dictionary[Constants.ClassType, WeaponDisciplineData] = {}
@@ -14,12 +20,75 @@ var ability_by_name: Dictionary[String, AbilityData] = {}
 var buff_data: Dictionary[String, BuffData] = {}
 var buffs_by_name: Dictionary[String, BuffData] = {}
 
+# Background loader for the heavy abilities + items scan (~800 .tres). See
+# _ready() / ensure_loaded() for the loading strategy.
+var _load_thread: Thread = null
+var _content_loaded: bool = false
+
 func _ready() -> void:
+	# Disciplines (character-select portrait + base stats) and buffs (combat)
+	# total ~23 .tres and have early consumers, so they load synchronously
+	# before the first frame.
 	_load_class_data()
+	_load_buff_data()
+
+	# Abilities + items (~800 .tres, each dragging icons / projectile scenes /
+	# upgrade trees) are not needed until a player spawns into a map. They load
+	# on a background thread so the login screen renders immediately instead of
+	# blocking on a disk scan it never uses. Any consumer that needs them sooner
+	# calls ensure_loaded(), which transparently blocks until the scan finishes;
+	# the public ability/item getters do this automatically.
+	_start_deferred_load()
+
+
+func _start_deferred_load() -> void:
+	_load_thread = Thread.new()
+	var err: int = _load_thread.start(_load_deferred_content)
+	if err != OK:
+		# Threads unavailable on this platform — fall back to a synchronous load
+		# so the indexes are still populated (just without the startup win).
+		push_warning("ResourceManager: background load thread unavailable (err %d); loading synchronously." % err)
+		_load_thread = null
+		_load_item_data()
+		_load_ability_data()
+		_content_loaded = true
+		content_ready.emit()
+
+
+# Runs on the background thread. Must not emit signals or join itself here —
+# both are marshalled back to the main thread via call_deferred.
+func _load_deferred_content() -> void:
 	_load_item_data()
 	_load_ability_data()
-	_load_buff_data()
-	
+	call_deferred("_finish_deferred_load")
+
+
+# Main thread: the worker has signalled completion, so join it and announce.
+func _finish_deferred_load() -> void:
+	ensure_loaded()
+
+
+## Blocks the calling (main) thread until the deferred abilities + items scan has
+## finished, then returns. Idempotent and effectively free once loaded. The
+## public ability/item getters call this for you; call it directly only where the
+## indexes are read without going through a getter (e.g. iterating
+## ability_data.values(), or a test harness that runs on the first frame).
+func ensure_loaded() -> void:
+	if _content_loaded:
+		return
+	if _load_thread != null:
+		# No worse than the old synchronous _ready() for an early caller, and only
+		# paid once by the first consumer that needs the data before it is ready.
+		_load_thread.wait_to_finish()
+		_load_thread = null
+	_content_loaded = true
+	content_ready.emit()
+
+
+## True once the deferred abilities + items scan has completed.
+func is_content_ready() -> bool:
+	return _content_loaded
+
 
 #region Item Data Functions
 
@@ -38,6 +107,7 @@ func _load_item_data() -> void:
 		
 
 func get_item_data(item_id: String) -> ItemData:
+	ensure_loaded()
 	# If it's a UUID, look it up directly
 	if item_data.has(item_id):
 		return item_data[item_id]
@@ -52,6 +122,7 @@ func get_item_data(item_id: String) -> ItemData:
 	
 	
 func get_item_by_name(item_name: String) -> ItemData:
+	ensure_loaded()
 	return item_by_name.get(item_name)
 	
 #endregion
@@ -157,6 +228,7 @@ func _load_ability_data() -> void:
 
 
 func get_ability_data(ability_identifier: String) -> AbilityData:
+	ensure_loaded()
 	# First check by ID
 	if ability_data.has(ability_identifier):
 		return ability_data[ability_identifier]
@@ -170,6 +242,7 @@ func get_ability_data(ability_identifier: String) -> AbilityData:
 	return null
 
 func get_ability_by_name(ability_name: String) -> AbilityData:
+	ensure_loaded()
 	return ability_by_name.get(ability_name)
 
 #endregion

--- a/scripts/Resources/CLAUDE.md
+++ b/scripts/Resources/CLAUDE.md
@@ -14,7 +14,7 @@ here; the **data instances** (`.tres` files) live under `resources/`.
 | `PetSystem/` | `PetData` (the static pet variety definition — sprite, walk speed, leash radius, autoloot radius, hunger curve) |
 | `StatSystem/` | `StatData` |
 | `QuestSystem/` | `QuestData` |
-| (root) | `EnemyData.gd` |
+| (root) | `EnemyData.gd`, `BossAttackData.gd` |
 
 ## ResourceManager loads most of this for free
 
@@ -28,6 +28,19 @@ here; the **data instances** (`.tres` files) live under `resources/`.
 
 Look content up with `ResourceManager.get_ability_data(id_or_name)`,
 `get_item_by_name(name)`, etc. — never `load()` content `.tres` at runtime.
+
+**Loading is split for startup speed.** Disciplines + buffs load synchronously in
+`_ready()` (they have early consumers — the character-select portrait, combat
+buffs). The heavy categories — **abilities + items (~800 `.tres`)** — load on a
+**background thread**, because nothing needs them until a player spawns into a
+map; this keeps the login screen from blocking on a disk scan it never reads. The
+`get_ability_data` / `get_item_*` getters call `ResourceManager.ensure_loaded()`
+internally, so normal callers see no difference (an early caller transparently
+blocks until the scan finishes). **If you read `ability_data` / `item_data`
+directly instead of through a getter** (e.g. iterating `.values()`), call
+`ResourceManager.ensure_loaded()` first — the dict may still be filling. Connect
+to the `content_ready` signal (or poll `is_content_ready()`) to react to
+completion without blocking.
 
 **`QuestData` follows the same pattern, but owned by `QuestManager`** —
 `QuestManager._load_quests_from_resources()` recursively scans

--- a/scripts/Resources/CLAUDE.md
+++ b/scripts/Resources/CLAUDE.md
@@ -42,6 +42,13 @@ directly instead of through a getter** (e.g. iterating `.values()`), call
 to the `content_ready` signal (or poll `is_content_ready()`) to react to
 completion without blocking.
 
+The recurse → list → load scan itself lives in one place,
+`scripts/Managers/content_library.gd` (`ContentLibrary.scan(path, on_resource)`),
+shared by `ResourceManager`, `QuestManager`, and `PetManager` — each passes a
+callback that does its own type-guard + indexing. It has **no `class_name`** (a
+global class identifier doesn't resolve in headless `--script` runs and would make
+the autoloads fail to compile); consumers `preload()` it by path.
+
 **`QuestData` follows the same pattern, but owned by `QuestManager`** —
 `QuestManager._load_quests_from_resources()` recursively scans
 `resources/Quests/` on `_ready()` and keys each loaded `QuestData` by its

--- a/scripts/UI/LoginScreen.gd
+++ b/scripts/UI/LoginScreen.gd
@@ -300,6 +300,9 @@ func _build_dev_max_save(username: String, disc: int) -> Dictionary:
 		secondary[str(i)] = ""
 
 	var slot: int = 0
+	# Reads the ability index directly (not via a getter), so make sure the
+	# background abilities/items scan has finished first.
+	ResourceManager.ensure_loaded()
 	for ab in ResourceManager.ability_data.values():
 		if ab.ability_type != Constants.AbilityType.ACTIVE:
 			continue

--- a/test/run_tests.gd
+++ b/test/run_tests.gd
@@ -38,6 +38,14 @@ func _process(_delta: float) -> bool:
 	if _ran:
 		return true
 	_ran = true
+	# Abilities + items now load on a background thread (see ResourceManager).
+	# The ability suites read ResourceManager.ability_data directly, so block
+	# until that scan has finished before running anything. Autoload globals
+	# aren't compile-time identifiers in a --script entry point, so reach it by
+	# node path rather than by name.
+	var rm := root.get_node_or_null("ResourceManager")
+	if rm != null:
+		rm.ensure_loaded()
 	var any_failed := _run_all()
 	quit(1 if any_failed else 0)
 	return true


### PR DESCRIPTION
## Problem

`ResourceManager._ready()` loaded **~820 `.tres` synchronously on the main thread** before anything rendered, and each `ResourceLoader.load()` dragged in its full transitive graph (icons, projectile scenes, upgrade trees, SpriteFrames) — the root cause of slow startup.

The decisive finding from mapping call sites: **~800 of those files (all 450 abilities + 347 items) aren't needed until a player spawns into a map.** Only the 23 cheap files (9 disciplines + 14 buffs) have an early consumer (the character-select portrait + combat buffs). The login screen was blocking on a disk scan it never reads.

## Approach (Candidate A from the architecture review)

The `get_ability_data(id)` / `get_item_by_name(name)` lookup surface was already deep; the shallow part was the **loading strategy baked into the interface** — every caller silently depended on "all content resident by frame 1." This makes readiness an explicit, testable part of the interface and changes only the strategy behind the unchanged getters:

- **Disciplines + buffs** still load synchronously in `_ready()` (cheap, early consumers).
- **Abilities + items** load on a background `Thread`. The login screen calls no getter, so it renders immediately.
- **`ensure_loaded()`** transparently joins the worker for any consumer that needs the data sooner. The ability/item getters call it automatically → **existing callers need zero changes**.
- **`content_ready` signal** / **`is_content_ready()`** expose readiness for listeners that prefer to react rather than block.
- Falls back to a synchronous load if `Thread.start()` fails (single-threaded platforms).

Two direct-dict iterators on the early path are gated explicitly (they bypass the getters): the **test harness** (runs on the first frame) and the **dev max-save builder**.

## Server-authority

No gameplay state moves — loading strategy isn't authoritative state, so the wire seam is untouched. The one invariant honoured: the **server** must `ensure_loaded()` before `JoinHandshake` grants starter equipment or `AbilityComponent` loads abilities — the getter-internal gate guarantees this instead of relying on "it finished by frame 1."

## Verification

- `198/198` headless tests pass (`run_tests.bat`).
- Smoke test confirms the background scan completes naturally (~51 frames / <1s), emits `content_ready` on the main thread, and populates all indexes (86 abilities by id, 347 items via the thread; 9 disciplines + 14 buffs synchronously).

## Notes

- Base is `feat/weapon-identity-overhaul` (stacked on the in-flight weapon work, which remains uncommitted in the working tree).
- Follow-ups deliberately left out of scope: stripping presentation deps / skipping textures on the dedicated server (Candidate B), unifying the three eager autoload scanners behind one `ContentLibrary` (Candidate C), and fixing `CharacterSelectScreen._load_weapon()`'s bare `load()` that bypasses the index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)